### PR TITLE
nurlbox: a busybox-shaped userland, and the holes it found

### DIFF
--- a/compiler/tests/outputs-windows/path_basic.txt
+++ b/compiler/tests/outputs-windows/path_basic.txt
@@ -7,13 +7,18 @@ absolute foo/bar: F
 absolute C:/x: T
 absolute foo: F
 basename /a/b/c.txt: c.txt
-basename /a/b/: 
+basename /a/b/: b
 basename foo: foo
 basename .bashrc: .bashrc
+basename /: /
+basename a//b: b
 dirname /a/b/c.txt: /a/b
-dirname /a/b/: /a/b
-dirname foo: 
+dirname /a/b/: /a
+dirname foo: .
 dirname /foo: /
+dirname /: /
+dirname a//b: a
+dirname /a/: /
 ext file.tar.gz: gz
 ext .bashrc: 
 ext noext: 

--- a/compiler/tests/outputs/path_basic.txt
+++ b/compiler/tests/outputs/path_basic.txt
@@ -7,13 +7,18 @@ absolute foo/bar: F
 absolute C:/x: T
 absolute foo: F
 basename /a/b/c.txt: c.txt
-basename /a/b/: 
+basename /a/b/: b
 basename foo: foo
 basename .bashrc: .bashrc
+basename /: /
+basename a//b: b
 dirname /a/b/c.txt: /a/b
-dirname /a/b/: /a/b
-dirname foo: 
+dirname /a/b/: /a
+dirname foo: .
 dirname /foo: /
+dirname /: /
+dirname a//b: a
+dirname /a/: /
 ext file.tar.gz: gz
 ext .bashrc: 
 ext noext: 

--- a/compiler/tests/outputs/regex_captures.txt
+++ b/compiler/tests/outputs/regex_captures.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+(a+)(b+) | xxaaabbyy | 2 groups @2+5 → <aaa|bb>
+([a-z]+)@([a-z]+) | mail ada@example org | 2 groups @5+11 → example:ada
+foo | a foo b | 0 groups @2+3 → [foo]
+(x)?(y) | y | 2 groups @0+1 → 1=[] 2=[y]
+((a)(b))c | abc | 3 groups @0+3 → ab a b
+a|ab | abc | 0 groups @0+2 → ab
+^(\w+)\s+(\w+)$ | hello world | 2 groups @0+11 → world hello
+(a)(b)(c)(d)(e)(f)(g)(h)(i) | abcdefghi | 9 groups @0+9 → ihgfedcba
+(no) | yes | no match
+x(y*)z | xz | 1 groups @0+2 → []
+(a|b)+ | abab | 1 groups @0+4 → abab/b
+q | q | 0 groups @0+1 → &amp \ slash 
+ newline

--- a/compiler/tests/path_basic.nu
+++ b/compiler/tests/path_basic.nu
@@ -85,11 +85,16 @@ $ `stdlib/core/string.nu`
     ( test_basename `/a/b/` )
     ( test_basename `foo` )
     ( test_basename `.bashrc` )
+    ( test_basename `/` )
+    ( test_basename `a//b` )
 
     ( test_dirname `/a/b/c.txt` )
     ( test_dirname `/a/b/` )
     ( test_dirname `foo` )
     ( test_dirname `/foo` )
+    ( test_dirname `/` )
+    ( test_dirname `a//b` )
+    ( test_dirname `/a/` )
 
     ( test_ext `file.tar.gz` )
     ( test_ext `.bashrc` )

--- a/compiler/tests/regex_captures.nu
+++ b/compiler/tests/regex_captures.nu
@@ -1,0 +1,56 @@
+// regex_captures.nu — capture groups: regex_find_caps / regex_expand.
+//
+// Pins the Pike-VM capture layer: group numbering by opening paren,
+// nesting, a group that does not participate, leftmost-longest
+// alternation, and the `&` / `\N` replacement template.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/regex.nu`
+
+@ show s pat s text s tmpl → v {
+    ( nurl_print pat )
+    ( nurl_print ` | ` )
+    ( nurl_print text )
+    ( nurl_print ` | ` )
+    ?? ( regex_compile pat ) {
+        T r → {
+            : ( Vec i ) slots ( vec_new [i] )
+            ?? ( regex_find_caps r text slots ) {
+                T m → {
+                    ( nurl_print ( nurl_str_int ( regex_ngroups r ) ) )
+                    ( nurl_print ` groups @` )
+                    ( nurl_print ( nurl_str_int . m start ) )
+                    ( nurl_print `+` )
+                    ( nurl_print ( nurl_str_int . m len ) )
+                    ( nurl_print ` → ` )
+                    : String e ( regex_expand text slots tmpl )
+                    ( nurl_print ( string_data e ) )
+                    ( string_free e )
+                }
+                F _ → ( nurl_print `no match` )
+            }
+            ( vec_free [i] slots )
+            ( regex_free r )
+        }
+        F _ → ( nurl_print `compile error` )
+    }
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    ( show `(a+)(b+)` `xxaaabbyy` `<\1|\2>` )
+    ( show `([a-z]+)@([a-z]+)` `mail ada@example org` `\2:\1` )
+    ( show `foo` `a foo b` `[&]` )
+    ( show `(x)?(y)` `y` `1=[\1] 2=[\2]` )
+    ( show `((a)(b))c` `abc` `\1 \2 \3` )
+    ( show `a|ab` `abc` `&` )
+    ( show `^(\w+)\s+(\w+)$` `hello world` `\2 \1` )
+    ( show `(a)(b)(c)(d)(e)(f)(g)(h)(i)` `abcdefghi` `\9\8\7\6\5\4\3\2\1` )
+    ( show `(no)` `yes` `\1` )
+    ( show `x(y*)z` `xz` `[\1]` )
+    ( show `(a|b)+` `abab` `&/\1` )
+    ( show `q` `q` `\&amp \\\\ slash \n newline` )
+    ^ 0
+}

--- a/packages/nurlbox/README.md
+++ b/packages/nurlbox/README.md
@@ -1,0 +1,83 @@
+# `nurlbox` — the Swiss Army knife of NURL
+
+One binary, many utilities. `nurlbox` is a busybox-shaped multi-call
+executable: it decides which utility it is from the name it was invoked
+under, so a directory of symlinks pointing at it is a complete userland.
+
+```sh
+nurlbox                     # list the applets
+nurlbox cat file            # run one by name
+ln -s nurlbox /usr/bin/cat  # …or install it as itself
+cat file
+```
+
+Everything is pure NURL over the shipped standard library. There is no
+shelling out, no `coreutils` underneath, and nothing to link beyond libc
+— which is also why the same source builds for Linux, macOS, Windows and
+wasm32-wasi, and **boots as its own kernel** on the unikernel target.
+
+## The applets
+
+| Group | Applets |
+|---|---|
+| text | `cat` `echo` `head` `tail` `wc` `seq` `yes` `tac` `rev` `nl` `cut` `tr` `sort` `uniq` `tee` |
+| search & edit | `grep` `egrep` `fgrep` `sed` `find` |
+| files | `ls` `stat` `du` `cp` `mv` `rm` `mkdir` `rmdir` `ln` `touch` `chmod` `readlink` `realpath` `truncate` `mktemp` |
+| digests | `md5sum` `sha1sum` `sha256sum` `sha512sum` `cksum` `crc32` `base64` |
+| shell | `test` `[` `expr` `xargs` `sleep` `usleep` `true` `false` `env` `printenv` `printf` `which` |
+| system | `pwd` `basename` `dirname` `uname` `arch` `hostname` `whoami` `id` `groups` `logname` `nproc` `date` `sync` `clear` `tty` |
+
+## What "clone" means here
+
+The specification is the original, and the test suite says so: every case
+in [`tests/cases.sh`](tests/cases.sh) runs the same command line through
+`nurlbox` and through the system `busybox`, and the two must agree on
+stdout, on the bytes, and on the exit status. Where an applet mutates the
+filesystem the comparison is the resulting *tree* — names, contents and
+permission bits — because that is a `cp`'s real output, not what it
+printed.
+
+```sh
+./tests/nurlbox_test.sh          # ~260 differential cases
+BUSYBOX=/path/to/busybox ./tests/nurlbox_test.sh
+```
+
+Three deliberate divergences, each because the original takes a shortcut
+a modern tool should not:
+
+- **Byte fidelity.** A file whose last line has no newline does not grow
+  one, in any applet. busybox's `cat -n` and `sed` both append one.
+- **CRLF survives.** `head`, `cat`, `sed` and the rest copy the line
+  terminator the input carried, rather than normalising it to `\n`.
+- **No trailing whitespace.** `ls -lh` prints `total 12K`, not
+  `total 12K····`.
+
+Where busybox does not implement an option at all (`cat -E`, `cat -s`,
+`nl -n`, `cksum`), the reference is GNU coreutils, and the suite compares
+against that instead. And `find` sorts each directory it reads, so a run
+is reproducible; the original emits in whatever order the filesystem
+answered.
+
+## What it needed from the language
+
+The point of writing a userland is that it finds the holes. These were
+fixed where they actually were, not worked around here:
+
+| Gap | Fix |
+|---|---|
+| No `stat(2)` at all | `FileStat` + `fs_stat` / `fs_lstat` / `fs_fstat`, mode strings, `fs_set_times`, `fs_user_name` — `stdlib/std/fs.nu` over a new fixed-layout runtime thunk |
+| No way to enumerate the environment | `env_count` / `env_entry` / `env_list` — `stdlib/ext/env.nu` |
+| No `uname`, host name or processor count | `stdlib/std/sysinfo.nu` |
+| Time was UTC-only | `tz_offset` / `tz_name` / `time_local` — `stdlib/std/time.nu`, plus a dozen more `strftime` directives |
+| `bufio` could not read a line verbatim | `bufreader_read_line_raw`, which keeps the terminator |
+| Regular expressions had no capture groups | a Pike VM with capture slots in `stdlib/ext/regex.nu`; `regex_find_caps`, `regex_ngroups`, `regex_expand` |
+| The wildcard matcher was private to `fs_glob` | `fs_match` / `fs_match_glob` |
+| `path_dirname "foo"` answered `""`, `path_basename "/a/b/"` answered `""` | POSIX semantics in `stdlib/std/path.nu` |
+| `file_delete` could not delete a dangling symlink | it stopped probing with `access(2)` first |
+| `mkdir` ignored the umask | `nurl_dir_create` passes 0777 and lets the kernel subtract |
+
+## Memory
+
+Leak-clean under AddressSanitizer with `detect_leaks=1` across every
+applet — the manual-handle contract (`String`, `Vec`) is honoured on
+every path, including the error paths.

--- a/packages/nurlbox/nurl.toml
+++ b/packages/nurlbox/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nurlbox"
+version = "0.1.0"
+description = "The Swiss Army knife of NURL — a single multi-call binary carrying tiny, POSIX-shaped implementations of the everyday UNIX utilities (cat, ls, cp, mv, rm, grep, sed, sort, wc, head, tail, find, tar, gzip, sha256sum, …). One `nurlbox` binary dispatches on argv[0], exactly as busybox does, so a directory of symlinks becomes a complete userland. Pure NURL over the shipped stdlib: no libc utilities, no shell-outs. Builds for Linux, macOS, Windows and wasm32-wasi, and boots as its own kernel on the unikernel target."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurlbox"
+
+[dependencies]

--- a/packages/nurlbox/src/bx.nu
+++ b/packages/nurlbox/src/bx.nu
@@ -1,0 +1,435 @@
+// nurlbox/bx.nu — the plumbing every applet shares.
+//
+// busybox's own glue is three things: a diagnostic prefix that names
+// the applet rather than the binary, one option scanner (`getopt32`)
+// that every applet drives from a short spec string, and a handful of
+// byte-level output helpers. This file is that, in NURL.
+//
+// Option scanning follows busybox's model deliberately:
+//
+//     : BxOpts o ( bx_getopt argv 1 `ln:` `number=n,lines=n` )
+//     ? ( bx_has o `l` ) { ... } {}
+//     : s v ( bx_val o `n` )          // `` when the option was absent
+//     : ( Vec String ) rest ( bx_operands o )
+//
+// The spec is a run of option letters; a letter followed by `:` takes a
+// value. `longs` maps long names onto those letters, `name=letter`
+// comma-separated, so `--lines 5` and `-n5` land in the same slot.
+// Clustered shorts (`-la`), an attached value (`-n5`), a detached value
+// (`-n 5`), `--name=value`, `--` and a bare `-` (an operand, by
+// universal convention stdin) all behave as POSIX describes.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/errors.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+
+// The name diagnostics carry. Set once by the dispatcher, so every
+// message reads `rm: cannot remove 'x'` and not `nurlbox: ...`.
+: ~ s g_bx_name `nurlbox`
+
+@ bx_name → s { ^ g_bx_name }
+
+@ bx_set_name s n → v { = g_bx_name n }
+
+// ── Diagnostics ───────────────────────────────────────────────────
+
+@ bx_err s msg → v {
+    ( nurl_eprint g_bx_name )
+    ( nurl_eprint `: ` )
+    ( nurl_eprint msg )
+    ( nurl_eprint `\n` )
+}
+
+// `applet: subject: msg` — the shape every coreutils error takes.
+@ bx_err_at s subject s msg → v {
+    ( nurl_eprint g_bx_name )
+    ( nurl_eprint `: ` )
+    ( nurl_eprint subject )
+    ( nurl_eprint `: ` )
+    ( nurl_eprint msg )
+    ( nurl_eprint `\n` )
+}
+
+// ── Output ────────────────────────────────────────────────────────
+
+// Write a String's bytes verbatim — NULs and all — through stdout's
+// ordinary buffer, so it never reorders against `nurl_print`.
+@ bx_write String buf → v {
+    : i n ( string_len buf )
+    ? > n 0 { ( nurl_print_bytes ( string_data buf ) n ) } {}
+}
+
+@ bx_write_bytes ( Vec u ) buf → v {
+    : i n ( vec_len [u] buf )
+    ? > n 0 { ( nurl_print_bytes # s ( vec_data [u] buf ) n ) } {}
+}
+
+// ── Small string helpers ──────────────────────────────────────────
+
+@ bx_streq s a s b → b { ^ != 0 ( nurl_str_eq a b ) }
+
+// Borrowed view of argv[idx]; the empty string past the end. Callers
+// treat it as read-only — the Vec still owns the bytes.
+@ bx_at ( Vec String ) v i idx → s {
+    ? | < idx 0 >= idx ( vec_len [String] v ) { ^ `` } {}
+    ?? ( vec_get [String] v idx ) {
+        T x → { ^ ( string_data x ) }
+        F _ → { ^ `` }
+    }
+}
+
+// ── Option scanning ───────────────────────────────────────────────
+
+: BxOpts {
+    s spec
+    i flags  // bit k set = the k-th option letter of `spec` was given
+    ( Vec String ) vals  // one slot per option letter, `` when unset
+    ( Vec String ) allvals  // every value-bearing occurrence, in order
+    ( Vec i ) allords  // the option ordinal each `allvals` entry belongs to
+    ( Vec String ) args  // the operands, in order
+    b ok
+}
+
+// Ordinal of `letter` among the option letters of `spec`, or -1.
+@ __bx_ord s spec i lc → i {
+    : i n ( nurl_str_len spec )
+    : ~ i i 0
+    : ~ i k 0
+    : ~ i found -1
+    ~ < i n {
+        : i c ( nurl_str_get spec i )
+        ? != c 58 {
+            ? & < found 0 == c lc { = found k } {}
+            = k + k 1
+        } {}
+        = i + i 1
+    }
+    ^ found
+}
+
+@ __bx_letters s spec → i {
+    : i n ( nurl_str_len spec )
+    : ~ i i 0
+    : ~ i k 0
+    ~ < i n {
+        ? != ( nurl_str_get spec i ) 58 { = k + k 1 } {}
+        = i + i 1
+    }
+    ^ k
+}
+
+// Does the ordinal-`ord` option letter take a value?
+@ __bx_takes_val s spec i ord → b {
+    : i n ( nurl_str_len spec )
+    : ~ i i 0
+    : ~ i k 0
+    : ~ b ans F
+    ~ < i n {
+        : i c ( nurl_str_get spec i )
+        ? != c 58 {
+            ? == k ord {
+                ? < + i 1 n { ? == ( nurl_str_get spec + i 1 ) 58 { = ans T } {} } {}
+            } {}
+            = k + k 1
+        } {}
+        = i + i 1
+    }
+    ^ ans
+}
+
+// Resolve a long option name against the `name=letter,…` table.
+// Returns the letter's character code, or -1 when unknown.
+@ __bx_long_letter s longs s name → i {
+    : i ln ( nurl_str_len longs )
+    : i nn ( nurl_str_len name )
+    : ~ i i 0
+    : ~ i ans -1
+    ~ < i ln {
+        // one entry: up to the next ','
+        : ~ i e i
+        ~ & < e ln != ( nurl_str_get longs e ) 44 { = e + e 1 }
+        // split it at '='
+        : ~ i eq i
+        ~ & < eq e != ( nurl_str_get longs eq ) 61 { = eq + eq 1 }
+        ? & < ans 0 == - eq i nn {
+            : ~ b same T
+            : ~ i k 0
+            ~ < k nn {
+                ? != ( nurl_str_get longs + i k ) ( nurl_str_get name k ) { = same F } {}
+                = k + k 1
+            }
+            ? & same < + eq 1 e { = ans ( nurl_str_get longs + eq 1 ) } {}
+        } {}
+        = i + e 1
+    }
+    ^ ans
+}
+
+// The last value wins for `bx_val`, and EVERY value is kept for
+// `bx_vals` — `grep -e a -e b` and `tar -f x -f y` mean different things
+// and a scanner that only remembered the last could not tell them apart.
+@ __bx_set_val ( Vec String ) vals ( Vec String ) allvals ( Vec i ) allords i ord s value → v {
+    ?? ( vec_get [String] vals ord ) {
+        T slot → { ( string_clear slot ) ( string_push_str slot value ) }
+        F _ → {}
+    }
+    ( vec_push [String] allvals ( string_from value ) )
+    ( vec_push [i] allords ord )
+}
+
+// Scan `argv` from `start`. See the file header for the spec grammar.
+@ bx_getopt ( Vec String ) argv i start s spec s longs → BxOpts {
+    : i nletters ( __bx_letters spec )
+    : ( Vec String ) vals ( vec_new [String] )
+    : ~ i j 0
+    ~ < j nletters {
+        ( vec_push [String] vals ( string_new ) )
+        = j + j 1
+    }
+    : ( Vec String ) allvals ( vec_new [String] )
+    : ( Vec i ) allords ( vec_new [i] )
+    : ( Vec String ) args ( vec_new [String] )
+    : ~ i flags 0
+    : ~ b ok T
+    : ~ b endopts F
+    : i n ( vec_len [String] argv )
+    : ~ i i start
+    ~ < i n {
+        : s tok ( bx_at argv i )
+        : i tl ( nurl_str_len tok )
+        // `-2` and `-.5` are operands, not options, for a tool whose
+        // spec has no digit letters — `seq 10 -2 2` counts down, it does
+        // not ask for an option named `2`.
+        : b numeric & & > tl 1 == ( nurl_str_get tok 0 ) 45
+        & | ( bx_is_digit ( nurl_str_get tok 1 ) ) == ( nurl_str_get tok 1 ) 46
+        < ( __bx_ord spec ( nurl_str_get tok 1 ) ) 0
+        ? | endopts | numeric | < tl 2 != ( nurl_str_get tok 0 ) 45 {
+            ( vec_push [String] args ( string_from tok ) )
+        } {
+            ? & == ( nurl_str_get tok 1 ) 45 == tl 2 {
+                = endopts T
+            } {
+                ? == ( nurl_str_get tok 1 ) 45 {
+                    // --name  or  --name=value
+                    : ~ i eq 2
+                    ~ & < eq tl != ( nurl_str_get tok eq ) 61 { = eq + eq 1 }
+                    : s nm ( nurl_str_slice tok 2 - eq 2 )
+                    : i lc ( __bx_long_letter longs nm )
+                    ? < lc 0 {
+                        ( nurl_eprint g_bx_name )
+                        ( nurl_eprint `: unrecognized option '` )
+                        ( nurl_eprint tok )
+                        ( nurl_eprint `'\n` )
+                        = ok F
+                        = i n
+                    } {
+                        : i ord ( __bx_ord spec lc )
+                        = flags | flags << 1 ord
+                        ? ( __bx_takes_val spec ord ) {
+                            ? < eq tl {
+                                : s v ( nurl_str_slice tok + eq 1 - tl + eq 1 )
+                                ( __bx_set_val vals allvals allords ord v )
+                            } {
+                                ? < + i 1 n {
+                                    = i + i 1
+                                    ( __bx_set_val vals allvals allords ord ( bx_at argv i ) )
+                                } {
+                                    ( nurl_eprint g_bx_name )
+                                    ( nurl_eprint `: option '` )
+                                    ( nurl_eprint tok )
+                                    ( nurl_eprint `' requires an argument\n` )
+                                    = ok F
+                                    = i n
+                                }
+                            }
+                        } {}
+                    }
+                } {
+                    // a cluster of shorts: -la, -n5, -n 5
+                    : ~ i k 1
+                    ~ < k tl {
+                        : i c ( nurl_str_get tok k )
+                        : i ord ( __bx_ord spec c )
+                        ? < ord 0 {
+                            ( nurl_eprint g_bx_name )
+                            ( nurl_eprint `: invalid option -- '` )
+                            : s bad ( nurl_str_slice tok k 1 )
+                            ( nurl_eprint bad )
+                            ( nurl_eprint `'\n` )
+                            = ok F
+                            = k tl
+                            = i n
+                        } {
+                            = flags | flags << 1 ord
+                            ? ( __bx_takes_val spec ord ) {
+                                ? < + k 1 tl {
+                                    : s v ( nurl_str_slice tok + k 1 - tl + k 1 )
+                                    ( __bx_set_val vals allvals allords ord v )
+                                } {
+                                    ? < + i 1 n {
+                                        = i + i 1
+                                        ( __bx_set_val vals allvals allords ord ( bx_at argv i ) )
+                                    } {
+                                        ( nurl_eprint g_bx_name )
+                                        ( nurl_eprint `: option requires an argument -- '` )
+                                        : s bad2 ( nurl_str_slice tok k 1 )
+                                        ( nurl_eprint bad2 )
+                                        ( nurl_eprint `'\n` )
+                                        = ok F
+                                        = i n
+                                    }
+                                }
+                                = k tl
+                            } {
+                                = k + k 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        = i + i 1
+    }
+    ^ @ BxOpts { spec flags vals allvals allords args ok }
+}
+
+@ bx_has BxOpts o s letter → b {
+    : i ord ( __bx_ord . o spec ( nurl_str_get letter 0 ) )
+    ? < ord 0 { ^ F } {}
+    ^ != 0 & . o flags << 1 ord
+}
+
+// The value given for an option, or `` when it was never supplied.
+@ bx_val BxOpts o s letter → s {
+    : i ord ( __bx_ord . o spec ( nurl_str_get letter 0 ) )
+    ? < ord 0 { ^ `` } {}
+    ^ ( bx_at . o vals ord )
+}
+
+// Every value given for an option, in command-line order. Appends to
+// `out`; the caller owns the Strings it receives.
+@ bx_vals BxOpts o s letter ( Vec String ) out → v {
+    : i ord ( __bx_ord . o spec ( nurl_str_get letter 0 ) )
+    ? < ord 0 { ^ } {}
+    : i n ( vec_len [i] . o allords )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [i] . o allords i ) {
+            T k → {
+                ? == k ord { ( vec_push [String] out ( string_from ( bx_at . o allvals i ) ) ) } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+}
+
+@ bx_operand_count BxOpts o → i { ^ ( vec_len [String] . o args ) }
+
+@ bx_operand BxOpts o i idx → s { ^ ( bx_at . o args idx ) }
+
+@ bx_ok BxOpts o → b { ^ . o ok }
+
+@ bx_opts_free BxOpts o → v {
+    ( vec_free_with [String] . o vals \ String x → v { ( string_free x ) } )
+    ( vec_free_with [String] . o allvals \ String x → v { ( string_free x ) } )
+    ( vec_free [i] . o allords )
+    ( vec_free_with [String] . o args \ String x → v { ( string_free x ) } )
+}
+
+// ── Inputs ────────────────────────────────────────────────────────
+//
+// Every filter takes the same shape of operand list: paths, where `-`
+// (and, for a tool given none at all, the empty list) means stdin.
+
+@ bx_is_stdin s path → b {
+    ^ | == ( nurl_str_len path ) 0 ( bx_streq path `-` )
+}
+
+// The POSIX spelling of an I/O failure — `No such file or directory`,
+// not the stdlib enum's terser `not found`. Utilities are read by people
+// and by scripts that grep their stderr, so the wording matters.
+@ bx_ioerr IoErr e → s {
+    ^ ?? e {
+        NotFound → `No such file or directory`
+        PermissionDenied → `Permission denied`
+        AlreadyExists → `File exists`
+        Interrupted → `Interrupted system call`
+        UnexpectedEof → `Unexpected end of file`
+        WriteFailed → `Write error`
+        ReadFailed → `Read error`
+        Other → `Input/output error`
+    }
+}
+
+// Open `path` (or stdin for `-`) as a buffered line reader. On failure
+// the error is reported here — the caller only needs the option.
+@ bx_reader s path → ?BufReader {
+    ? ( bx_is_stdin path ) { ^ @ ?BufReader { T ( bufreader_stdin ) } } {}
+    ?? ( bufreader_open path ) {
+        T br → { ^ @ ?BufReader { T br } }
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            ^ @ ?BufReader { F # BufReader 0 }
+        }
+    }
+}
+
+// Whole input as bytes, diagnostics included. `ok` says whether the
+// returned Vec means anything.
+@ bx_slurp s path inout b ok → ( Vec u ) {
+    = ok T
+    ? ( bx_is_stdin path ) { ^ ( read_all_stdin_bytes ) } {}
+    ?? ( read_file_bytes path ) {
+        T v → { ^ v }
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            = ok F
+            ^ ( vec_new [u] )
+        }
+    }
+}
+
+// ── Numbers ───────────────────────────────────────────────────────
+//
+// A count with the size suffixes every utility accepts: `b` (512),
+// `k`/`K` (1024), `M`, `G`, and the decimal `kB`/`MB`/`GB`. Returns -1
+// when the text is not a count at all, so a caller can diagnose it.
+@ bx_count s text → i {
+    : i n ( nurl_str_len text )
+    ? == n 0 { ^ -1 } {}
+    : ~ i i 0
+    : ~ i val 0
+    : ~ b any F
+    ~ & < i n ( bx_is_digit ( nurl_str_get text i ) ) {
+        = val + * val 10 - ( nurl_str_get text i ) 48
+        = any T
+        = i + i 1
+    }
+    ? ! any { ^ -1 } {}
+    ? == i n { ^ val } {}
+    : i c ( nurl_str_get text i )
+    : b kb & < + i 1 n == ( nurl_str_get text + i 1 ) 66
+    : i rest ? kb - n + i 2 - n + i 1
+    ? != rest 0 { ^ -1 } {}
+    ? == c 98 { ^ * val 512 } {}
+    ? | == c 107 == c 75 { ^ * val ? kb 1000 1024 } {}
+    ? == c 77 { ^ * val ? kb 1000000 1048576 } {}
+    ? == c 71 { ^ * val ? kb 1000000000 1073741824 } {}
+    ^ -1
+}
+
+@ bx_is_digit i c → b { ^ & >= c 48 <= c 57 }
+
+@ bx_is_hex i c → b {
+    ^ | ( bx_is_digit c ) | & >= c 97 <= c 102 & >= c 65 <= c 70
+}
+
+@ bx_hex_val i c → i {
+    ? ( bx_is_digit c ) { ^ - c 48 } {}
+    ? & >= c 97 <= c 102 { ^ + 10 - c 97 } {}
+    ^ + 10 - c 65
+}

--- a/packages/nurlbox/src/fileops.nu
+++ b/packages/nurlbox/src/fileops.nu
@@ -1,0 +1,1422 @@
+// nurlbox/fileops.nu — the applets that touch the filesystem.
+//
+// ls / stat / mkdir / rmdir / rm / cp / mv / ln / touch / readlink /
+// realpath / truncate / chmod / mktemp.
+//
+// Everything here goes through `fs_lstat` rather than `fs_stat` when it
+// walks: a recursive remove or copy that follows a symlink leaves the
+// tree it was given, which is the difference between deleting a
+// directory and deleting whatever it happened to point at.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/ext/env.nu`
+$ `bx.nu`
+
+// ── A directory entry, with the metadata a listing needs ──────────
+
+: BxEnt {
+    String name
+    i mode
+    i size
+    i mtime
+    i nlink
+    i uid
+    i gid
+    i blocks
+    i ino
+    b ok  // F when the entry could not be stat'ed at all
+}
+
+@ __ent_free BxEnt e → v { ( string_free . e name ) }
+
+@ __ent_of s dir s name b follow → BxEnt {
+    : String full ? == ( nurl_str_len dir ) 0 ( string_from name ) ( path_join dir name )
+    : ~ BxEnt out @ BxEnt { ( string_from name ) 0 0 0 0 0 0 0 0 F }
+    : !FileStat IoErr r ? follow ( fs_stat ( string_data full ) ) ( fs_lstat ( string_data full ) )
+    ?? r {
+        T st → {
+            = out @ BxEnt {
+                ( string_from name ) . st mode . st size . st mtime . st nlink
+                . st uid . st gid . st blocks . st ino T
+            }
+        }
+        F _ → {}
+    }
+    ( string_free full )
+    ^ out
+}
+
+// ── ls ────────────────────────────────────────────────────────────
+
+: i LS_ALL 1  // -a
+: i LS_LONG 2  // -l
+: i LS_ONE 4  // -1
+: i LS_DIRS 8  // -d
+: i LS_REVERSE 16  // -r
+: i LS_TIME 32  // -t
+: i LS_SIZE_SORT 64  // -S
+: i LS_RECURSE 128  // -R
+: i LS_ALMOST 256  // -A
+: i LS_CLASSIFY 512  // -F
+: i LS_INODE 1024  // -i
+: i LS_HUMAN 2048  // -h
+: i LS_NUMERIC 4096  // -n
+: i LS_BLOCKS 8192  // -s
+: i LS_SLASH 16384  // -p
+: i LS_COLUMNS 32768  // -C / a tty
+
+// 1024-based sizes the way `-h` prints them: 4.0K, 1.5M, 12G.
+@ bx_human i n → String {
+    : String out ( string_new )
+    ? < n 1024 {
+        ( string_push_int out n )
+        ^ out
+    } {}
+    : s units `KMGTPE`
+    : ~ i v n
+    : ~ i unit -1
+    : ~ i rem 0
+    ~ & >= v 1024 < unit 5 {
+        = rem - v * / v 1024 1024
+        = v / v 1024
+        = unit + unit 1
+    }
+    // One decimal below 10, none above — `9.9K`, then `10K`.
+    ? < v 10 {
+        : i tenth / + * rem 10 512 1024
+        : ~ i whole v
+        : ~ i frac tenth
+        ? >= frac 10 { = whole + whole 1 = frac 0 } {}
+        ( string_push_int out whole )
+        ( string_push_char out 46 )
+        ( string_push_int out frac )
+    } {
+        ( string_push_int out ? >= rem 512 + v 1 v )
+    }
+    ( string_push_char out ( nurl_str_get units unit ) )
+    ^ out
+}
+
+@ __ls_suffix i flags i mode → i {
+    : i k ( nurl_stat_kind mode )
+    ? == k FS_KIND_DIR { ^ ? != 0 & flags | LS_CLASSIFY LS_SLASH 47 0 } {}
+    ? == 0 & flags LS_CLASSIFY { ^ 0 } {}
+    ? == k FS_KIND_SYMLINK { ^ 64 } {}
+    ? == k FS_KIND_FIFO { ^ 124 } {}
+    ? == k FS_KIND_SOCKET { ^ 61 } {}
+    ? & == k FS_KIND_FILE != 0 & mode 73 { ^ 42 } {}
+    ^ 0
+}
+
+// `Aug 27 14:03` for something in the last six months, `Aug 27  2024`
+// for anything older — the rule every ls has followed since v7.
+@ __ls_time String out i mtime i now → v {
+    : Time t ( time_local mtime )
+    : String mon ( time_format t `%b %e ` )
+    ( string_push_bytes out # *u ( string_data mon ) ( string_len mon ) )
+    ( string_free mon )
+    ? | > mtime + now 3600 < mtime - now 15552000 {
+        ( string_push_char out 32 )
+        : String y ( time_format t `%Y` )
+        ( string_push_bytes out # *u ( string_data y ) ( string_len y ) )
+        ( string_free y )
+    } {
+        : String hm ( time_format t `%H:%M` )
+        ( string_push_bytes out # *u ( string_data hm ) ( string_len hm ) )
+        ( string_free hm )
+    }
+}
+
+@ __push_right String out s text i width → v {
+    : ~ i k - width ( nurl_str_len text )
+    ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+    ( string_push_str out text )
+}
+
+// `%-N.Ns` — pad on the right, and TRUNCATE at N, which is what keeps
+// a long user name from shifting every column after it.
+@ __push_left String out s text i width → v {
+    : i n ( nurl_str_len text )
+    : i take ? > n width width n
+    ( string_push_bytes out # *u text take )
+    : ~ i k - width take
+    ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+}
+
+@ __ls_owner i id b numeric b group → String {
+    ? numeric { ^ ( string_from ( nurl_str_int id ) ) } {}
+    : ?String r ? group ( fs_group_name id ) ( fs_user_name id )
+    ?? r {
+        T n → { ^ n }
+        F _ → { ^ ( string_from ( nurl_str_int id ) ) }
+    }
+}
+
+@ __ls_cmp BxEnt a BxEnt b i flags → i {
+    : ~ i r 0
+    ? != 0 & flags LS_TIME {
+        = r ( cmp_int . b mtime . a mtime )
+        ? == r 0 { = r ( cmp_string . a name . b name ) } {}
+    } {
+        ? != 0 & flags LS_SIZE_SORT {
+            = r ( cmp_int . b size . a size )
+            ? == r 0 { = r ( cmp_string . a name . b name ) } {}
+        } {
+            = r ( cmp_string . a name . b name )
+        }
+    }
+    ^ ? != 0 & flags LS_REVERSE - 0 r r
+}
+
+// One entry, long form, into `out`. The column widths are busybox's
+// fixed ones — nlink %4, user and group %-8.8s, size %9 (or %7 under
+// -h) — not widths computed from the listing, so two `ls -l` runs over
+// different directories still line up when you read them side by side.
+@ __ls_long BxEnt e s dir i flags i now → v {
+    : String out ( string_new )
+    ? != 0 & flags LS_INODE {
+        ( string_push_int out . e ino )
+        ( string_push_char out 32 )
+    } {}
+    ? != 0 & flags LS_BLOCKS {
+        ( __push_right out ( nurl_str_int / . e blocks 2 ) 6 )
+        ( string_push_char out 32 )
+    } {}
+    : FileStat st @ FileStat { . e mode . e size . e mtime 0 . e uid . e gid . e nlink . e ino 0 0 . e blocks 0 0 0 0 0 }
+    : String modes ( stat_mode_string st )
+    ( string_push_bytes out # *u ( string_data modes ) ( string_len modes ) )
+    ( string_free modes )
+    ( string_push_char out 32 )
+    ( __push_right out ( nurl_str_int . e nlink ) 4 )
+    ( string_push_char out 32 )
+    : String un ( __ls_owner . e uid != 0 & flags LS_NUMERIC F )
+    ( __push_left out ( string_data un ) 8 )
+    ( string_free un )
+    ( string_push_char out 32 )
+    : String gn ( __ls_owner . e gid != 0 & flags LS_NUMERIC T )
+    ( __push_left out ( string_data gn ) 8 )
+    ( string_free gn )
+    ( string_push_char out 32 )
+    ? != 0 & flags LS_HUMAN {
+        : String h ( bx_human . e size )
+        ( __push_right out ( string_data h ) 7 )
+        ( string_free h )
+    } {
+        ( __push_right out ( nurl_str_int . e size ) 9 )
+    }
+    ( string_push_char out 32 )
+    ( __ls_time out . e mtime now )
+    ( string_push_char out 32 )
+    ( string_push_bytes out # *u ( string_data . e name ) ( string_len . e name ) )
+    : i sfx ( __ls_suffix flags . e mode )
+    ? != sfx 0 { ( string_push_char out sfx ) } {}
+    ? == ( nurl_stat_kind . e mode ) FS_KIND_SYMLINK {
+        : String full ? == ( nurl_str_len dir ) 0 ( string_clone . e name ) ( path_join dir ( string_data . e name ) )
+        ?? ( fs_readlink ( string_data full ) ) {
+            T tgt → {
+                ( string_push_str out ` -> ` )
+                ( string_push_bytes out # *u ( string_data tgt ) ( string_len tgt ) )
+                ( string_free tgt )
+            }
+            F _ → {}
+        }
+        ( string_free full )
+    } {}
+    ( string_push_char out 10 )
+    ( bx_write out )
+    ( string_free out )
+}
+
+@ __ls_name_only BxEnt e i flags → v {
+    : String out ( string_new )
+    ? != 0 & flags LS_INODE {
+        ( string_push_int out . e ino )
+        ( string_push_char out 32 )
+    } {}
+    ? != 0 & flags LS_BLOCKS {
+        ( __push_right out ( nurl_str_int / . e blocks 2 ) 6 )
+        ( string_push_char out 32 )
+    } {}
+    ( string_push_bytes out # *u ( string_data . e name ) ( string_len . e name ) )
+    : i sfx ( __ls_suffix flags . e mode )
+    ? != sfx 0 { ( string_push_char out sfx ) } {}
+    ( string_push_char out 10 )
+    ( bx_write out )
+    ( string_free out )
+}
+
+// Down-then-across columns, the layout `ls` uses on a terminal.
+@ __ls_columns ( Vec BxEnt ) ents i flags i width → v {
+    : i n ( vec_len [BxEnt] ents )
+    ? == n 0 { ^ } {}
+    : ~ i widest 0
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [BxEnt] ents i ) {
+            T e → {
+                : i w + ( string_len . e name ) ? != 0 ( __ls_suffix flags . e mode ) 1 0
+                ? > w widest { = widest w } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    : i colw + widest 2
+    : ~ i cols / width colw
+    ? < cols 1 { = cols 1 } {}
+    ? > cols n { = cols n } {}
+    : i rows / + n - cols 1 cols
+    : String out ( string_new )
+    : ~ i r 0
+    ~ < r rows {
+        : ~ i c 0
+        ~ < c cols {
+            : i idx + r * c rows
+            ? < idx n {
+                ?? ( vec_get [BxEnt] ents idx ) {
+                    T e → {
+                        ( string_push_bytes out # *u ( string_data . e name ) ( string_len . e name ) )
+                        : i sfx ( __ls_suffix flags . e mode )
+                        : ~ i used ( string_len . e name )
+                        ? != sfx 0 { ( string_push_char out sfx ) = used + used 1 } {}
+                        ? < + idx rows n {
+                            : ~ i pad - colw used
+                            ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+                        } {}
+                    }
+                    F _ → {}
+                }
+            } {}
+            = c + c 1
+        }
+        ( string_push_char out 10 )
+        = r + r 1
+    }
+    ( bx_write out )
+    ( string_free out )
+}
+
+@ __ls_emit ( Vec BxEnt ) ents s dir i flags i now → v {
+    : i n ( vec_len [BxEnt] ents )
+    : b longform != 0 & flags LS_LONG
+    // `total` counts 1 KiB blocks and is printed for a DIRECTORY
+    // listing only — operands named on the command line get none.
+    ? & > ( nurl_str_len dir ) 0 != 0 & flags | LS_LONG LS_BLOCKS {
+        : ~ i total 0
+        : ~ i i 0
+        ~ < i n {
+            ?? ( vec_get [BxEnt] ents i ) {
+                T e → { = total + total / . e blocks 2 }
+                F _ → {}
+            }
+            = i + i 1
+        }
+        ( nurl_print `total ` )
+        ? != 0 & flags LS_HUMAN {
+            : String h ( bx_human * total 1024 )
+            ( nurl_print ( string_data h ) )
+            ( string_free h )
+        } { ( nurl_print ( nurl_str_int total ) ) }
+        ( nurl_print `\n` )
+    } {}
+    ? longform {
+        : ~ i k 0
+        ~ < k n {
+            ?? ( vec_get [BxEnt] ents k ) {
+                T e → { ( __ls_long e dir flags now ) }
+                F _ → {}
+            }
+            = k + k 1
+        }
+    } {
+        ? != 0 & flags LS_COLUMNS {
+            : ~ i width 80
+            ?? ( env_get `COLUMNS` ) {
+                T c → {
+                    : i w ( nurl_str_to_int ( string_data c ) )
+                    ? > w 0 { = width w } {}
+                    ( string_free c )
+                }
+                F _ → {}
+            }
+            ( __ls_columns ents flags width )
+        } {
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [BxEnt] ents k ) {
+                    T e → { ( __ls_name_only e flags ) }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+        }
+    }
+}
+
+@ __ls_sort ( Vec BxEnt ) ents i flags → v {
+    ( sort_by [BxEnt] ents \ BxEnt a BxEnt b → i { ^ ( __ls_cmp a b flags ) } )
+}
+
+@ __ls_dir s dir i flags i now b header b more_after → i {
+    ?? ( dir_list dir ) {
+        F e → {
+            ( bx_err_at dir ( bx_ioerr e ) )
+            ^ 1
+        }
+        T names → {
+            : ( Vec BxEnt ) ents ( vec_new [BxEnt] )
+            ? != 0 & flags LS_ALL {
+                ( vec_push [BxEnt] ents ( __ent_of dir `.` F ) )
+                ( vec_push [BxEnt] ents ( __ent_of dir `..` F ) )
+            } {}
+            : i n ( vec_len [String] names )
+            : ~ i i 0
+            ~ < i n {
+                : s nm ( bx_at names i )
+                : b hidden == ( nurl_str_get nm 0 ) 46
+                ? | ! hidden != 0 & flags | LS_ALL LS_ALMOST {
+                    ( vec_push [BxEnt] ents ( __ent_of dir nm F ) )
+                } {}
+                = i + i 1
+            }
+            ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+            ( __ls_sort ents flags )
+            ? header {
+                ( nurl_print dir )
+                ( nurl_print `:\n` )
+            } {}
+            ( __ls_emit ents dir flags now )
+            : ~ i rc 0
+            ? != 0 & flags LS_RECURSE {
+                : i m ( vec_len [BxEnt] ents )
+                : ~ i k 0
+                ~ < k m {
+                    ?? ( vec_get [BxEnt] ents k ) {
+                        T e → {
+                            : s nm ( string_data . e name )
+                            ? & == ( nurl_stat_kind . e mode ) FS_KIND_DIR
+                            & ! ( bx_streq nm `.` ) ! ( bx_streq nm `..` ) {
+                                : String sub ( path_join dir nm )
+                                ( nurl_print `\n` )
+                                : i one ( __ls_dir ( string_data sub ) flags now T F )
+                                ? != one 0 { = rc 1 } {}
+                                ( string_free sub )
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            } {}
+            ( vec_free_with [BxEnt] ents \ BxEnt x → v { ( __ent_free x ) } )
+            ^ rc
+        }
+    }
+}
+
+@ ap_ls ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `laAd1rtSRFihnspCUx` `all=a,almost-all=A,long=l,reverse=r,recursive=R,inode=i,human-readable=h,numeric-uid-gid=n,size=s,classify=F,directory=d` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i flags 0
+        ? ( bx_has o `a` ) { = flags | flags LS_ALL } {}
+        ? ( bx_has o `A` ) { = flags | flags LS_ALMOST } {}
+        ? ( bx_has o `l` ) { = flags | flags LS_LONG } {}
+        ? ( bx_has o `1` ) { = flags | flags LS_ONE } {}
+        ? ( bx_has o `d` ) { = flags | flags LS_DIRS } {}
+        ? ( bx_has o `r` ) { = flags | flags LS_REVERSE } {}
+        ? ( bx_has o `t` ) { = flags | flags LS_TIME } {}
+        ? ( bx_has o `S` ) { = flags | flags LS_SIZE_SORT } {}
+        ? ( bx_has o `R` ) { = flags | flags LS_RECURSE } {}
+        ? ( bx_has o `F` ) { = flags | flags LS_CLASSIFY } {}
+        ? ( bx_has o `p` ) { = flags | flags LS_SLASH } {}
+        ? ( bx_has o `i` ) { = flags | flags LS_INODE } {}
+        ? ( bx_has o `h` ) { = flags | flags LS_HUMAN } {}
+        ? ( bx_has o `n` ) { = flags | flags | LS_NUMERIC LS_LONG } {}
+        ? ( bx_has o `s` ) { = flags | flags LS_BLOCKS } {}
+        // Columns only when the output is a terminal and nothing asked
+        // for one-per-line — the same rule coreutils applies, and the
+        // reason `ls | cat` is always one name per line.
+        ? & == 0 & flags | LS_LONG LS_ONE | ( bx_has o `C` ) ( term_is_tty 1 ) {
+            = flags | flags LS_COLUMNS
+        } {}
+        : i now ( now_seconds )
+        : i nops ( bx_operand_count o )
+        : ( Vec BxEnt ) loose ( vec_new [BxEnt] )
+        : ( Vec String ) dirs ( vec_new [String] )
+        ? == nops 0 {
+            ( vec_push [String] dirs ( string_from `.` ) )
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                ?? ( fs_lstat p ) {
+                    T st → {
+                        : ~ b isdir & ( stat_is_dir st ) == 0 & flags LS_DIRS
+                        ? & ( stat_is_symlink st ) == 0 & flags LS_DIRS {
+                            ?? ( fs_stat p ) {
+                                T st2 → { ? ( stat_is_dir st2 ) { = isdir T } {} }
+                                F _ → {}
+                            }
+                        } {}
+                        ? isdir {
+                            ( vec_push [String] dirs ( string_from p ) )
+                        } {
+                            ( vec_push [BxEnt] loose ( __ent_of `` p F ) )
+                        }
+                    }
+                    F e → {
+                        ( bx_err_at p ( bx_ioerr e ) )
+                        = rc 1
+                    }
+                }
+                = i + i 1
+            }
+        }
+        ? > ( vec_len [BxEnt] loose ) 0 {
+            ( __ls_sort loose flags )
+            ( __ls_emit loose `` flags now )
+        } {}
+        : i nd ( vec_len [String] dirs )
+        : b header | > nd 1 > ( vec_len [BxEnt] loose ) 0
+        : ~ i d 0
+        ~ < d nd {
+            ? | > d 0 > ( vec_len [BxEnt] loose ) 0 { ( nurl_print `\n` ) } {}
+            : i one ( __ls_dir ( bx_at dirs d ) flags now | header != 0 & flags LS_RECURSE F )
+            ? != one 0 { = rc 1 } {}
+            = d + d 1
+        }
+        ( vec_free_with [BxEnt] loose \ BxEnt x → v { ( __ent_free x ) } )
+        ( vec_free_with [String] dirs \ String x → v { ( string_free x ) } )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── mkdir / rmdir ─────────────────────────────────────────────────
+
+@ ap_mkdir ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `pm:v` `parents=p,mode=m,verbose=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i mode -1
+        ? ( bx_has o `m` ) {
+            : i m ( bx_parse_mode ( bx_val o `m` ) 493 )
+            ? < m 0 {
+                ( bx_err_at ( bx_val o `m` ) `invalid mode` )
+                = rc 1
+            } { = mode m }
+        } {}
+        ? == rc 0 {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                : !v IoErr r ? ( bx_has o `p` ) ( dir_create_all p ) ( dir_create p )
+                ?? r {
+                    T _ → {
+                        ? ( bx_has o `v` ) {
+                            ( nurl_print ( bx_name ) )
+                            ( nurl_print `: created directory '` )
+                            ( nurl_print p )
+                            ( nurl_print `'\n` )
+                        } {}
+                        ? >= mode 0 {
+                            ?? ( set_permissions p mode ) { T _ → {} F _ → {} }
+                        } {}
+                    }
+                    F e → {
+                        // -p makes an existing directory a success, which
+                        // is the entire point of the flag.
+                        : ~ b fine F
+                        ? ( bx_has o `p` ) {
+                            ?? ( fs_stat p ) {
+                                T st → { ? ( stat_is_dir st ) { = fine T } {} }
+                                F _ → {}
+                            }
+                        } {}
+                        ? ! fine {
+                            ( bx_err_at p ( bx_ioerr e ) )
+                            = rc 1
+                        } {}
+                    }
+                }
+                = i + i 1
+            }
+        } {}
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_rmdir ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `pv` `parents=p,verbose=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i i 0
+        ~ < i nops {
+            : String p ( string_from ( bx_operand o i ) )
+            : ~ b going T
+            ~ going {
+                = going F
+                ?? ( dir_remove ( string_data p ) ) {
+                    T _ → {
+                        ? ( bx_has o `p` ) {
+                            : String parent ( path_dirname ( string_data p ) )
+                            ? & > ( string_len parent ) 0 ! ( bx_streq ( string_data parent ) `.` ) {
+                                ( string_clear p )
+                                ( string_push_bytes p # *u ( string_data parent ) ( string_len parent ) )
+                                = going T
+                            } {}
+                            ( string_free parent )
+                        } {}
+                    }
+                    F e → {
+                        ( bx_err_at ( string_data p ) ( bx_ioerr e ) )
+                        = rc 1
+                    }
+                }
+            }
+            ( string_free p )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── modes ─────────────────────────────────────────────────────────
+
+// An octal mode (`755`, `0644`) or a symbolic one (`u+x`, `a-w`,
+// `go=rX`), applied to `base`. Returns -1 when the text is neither.
+@ bx_parse_mode s text i base → i {
+    : i n ( nurl_str_len text )
+    ? == n 0 { ^ -1 } {}
+    ? & >= ( nurl_str_get text 0 ) 48 <= ( nurl_str_get text 0 ) 55 {
+        : ~ i v 0
+        : ~ i k 0
+        ~ < k n {
+            : i c ( nurl_str_get text k )
+            ? ! & >= c 48 <= c 55 { ^ -1 } {}
+            = v + * v 8 - c 48
+            = k + k 1
+        }
+        ^ v
+    } {}
+    : ~ i cur base
+    : ~ i i 0
+    ~ < i n {
+        : ~ i who 0
+        : ~ b any_who F
+        : ~ b scanning T
+        ~ & scanning < i n {
+            : i c ( nurl_str_get text i )
+            ? == c 117 { = who | who 4 = any_who T = i + i 1 } {
+                ? == c 103 { = who | who 2 = any_who T = i + i 1 } {
+                    ? == c 111 { = who | who 1 = any_who T = i + i 1 } {
+                        ? == c 97 { = who 7 = any_who T = i + i 1 } { = scanning F } } } }
+        }
+        ? ! any_who { = who 7 } {}
+        ? >= i n { ^ -1 } {}
+        : i op ( nurl_str_get text i )
+        ? ! | == op 43 | == op 45 == op 61 { ^ -1 } {}
+        = i + i 1
+        : ~ i bits 0
+        : ~ b more T
+        ~ & more < i n {
+            : i c ( nurl_str_get text i )
+            ? == c 114 { = bits | bits 4 = i + i 1 } {
+                ? == c 119 { = bits | bits 2 = i + i 1 } {
+                    ? == c 120 { = bits | bits 1 = i + i 1 } {
+                        ? == c 88 { = bits | bits 1 = i + i 1 } {
+                            ? == c 115 { = bits | bits 8 = i + i 1 } {
+                                ? == c 116 { = bits | bits 16 = i + i 1 } { = more F } } } } } }
+        }
+        : ~ i mask 0
+        ? != 0 & who 4 { = mask | mask << & bits 7 6 } {}
+        ? != 0 & who 2 { = mask | mask << & bits 7 3 } {}
+        ? != 0 & who 1 { = mask | mask & bits 7 } {}
+        ? != 0 & bits 8 {
+            ? != 0 & who 4 { = mask | mask 2048 } {}
+            ? != 0 & who 2 { = mask | mask 1024 } {}
+        } {}
+        ? != 0 & bits 16 { = mask | mask 512 } {}
+        ? == op 43 { = cur | cur mask } {}
+        ? == op 45 { = cur & cur ~ mask } {}
+        ? == op 61 {
+            : ~ i clear 0
+            ? != 0 & who 4 { = clear | clear 448 } {}
+            ? != 0 & who 2 { = clear | clear 56 } {}
+            ? != 0 & who 1 { = clear | clear 7 } {}
+            = cur | & cur ~ clear mask
+        } {}
+        ? & < i n == ( nurl_str_get text i ) 44 { = i + i 1 } {}
+    }
+    ^ cur
+}
+
+@ __chmod_one s path s spec b recurse b verbose → i {
+    : ~ i rc 0
+    ?? ( fs_lstat path ) {
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            ^ 1
+        }
+        T st → {
+            // A symlink has no mode of its own worth changing; chmod
+            // follows it, and chmod on a dangling one is an error.
+            ? ! ( stat_is_symlink st ) {
+                : i want ( bx_parse_mode spec ( stat_mode_bits st ) )
+                ? < want 0 {
+                    ( bx_err_at spec `invalid mode` )
+                    ^ 1
+                } {}
+                ?? ( set_permissions path want ) {
+                    T _ → {
+                        ? verbose {
+                            ( nurl_print `mode of '` )
+                            ( nurl_print path )
+                            ( nurl_print `' changed\n` )
+                        } {}
+                    }
+                    F e2 → {
+                        ( bx_err_at path ( bx_ioerr e2 ) )
+                        = rc 1
+                    }
+                }
+            } {}
+            ? & recurse ( stat_is_dir st ) {
+                ?? ( dir_list path ) {
+                    T names → {
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String sub ( path_join path ( bx_at names k ) )
+                            : i one ( __chmod_one ( string_data sub ) spec recurse verbose )
+                            ? != one 0 { = rc 1 } {}
+                            ( string_free sub )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F _ → { = rc 1 }
+                }
+            } {}
+        }
+    }
+    ^ rc
+}
+
+@ ap_chmod ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `Rvcf` `recursive=R,verbose=v,changes=c,silent=f` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? < nops 2 {
+            ( bx_err `usage: chmod [-Rv] MODE FILE...` )
+            = rc 1
+        } {
+            : s spec ( bx_operand o 0 )
+            : ~ i i 1
+            ~ < i nops {
+                : i one ( __chmod_one ( bx_operand o i ) spec ( bx_has o `R` ) | ( bx_has o `v` ) ( bx_has o `c` ) )
+                ? != one 0 { = rc 1 } {}
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── rm ────────────────────────────────────────────────────────────
+
+@ __rm_one s path b recurse b force b verbose → i {
+    ?? ( fs_lstat path ) {
+        F e → {
+            ? force { ^ 0 } {}
+            ( bx_err_at path ( bx_ioerr e ) )
+            ^ 1
+        }
+        T st → {
+            ? ( stat_is_dir st ) {
+                ? ! recurse {
+                    ( bx_err_at path `Is a directory` )
+                    ^ 1
+                } {}
+                : ~ i rc 0
+                ?? ( dir_list path ) {
+                    T names → {
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String sub ( path_join path ( bx_at names k ) )
+                            : i one ( __rm_one ( string_data sub ) recurse force verbose )
+                            ? != one 0 { = rc 1 } {}
+                            ( string_free sub )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F e2 → {
+                        ( bx_err_at path ( bx_ioerr e2 ) )
+                        = rc 1
+                    }
+                }
+                ?? ( dir_remove path ) {
+                    T _ → {
+                        ? verbose {
+                            ( nurl_print `removed directory '` )
+                            ( nurl_print path )
+                            ( nurl_print `'\n` )
+                        } {}
+                    }
+                    F e3 → {
+                        ( bx_err_at path ( bx_ioerr e3 ) )
+                        = rc 1
+                    }
+                }
+                ^ rc
+            } {}
+            ?? ( file_delete path ) {
+                T _ → {
+                    ? verbose {
+                        ( nurl_print `removed '` )
+                        ( nurl_print path )
+                        ( nurl_print `'\n` )
+                    } {}
+                    ^ 0
+                }
+                F e4 → {
+                    ? force { ^ 0 } {}
+                    ( bx_err_at path ( bx_ioerr e4 ) )
+                    ^ 1
+                }
+            }
+        }
+    }
+}
+
+@ ap_rm ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `rRfvi` `recursive=r,force=f,verbose=v,interactive=i` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : b force ( bx_has o `f` )
+        ? == nops 0 {
+            ? ! force {
+                ( bx_err `missing operand` )
+                = rc 1
+            } {}
+        } {
+            : b recurse | ( bx_has o `r` ) ( bx_has o `R` )
+            : ~ i i 0
+            ~ < i nops {
+                : i one ( __rm_one ( bx_operand o i ) recurse force ( bx_has o `v` ) )
+                ? != one 0 { = rc 1 } {}
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── cp ────────────────────────────────────────────────────────────
+
+& `c` @ link s target s linkpath → i32
+
+: i CP_RECURSE 1
+: i CP_PRESERVE 2
+: i CP_FORCE 4
+: i CP_VERBOSE 8
+: i CP_NODEREF 16
+: i CP_NOCLOBBER 32
+
+@ __cp_verbose s src s dst → v {
+    ( nurl_print `'` )
+    ( nurl_print src )
+    ( nurl_print `' -> '` )
+    ( nurl_print dst )
+    ( nurl_print `'\n` )
+}
+
+@ __cp_preserve s dst FileStat st → v {
+    ?? ( set_permissions dst ( stat_mode_bits st ) ) { T _ → {} F _ → {} }
+    ?? ( fs_set_times dst . st atime . st atime_ns . st mtime . st mtime_ns T ) { T _ → {} F _ → {} }
+}
+
+@ __cp_one s src s dst i flags → i {
+    ?? ( fs_lstat src ) {
+        F e → {
+            ( bx_err_at src ( bx_ioerr e ) )
+            ^ 1
+        }
+        T st → {
+            // -n: an existing destination is left alone, silently.
+            ? != 0 & flags CP_NOCLOBBER {
+                ?? ( fs_lstat dst ) {
+                    T _ → { ^ 0 }
+                    F _ → {}
+                }
+            } {}
+            ? & ( stat_is_symlink st ) != 0 & flags CP_NODEREF {
+                ?? ( fs_readlink src ) {
+                    T tgt → {
+                        ? != 0 & flags CP_FORCE {
+                            ?? ( file_delete dst ) { T _ → {} F _ → {} }
+                        } {}
+                        : ~ i rc 0
+                        ?? ( fs_symlink ( string_data tgt ) dst ) {
+                            T _ → { ? != 0 & flags CP_VERBOSE { ( __cp_verbose src dst ) } {} }
+                            F e2 → {
+                                ( bx_err_at dst ( bx_ioerr e2 ) )
+                                = rc 1
+                            }
+                        }
+                        ( string_free tgt )
+                        ^ rc
+                    }
+                    F e3 → {
+                        ( bx_err_at src ( bx_ioerr e3 ) )
+                        ^ 1
+                    }
+                }
+            } {}
+            ? ( stat_is_dir st ) {
+                ? == 0 & flags CP_RECURSE {
+                    ( bx_err_at src `omitting directory` )
+                    ^ 1
+                } {}
+                : ~ i rc 0
+                ?? ( dir_create dst ) {
+                    T _ → {}
+                    F _ → {
+                        // Already a directory is fine; anything else is
+                        // reported when the first child fails.
+                        ?? ( fs_stat dst ) {
+                            T dstat → { ? ! ( stat_is_dir dstat ) { = rc 1 } {} }
+                            F _ → { = rc 1 }
+                        }
+                    }
+                }
+                ? != rc 0 {
+                    ( bx_err_at dst `cannot create directory` )
+                    ^ 1
+                } {}
+                ?? ( dir_list src ) {
+                    T names → {
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String s2 ( path_join src ( bx_at names k ) )
+                            : String d2 ( path_join dst ( bx_at names k ) )
+                            : i one ( __cp_one ( string_data s2 ) ( string_data d2 ) flags )
+                            ? != one 0 { = rc 1 } {}
+                            ( string_free s2 )
+                            ( string_free d2 )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F e4 → {
+                        ( bx_err_at src ( bx_ioerr e4 ) )
+                        = rc 1
+                    }
+                }
+                ? != 0 & flags CP_PRESERVE { ( __cp_preserve dst st ) } {}
+                ? != 0 & flags CP_VERBOSE { ( __cp_verbose src dst ) } {}
+                ^ rc
+            } {}
+            ? != 0 & flags CP_FORCE {
+                ?? ( file_delete dst ) { T _ → {} F _ → {} }
+            } {}
+            ?? ( fs_copy_file src dst ) {
+                T _ → {
+                    // Without -p the destination still gets the source's
+                    // permission bits, as POSIX cp specifies; -p adds the
+                    // timestamps.
+                    ?? ( set_permissions dst ( stat_mode_bits st ) ) { T _ → {} F _ → {} }
+                    ? != 0 & flags CP_PRESERVE { ( __cp_preserve dst st ) } {}
+                    ? != 0 & flags CP_VERBOSE { ( __cp_verbose src dst ) } {}
+                    ^ 0
+                }
+                F e5 → {
+                    ( bx_err_at dst ( bx_ioerr e5 ) )
+                    ^ 1
+                }
+            }
+        }
+    }
+}
+
+// `cp a b/` and `cp a b c dir` both end at a directory: the destination
+// for each source is dir/basename(source).
+@ __dest_for s dst s src b into_dir → String {
+    ? ! into_dir { ^ ( string_from dst ) } {}
+    : String base ( path_basename src )
+    : String full ( path_join dst ( string_data base ) )
+    ( string_free base )
+    ^ full
+}
+
+@ __is_dir s p → b {
+    ?? ( fs_stat p ) {
+        T st → { ^ ( stat_is_dir st ) }
+        F _ → { ^ F }
+    }
+}
+
+@ ap_cp ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `rRapfvdLnPTi` `recursive=r,archive=a,preserve=p,force=f,verbose=v,no-dereference=d,dereference=L,no-clobber=n,no-target-directory=T` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? < nops 2 {
+            ( bx_err `missing destination file operand` )
+            = rc 1
+        } {
+            : ~ i flags 0
+            ? | ( bx_has o `r` ) | ( bx_has o `R` ) ( bx_has o `a` ) { = flags | flags CP_RECURSE } {}
+            ? | ( bx_has o `p` ) ( bx_has o `a` ) { = flags | flags CP_PRESERVE } {}
+            // A recursive copy keeps symlinks as symlinks unless -L says
+            // otherwise: dereferencing turns one link into a second full
+            // copy of its target, and a link loop into an infinite one.
+            ? | ( bx_has o `d` ) | ( bx_has o `P` ) | ( bx_has o `a` ) != 0 & flags CP_RECURSE { = flags | flags CP_NODEREF } {}
+            ? ( bx_has o `L` ) { = flags & flags ~ CP_NODEREF } {}
+            ? ( bx_has o `f` ) { = flags | flags CP_FORCE } {}
+            ? ( bx_has o `v` ) { = flags | flags CP_VERBOSE } {}
+            ? ( bx_has o `n` ) { = flags | flags CP_NOCLOBBER } {}
+            : s dst ( bx_operand o - nops 1 )
+            : b into_dir & ( __is_dir dst ) ! ( bx_has o `T` )
+            ? & > nops 3 ! into_dir {
+                ( bx_err_at dst `not a directory` )
+                = rc 1
+            } {
+                : ~ i i 0
+                ~ < i - nops 1 {
+                    : s src ( bx_operand o i )
+                    : String d ( __dest_for dst src into_dir )
+                    : i one ( __cp_one src ( string_data d ) flags )
+                    ? != one 0 { = rc 1 } {}
+                    ( string_free d )
+                    = i + i 1
+                }
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── mv ────────────────────────────────────────────────────────────
+
+@ __mv_one s src s dst b force b verbose → i {
+    ? ! force {
+        ?? ( fs_lstat dst ) {
+            T _ → {}
+            F _ → {}
+        }
+    } {}
+    ?? ( fs_rename src dst ) {
+        T _ → {
+            ? verbose { ( __cp_verbose src dst ) } {}
+            ^ 0
+        }
+        F _ → {}
+    }
+    // A rename across filesystems is EXDEV; copy then remove is what
+    // every mv does about it, and the copy must preserve metadata
+    // because a move is not supposed to change the file.
+    : i c ( __cp_one src dst | | CP_RECURSE CP_PRESERVE CP_NODEREF )
+    ? != c 0 { ^ 1 } {}
+    : i r ( __rm_one src T T F )
+    ? != r 0 { ^ 1 } {}
+    ? verbose { ( __cp_verbose src dst ) } {}
+    ^ 0
+}
+
+@ ap_mv ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `fvniT` `force=f,verbose=v,no-clobber=n,no-target-directory=T` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? < nops 2 {
+            ( bx_err `missing destination file operand` )
+            = rc 1
+        } {
+            : s dst ( bx_operand o - nops 1 )
+            : b into_dir & ( __is_dir dst ) ! ( bx_has o `T` )
+            : ~ i i 0
+            ~ < i - nops 1 {
+                : s src ( bx_operand o i )
+                : String d ( __dest_for dst src into_dir )
+                : ~ b skip F
+                ? ( bx_has o `n` ) {
+                    ?? ( fs_lstat ( string_data d ) ) {
+                        T _ → { = skip T }
+                        F _ → {}
+                    }
+                } {}
+                ? ! skip {
+                    : i one ( __mv_one src ( string_data d ) ( bx_has o `f` ) ( bx_has o `v` ) )
+                    ? != one 0 { = rc 1 } {}
+                } {}
+                ( string_free d )
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── ln ────────────────────────────────────────────────────────────
+
+@ ap_ln ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `sfvnT` `symbolic=s,force=f,verbose=v,no-target-directory=T` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {
+            // `ln TARGET` links into the current directory.
+            : s dst ? > nops 1 ( bx_operand o - nops 1 ) `.`
+            : b into_dir | == nops 1 & ( __is_dir dst ) ! ( bx_has o `T` )
+            : i last ? > nops 1 - nops 1 nops
+            : ~ i i 0
+            ~ < i last {
+                : s src ( bx_operand o i )
+                : String d ( __dest_for dst src into_dir )
+                ? ( bx_has o `f` ) {
+                    ?? ( file_delete ( string_data d ) ) { T _ → {} F _ → {} }
+                } {}
+                ? ( bx_has o `s` ) {
+                    ?? ( fs_symlink src ( string_data d ) ) {
+                        T _ → { ? ( bx_has o `v` ) { ( __cp_verbose ( string_data d ) src ) } {} }
+                        F e → {
+                            ( bx_err_at ( string_data d ) ( bx_ioerr e ) )
+                            = rc 1
+                        }
+                    }
+                } {
+                    : i32 lr ( link src ( string_data d ) )
+                    ? != # i lr 0 {
+                        ( bx_err_at ( string_data d ) ( bx_ioerr ( _io_err_of_kind ( errno_kind ) ) ) )
+                        = rc 1
+                    } {
+                        ? ( bx_has o `v` ) { ( __cp_verbose ( string_data d ) src ) } {}
+                    }
+                }
+                ( string_free d )
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── touch ─────────────────────────────────────────────────────────
+
+@ ap_touch ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `camr:d:t:` `no-create=c,reference=r,date=d` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i when ( now_seconds )
+        : ~ i when_ns 0
+        : ~ b have_time F
+        ? ( bx_has o `r` ) {
+            ?? ( fs_stat ( bx_val o `r` ) ) {
+                T st → {
+                    = when . st mtime
+                    = when_ns . st mtime_ns
+                    = have_time T
+                }
+                F e → {
+                    ( bx_err_at ( bx_val o `r` ) ( bx_ioerr e ) )
+                    = rc 1
+                }
+            }
+        } {}
+        ? ( bx_has o `d` ) {
+            ?? ( time_parse_iso ( bx_val o `d` ) ) {
+                T secs → { = when secs = when_ns 0 = have_time T }
+                F _ → {
+                    ( bx_err_at ( bx_val o `d` ) `invalid date` )
+                    = rc 1
+                }
+            }
+        } {}
+        : b touch_a | ( bx_has o `a` ) ! ( bx_has o `m` )
+        : b touch_m | ( bx_has o `m` ) ! ( bx_has o `a` )
+        ? == rc 0 {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                : ~ b exists F
+                : ~ i atime when
+                : ~ i atime_ns when_ns
+                : ~ i mtime when
+                : ~ i mtime_ns when_ns
+                ?? ( fs_stat p ) {
+                    T st → {
+                        = exists T
+                        // -a alone leaves mtime where it was, -m alone
+                        // leaves atime — so read the current pair first.
+                        ? ! touch_a { = atime . st atime = atime_ns . st atime_ns } {}
+                        ? ! touch_m { = mtime . st mtime = mtime_ns . st mtime_ns } {}
+                    }
+                    F _ → {}
+                }
+                ? ! exists {
+                    ? ( bx_has o `c` ) {
+                        = i + i 1
+                    } {
+                        ?? ( file_create p ) {
+                            T f → {
+                                ( file_close f )
+                                = exists T
+                            }
+                            F e → {
+                                ( bx_err_at p ( bx_ioerr e ) )
+                                = rc 1
+                            }
+                        }
+                    }
+                } {}
+                ? exists {
+                    ?? ( fs_set_times p atime atime_ns mtime mtime_ns T ) {
+                        T _ → {}
+                        F e2 → {
+                            ( bx_err_at p ( bx_ioerr e2 ) )
+                            = rc 1
+                        }
+                    }
+                } {}
+                = i + i 1
+            }
+        } {}
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── readlink / realpath ───────────────────────────────────────────
+
+@ ap_readlink ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `fnv` `canonicalize=f,no-newline=n,verbose=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i i 0
+        ~ < i nops {
+            : s p ( bx_operand o i )
+            ? ( bx_has o `f` ) {
+                : Path pp ( path_new p )
+                ?? ( path_canonical pp ) {
+                    T c → {
+                        ( nurl_print ( path_str c ) )
+                        ( nurl_print ? ( bx_has o `n` ) `` `\n` )
+                        ( path_free c )
+                    }
+                    F _ → {
+                        ? ( bx_has o `v` ) { ( bx_err_at p `No such file or directory` ) } {}
+                        = rc 1
+                    }
+                }
+                ( path_free pp )
+            } {
+                ?? ( fs_readlink p ) {
+                    T t → {
+                        ( nurl_print ( string_data t ) )
+                        ( nurl_print ? ( bx_has o `n` ) `` `\n` )
+                        ( string_free t )
+                    }
+                    F _ → {
+                        ? ( bx_has o `v` ) { ( bx_err_at p `Invalid argument` ) } {}
+                        = rc 1
+                    }
+                }
+            }
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_realpath ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `s` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i i 0
+        ~ < i nops {
+            : Path pp ( path_new ( bx_operand o i ) )
+            ?? ( path_canonical pp ) {
+                T c → {
+                    ( nurl_print ( path_str c ) )
+                    ( nurl_print `\n` )
+                    ( path_free c )
+                }
+                F _ → {
+                    ( bx_err_at ( bx_operand o i ) `No such file or directory` )
+                    = rc 1
+                }
+            }
+            ( path_free pp )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── truncate ──────────────────────────────────────────────────────
+
+@ ap_truncate ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `s:c` `size=s,no-create=c` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        ? ! ( bx_has o `s` ) {
+            ( bx_err `you must specify a size` )
+            = rc 1
+        } {
+            : i want ( bx_count ( bx_val o `s` ) )
+            ? < want 0 {
+                ( bx_err_at ( bx_val o `s` ) `invalid size` )
+                = rc 1
+            } {
+                : i nops ( bx_operand_count o )
+                : ~ i i 0
+                ~ < i nops {
+                    : s p ( bx_operand o i )
+                    : ~ b exists F
+                    ?? ( fs_stat p ) {
+                        T _ → { = exists T }
+                        F _ → {}
+                    }
+                    ? & ! exists ! ( bx_has o `c` ) {
+                        ?? ( file_create p ) {
+                            T f → { ( file_close f ) = exists T }
+                            F e → {
+                                ( bx_err_at p ( bx_ioerr e ) )
+                                = rc 1
+                            }
+                        }
+                    } {}
+                    ? exists {
+                        ?? ( file_truncate p want ) {
+                            T _ → {}
+                            F e2 → {
+                                ( bx_err_at p ( bx_ioerr e2 ) )
+                                = rc 1
+                            }
+                        }
+                    } {}
+                    = i + i 1
+                }
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── mktemp ────────────────────────────────────────────────────────
+
+@ ap_mktemp ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `dup:tq` `directory=d,dry-run=u,tmpdir=p,quiet=q` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : String dir ? ( bx_has o `p` ) ( string_from ( bx_val o `p` ) ) ( env_var_or `TMPDIR` `/tmp` )
+        : ~ String prefix ( string_from `tmp.` )
+        ? > ( bx_operand_count o ) 0 {
+            // A template's XXXXXX is replaced; anything before it is the
+            // prefix, which is all the uniqueness machinery needs.
+            : s t ( bx_operand o 0 )
+            : i x ( nurl_str_find t `XXX` )
+            ( string_clear prefix )
+            ( string_push_str prefix ? > x -1 ( nurl_str_slice t 0 x ) t )
+        } {}
+        ? ( bx_has o `d` ) {
+            // mkdir(2) fails if the name exists, so the loop IS the
+            // uniqueness test — no window between checking and creating.
+            : ~ i attempt 0
+            : ~ b made F
+            ~ & ! made < attempt 200 {
+                : String cand ( string_clone dir )
+                ( string_push_char cand 47 )
+                ( string_push_bytes cand # *u ( string_data prefix ) ( string_len prefix ) )
+                ( string_push_int cand + * ( now_ms ) 1000 + attempt * # i ( getpid ) 7 )
+                ?? ( dir_create ( string_data cand ) ) {
+                    T _ → {
+                        ( nurl_print ( string_data cand ) )
+                        ( nurl_print `\n` )
+                        = made T
+                    }
+                    F _ → {}
+                }
+                ( string_free cand )
+                = attempt + attempt 1
+            }
+            ? ! made {
+                ? ! ( bx_has o `q` ) { ( bx_err `failed to create directory` ) } {}
+                = rc 1
+            } {}
+        } {
+            ?? ( fs_tempfile ( string_data dir ) ( string_data prefix ) ) {
+                T p → {
+                    ? ( bx_has o `u` ) {
+                        ?? ( file_delete ( string_data p ) ) { T _ → {} F _ → {} }
+                    } {}
+                    ( nurl_print ( string_data p ) )
+                    ( nurl_print `\n` )
+                    ( string_free p )
+                }
+                F e → {
+                    ? ! ( bx_has o `q` ) { ( bx_err ( bx_ioerr e ) ) } {}
+                    = rc 1
+                }
+            }
+        }
+        ( string_free prefix )
+        ( string_free dir )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/filter.nu
+++ b/packages/nurlbox/src/filter.nu
@@ -1,0 +1,877 @@
+// nurlbox/filter.nu — the line-shaped filters.
+//
+// tac / rev / nl / cut / tr / sort / uniq / tee / comm / paste / fold /
+// expand / unexpand / split / cmp.
+//
+// Each reads its inputs through `bx_reader`, so `-` and a missing
+// operand both mean stdin, and each writes through one String buffer so
+// a long run costs one write per few thousand lines rather than one per
+// line.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `bx.nu`
+
+// Collect every line of one input, terminators stripped.
+@ bx_read_lines s path ( Vec String ) out → b {
+    ?? ( bx_reader path ) {
+        F _ → { ^ F }
+        T br → {
+            : String line ( string_new )
+            : ~ b more T
+            ~ more {
+                ? ( bufreader_read_line_into br line ) {
+                    ( vec_push [String] out ( string_clone line ) )
+                } { = more F }
+            }
+            ( string_free line )
+            ( bufreader_close br )
+            ^ T
+        }
+    }
+}
+
+@ bx_free_lines ( Vec String ) v → v {
+    ( vec_free_with [String] v \ String x → v { ( string_free x ) } )
+}
+
+// Every operand, or `-` when there are none.
+@ bx_inputs BxOpts o ( Vec String ) out → v {
+    : i n ( bx_operand_count o )
+    ? == n 0 {
+        ( vec_push [String] out ( string_from `-` ) )
+    } {
+        : ~ i i 0
+        ~ < i n {
+            ( vec_push [String] out ( string_from ( bx_operand o i ) ) )
+            = i + i 1
+        }
+    }
+}
+
+// ── tac ───────────────────────────────────────────────────────────
+
+@ ap_tac ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : i ni ( vec_len [String] ins )
+        : ~ i k 0
+        ~ < k ni {
+            : ( Vec String ) lines ( vec_new [String] )
+            ? ( bx_read_lines ( bx_at ins k ) lines ) {
+                : String out ( string_new )
+                : ~ i j ( vec_len [String] lines )
+                ~ > j 0 {
+                    ?? ( vec_get [String] lines - j 1 ) {
+                        T l → {
+                            ( string_push_bytes out # *u ( string_data l ) ( string_len l ) )
+                            ( string_push_char out 10 )
+                        }
+                        F _ → {}
+                    }
+                    = j - j 1
+                }
+                ( bx_write out )
+                ( string_free out )
+            } { = rc 1 }
+            ( bx_free_lines lines )
+            = k + k 1
+        }
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── rev ───────────────────────────────────────────────────────────
+
+@ ap_rev ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : i ni ( vec_len [String] ins )
+        : ~ i k 0
+        ~ < k ni {
+            ?? ( bx_reader ( bx_at ins k ) ) {
+                F _ → { = rc 1 }
+                T br → {
+                    : String line ( string_new )
+                    : String out ( string_new )
+                    : ~ b more T
+                    ~ more {
+                        ? ( bufreader_read_line_into br line ) {
+                            : ~ i j ( string_len line )
+                            ~ > j 0 {
+                                ( string_push_char out ( string_get line - j 1 ) )
+                                = j - j 1
+                            }
+                            ( string_push_char out 10 )
+                            ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                        } { = more F }
+                    }
+                    ( bx_write out )
+                    ( string_free out )
+                    ( string_free line )
+                    ( bufreader_close br )
+                }
+            }
+            = k + k 1
+        }
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── nl ────────────────────────────────────────────────────────────
+
+@ ap_nl ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `b:n:s:w:v:i:` `body-numbering=b,number-format=n,number-separator=s,number-width=w,starting-line-number=v,line-increment=i` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : s style ? ( bx_has o `b` ) ( bx_val o `b` ) `t`
+        : s fmt ? ( bx_has o `n` ) ( bx_val o `n` ) `rn`
+        : s sep ? ( bx_has o `s` ) ( bx_val o `s` ) `\t`
+        : i width ? ( bx_has o `w` ) ( nurl_str_to_int ( bx_val o `w` ) ) 6
+        : i start ? ( bx_has o `v` ) ( nurl_str_to_int ( bx_val o `v` ) ) 1
+        : i step ? ( bx_has o `i` ) ( nurl_str_to_int ( bx_val o `i` ) ) 1
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : ~ i num start
+        : i ni ( vec_len [String] ins )
+        : ~ i k 0
+        ~ < k ni {
+            ?? ( bx_reader ( bx_at ins k ) ) {
+                F _ → { = rc 1 }
+                T br → {
+                    : String line ( string_new )
+                    : String out ( string_new )
+                    : ~ b more T
+                    ~ more {
+                        ? ( bufreader_read_line_into br line ) {
+                            : b blank == ( string_len line ) 0
+                            : b numbered | ( bx_streq style `a` ) & ( bx_streq style `t` ) ! blank
+                            ? numbered {
+                                : s d ( nurl_str_int num )
+                                : i pad - width ( nurl_str_len d )
+                                ? ( bx_streq fmt `ln` ) {
+                                    ( string_push_str out d )
+                                    : ~ i q pad
+                                    ~ > q 0 { ( string_push_char out 32 ) = q - q 1 }
+                                } {
+                                    : ~ i q pad
+                                    ~ > q 0 { ( string_push_char out ? ( bx_streq fmt `rz` ) 48 32 ) = q - q 1 }
+                                    ( string_push_str out d )
+                                }
+                                ( string_push_str out sep )
+                                = num + num step
+                            } {
+                                : ~ i q width
+                                ~ > q 0 { ( string_push_char out 32 ) = q - q 1 }
+                                ( string_push_str out sep )
+                            }
+                            ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+                            ( string_push_char out 10 )
+                        } { = more F }
+                    }
+                    ( bx_write out )
+                    ( string_free out )
+                    ( string_free line )
+                    ( bufreader_close br )
+                }
+            }
+            = k + k 1
+        }
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── cut ───────────────────────────────────────────────────────────
+
+// A LIST like `1,3-5,7-` as a membership test. Ranges are 1-based and
+// `N-` means "to the end", which is how every cut spells it.
+: CutList {
+    ( Vec i ) lo
+    ( Vec i ) hi
+    b ok
+}
+
+@ __cut_parse s spec → CutList {
+    : ( Vec i ) lo ( vec_new [i] )
+    : ( Vec i ) hi ( vec_new [i] )
+    : ~ b ok T
+    : i n ( nurl_str_len spec )
+    : ~ i i 0
+    ~ < i n {
+        : ~ i a 0
+        : ~ b any_a F
+        ~ & < i n ( bx_is_digit ( nurl_str_get spec i ) ) {
+            = a + * a 10 - ( nurl_str_get spec i ) 48
+            = any_a T
+            = i + i 1
+        }
+        : ~ i b a
+        ? & < i n == ( nurl_str_get spec i ) 45 {
+            = i + i 1
+            : ~ i c 0
+            : ~ b any_c F
+            ~ & < i n ( bx_is_digit ( nurl_str_get spec i ) ) {
+                = c + * c 10 - ( nurl_str_get spec i ) 48
+                = any_c T
+                = i + i 1
+            }
+            = b ? any_c c 1000000000
+            ? ! any_a { = a 1 } {}
+        } {
+            ? ! any_a { = ok F } {}
+        }
+        ( vec_push [i] lo a )
+        ( vec_push [i] hi b )
+        ? & < i n == ( nurl_str_get spec i ) 44 { = i + i 1 } {
+            ? < i n { = ok F = i n } {}
+        }
+    }
+    ? == ( vec_len [i] lo ) 0 { = ok F } {}
+    ^ @ CutList { lo hi ok }
+}
+
+@ __cut_has CutList c i k → b {
+    : i n ( vec_len [i] . c lo )
+    : ~ i i 0
+    ~ < i n {
+        : ~ i a 0
+        : ~ i b 0
+        ?? ( vec_get [i] . c lo i ) { T x → { = a x } F _ → {} }
+        ?? ( vec_get [i] . c hi i ) { T x → { = b x } F _ → {} }
+        ? & >= k a <= k b { ^ T } {}
+        = i + i 1
+    }
+    ^ F
+}
+
+@ __cut_free CutList c → v {
+    ( vec_free [i] . c lo )
+    ( vec_free [i] . c hi )
+}
+
+@ ap_cut ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `b:c:f:d:sn` `bytes=b,characters=c,fields=f,delimiter=d,only-delimited=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i mode 0  // 0 none, 1 bytes/chars, 2 fields
+        : ~ s spec ``
+        ? | ( bx_has o `b` ) ( bx_has o `c` ) {
+            = mode 1
+            = spec ? ( bx_has o `b` ) ( bx_val o `b` ) ( bx_val o `c` )
+        } {}
+        ? ( bx_has o `f` ) {
+            = mode 2
+            = spec ( bx_val o `f` )
+        } {}
+        ? == mode 0 {
+            ( bx_err `you must specify a list of bytes, characters, or fields` )
+            = rc 1
+        } {
+            : CutList list ( __cut_parse spec )
+            ? ! . list ok {
+                ( bx_err_at spec `invalid list` )
+                = rc 1
+            } {
+                : i delim ? ( bx_has o `d` ) ( nurl_str_get ( bx_val o `d` ) 0 ) 9
+                : b only ( bx_has o `s` )
+                : ( Vec String ) ins ( vec_new [String] )
+                ( bx_inputs o ins )
+                : i ni ( vec_len [String] ins )
+                : ~ i k 0
+                ~ < k ni {
+                    ?? ( bx_reader ( bx_at ins k ) ) {
+                        F _ → { = rc 1 }
+                        T br → {
+                            : String line ( string_new )
+                            : String out ( string_new )
+                            : ~ b more T
+                            ~ more {
+                                ? ( bufreader_read_line_into br line ) {
+                                    : i ln ( string_len line )
+                                    ? == mode 1 {
+                                        : ~ i j 0
+                                        ~ < j ln {
+                                            ? ( __cut_has list + j 1 ) {
+                                                ( string_push_char out ( string_get line j ) )
+                                            } {}
+                                            = j + j 1
+                                        }
+                                        ( string_push_char out 10 )
+                                    } {
+                                        : ~ b has_delim F
+                                        : ~ i j 0
+                                        ~ < j ln {
+                                            ? == ( string_get line j ) delim { = has_delim T = j ln } { = j + j 1 }
+                                        }
+                                        ? & only ! has_delim {} {
+                                            ? ! has_delim {
+                                                ( string_push_bytes out # *u ( string_data line ) ln )
+                                                ( string_push_char out 10 )
+                                            } {
+                                                : ~ i field 1
+                                                : ~ i from 0
+                                                : ~ b first T
+                                                : ~ i j 0
+                                                ~ <= j ln {
+                                                    ? | == j ln == ( string_get line j ) delim {
+                                                        ? ( __cut_has list field ) {
+                                                            ? first { = first F } { ( string_push_char out delim ) }
+                                                            : ~ i q from
+                                                            ~ < q j {
+                                                                ( string_push_char out ( string_get line q ) )
+                                                                = q + q 1
+                                                            }
+                                                        } {}
+                                                        = field + field 1
+                                                        = from + j 1
+                                                    } {}
+                                                    = j + j 1
+                                                }
+                                                ( string_push_char out 10 )
+                                            }
+                                        }
+                                    }
+                                    ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                                } { = more F }
+                            }
+                            ( bx_write out )
+                            ( string_free out )
+                            ( string_free line )
+                            ( bufreader_close br )
+                        }
+                    }
+                    = k + k 1
+                }
+                ( bx_free_lines ins )
+            }
+            ( __cut_free list )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── tr ────────────────────────────────────────────────────────────
+
+// Expand `a-z`, `[:alpha:]`, `\n` and friends into a byte list.
+@ __tr_expand s spec ( Vec u ) out → v {
+    : i n ( nurl_str_len spec )
+    : ~ i i 0
+    ~ < i n {
+        : ~ i c ( nurl_str_get spec i )
+        ? & & == c 91 < + i 1 n == ( nurl_str_get spec + i 1 ) 58 {
+            : ~ i e + i 2
+            ~ & < e n != ( nurl_str_get spec e ) 58 { = e + e 1 }
+            : s name ( nurl_str_slice spec + i 2 - e + i 2 )
+            : ~ i b 0
+            ~ < b 256 {
+                : ~ b hit F
+                ? ( bx_streq name `alpha` ) { = hit | & >= b 65 <= b 90 & >= b 97 <= b 122 } {}
+                ? ( bx_streq name `digit` ) { = hit & >= b 48 <= b 57 } {}
+                ? ( bx_streq name `alnum` ) { = hit | | & >= b 65 <= b 90 & >= b 97 <= b 122 & >= b 48 <= b 57 } {}
+                ? ( bx_streq name `upper` ) { = hit & >= b 65 <= b 90 } {}
+                ? ( bx_streq name `lower` ) { = hit & >= b 97 <= b 122 } {}
+                ? ( bx_streq name `space` ) { = hit | == b 32 & >= b 9 <= b 13 } {}
+                ? ( bx_streq name `blank` ) { = hit | == b 32 == b 9 } {}
+                ? ( bx_streq name `punct` ) {
+                    = hit & > b 32 & < b 127 ! | | & >= b 65 <= b 90 & >= b 97 <= b 122 & >= b 48 <= b 57
+                } {}
+                ? ( bx_streq name `print` ) { = hit & >= b 32 < b 127 } {}
+                ? ( bx_streq name `graph` ) { = hit & > b 32 < b 127 } {}
+                ? ( bx_streq name `cntrl` ) { = hit | < b 32 == b 127 } {}
+                ? ( bx_streq name `xdigit` ) { = hit ( bx_is_hex b ) } {}
+                ? hit { ( vec_push [u] out # u b ) } {}
+                = b + b 1
+            }
+            = i ? < e n + e 2 n
+        } {
+            ? & == c 92 < + i 1 n {
+                : i e ( nurl_str_get spec + i 1 )
+                = i + i 2
+                ? == e 110 { = c 10 } {
+                    ? == e 116 { = c 9 } {
+                        ? == e 114 { = c 13 } {
+                            ? == e 92 { = c 92 } {
+                                ? & >= e 48 <= e 55 {
+                                    : ~ i val - e 48
+                                    : ~ i got 1
+                                    ~ & < got 3 & < i n & >= ( nurl_str_get spec i ) 48 <= ( nurl_str_get spec i ) 55 {
+                                        = val + * val 8 - ( nurl_str_get spec i ) 48
+                                        = i + i 1
+                                        = got + got 1
+                                    }
+                                    = c & val 255
+                                } { = c e } } } } }
+            } { = i + i 1 }
+            // A range `a-z`, but only when a real `-` sits between two
+            // characters — a trailing `-` is a literal dash.
+            ? & & < + i 1 ( nurl_str_len spec ) == ( nurl_str_get spec i ) 45 < + i 1 n {
+                : i hi ( nurl_str_get spec + i 1 )
+                : ~ i b c
+                ~ <= b hi {
+                    ( vec_push [u] out # u b )
+                    = b + b 1
+                }
+                = i + i 2
+            } {
+                ( vec_push [u] out # u c )
+            }
+        }
+    }
+}
+
+@ ap_tr ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `dsc` `delete=d,squeeze-repeats=s,complement=c` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : b del ( bx_has o `d` )
+        : b squeeze ( bx_has o `s` )
+        : b comp ( bx_has o `c` )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {
+            : ( Vec u ) set1 ( vec_new [u] )
+            : ( Vec u ) set2 ( vec_new [u] )
+            ( __tr_expand ( bx_operand o 0 ) set1 )
+            ? > nops 1 { ( __tr_expand ( bx_operand o 1 ) set2 ) } {}
+            // A 256-entry table beats a search per byte, and makes -c a
+            // single inversion pass instead of a special case everywhere.
+            : s inset ( nurl_zalloc 256 )
+            : ~ i j 0
+            ~ < j ( vec_len [u] set1 ) {
+                ?? ( vec_get [u] set1 j ) {
+                    T b → { = . # *u inset # i b # u 1 }
+                    F _ → {}
+                }
+                = j + j 1
+            }
+            ? comp {
+                : ~ i b 0
+                ~ < b 256 {
+                    = . # *u inset b # u ? == 0 # i . # *u inset b 1 0
+                    = b + b 1
+                }
+            } {}
+            // Translation target per byte: the matching member of SET2,
+            // with the last one repeated once SET2 runs out.
+            : s xlat ( nurl_zalloc 256 )
+            : ~ i b2 0
+            ~ < b2 256 { = . # *u xlat b2 # u b2 = b2 + b2 1 }
+            ? & ! del > ( vec_len [u] set2 ) 0 {
+                : i n2 ( vec_len [u] set2 )
+                : ~ i idx 0
+                : ~ i b 0
+                ~ < b 256 {
+                    ? != 0 # i . # *u inset b {
+                        : i pick ? < idx n2 idx - n2 1
+                        ?? ( vec_get [u] set2 pick ) {
+                            T t → { = . # *u xlat b t }
+                            F _ → {}
+                        }
+                        = idx + idx 1
+                    } {}
+                    = b + b 1
+                }
+            } {}
+            : String out ( string_new )
+            : ~ i last -1
+            : ~ b more T
+            ~ more {
+                : ( Vec u ) chunk ( read_n_bytes 65536 )
+                : i cn ( vec_len [u] chunk )
+                ? == cn 0 { = more F } {
+                    : *u p ( vec_data [u] chunk )
+                    : ~ i q 0
+                    ~ < q cn {
+                        : i c & 255 # i . p q
+                        : b inset_hit != 0 # i . # *u inset c
+                        ? & del inset_hit {} {
+                            : i outc ? del c & 255 # i . # *u xlat c
+                            : ~ b emit T
+                            ? squeeze {
+                                // -s collapses a run only when the byte
+                                // was in the set that produced it.
+                                : b member ? del != 0 # i . # *u inset outc inset_hit
+                                ? & member == outc last { = emit F } {}
+                            } {}
+                            ? emit { ( string_push_char out outc ) } {}
+                            = last outc
+                        }
+                        = q + q 1
+                    }
+                    ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                }
+                ( vec_free [u] chunk )
+            }
+            ( bx_write out )
+            ( string_free out )
+            ( nurl_free inset )
+            ( nurl_free xlat )
+            ( vec_free [u] set1 )
+            ( vec_free [u] set2 )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── sort ──────────────────────────────────────────────────────────
+
+: ~ i g_sort_flags 0
+: ~ i g_sort_key 0
+: ~ i g_sort_key_end 0
+: ~ i g_sort_delim -1
+
+: i SORT_REVERSE 1
+: i SORT_NUMERIC 2
+: i SORT_FOLD 4
+: i SORT_BLANKS 8
+
+// The comparison field of `line`, as [from, to).
+@ __sort_field String line inout i from inout i to → v {
+    = from 0
+    = to ( string_len line )
+    ? == g_sort_key 0 {
+        ? != 0 & g_sort_flags SORT_BLANKS {
+            ~ & < from to ( bx_is_blank ( string_get line from ) ) { = from + from 1 }
+        } {}
+        ^
+    } {}
+    : i n ( string_len line )
+    : ~ i field 1
+    : ~ i start 0
+    : ~ i i 0
+    : ~ i want_start -1
+    : ~ i want_end -1
+    ~ <= i n {
+        : b at_sep ? == i n T ? >= g_sort_delim 0 == ( string_get line i ) g_sort_delim
+        & ( bx_is_blank ( string_get line i ) ) ! ( bx_is_blank ( string_get line - i 1 ) )
+        ? at_sep {
+            ? == field g_sort_key { = want_start start } {}
+            ? == field g_sort_key_end { = want_end i } {}
+            = field + field 1
+            = start ? >= g_sort_delim 0 + i 1 i
+        } {}
+        = i + i 1
+    }
+    ? >= want_start 0 {
+        = from want_start
+        = to ? >= want_end 0 want_end n
+    } {}
+    ? != 0 & g_sort_flags SORT_BLANKS {
+        ~ & < from to ( bx_is_blank ( string_get line from ) ) { = from + from 1 }
+    } {}
+}
+
+@ bx_is_blank i c → b { ^ | == c 32 == c 9 }
+
+@ __sort_numeric String line i from i to → f {
+    : ~ i i from
+    ~ & < i to ( bx_is_blank ( string_get line i ) ) { = i + i 1 }
+    : String piece ( string_new )
+    ~ < i to {
+        : i c ( string_get line i )
+        ? | | ( bx_is_digit c ) | == c 45 == c 43 | == c 46 == c 101 {
+            ( string_push_char piece c )
+            = i + i 1
+        } { = i to }
+    }
+    : f v ( nurl_str_to_float ( string_data piece ) )
+    ( string_free piece )
+    ^ v
+}
+
+@ __sort_cmp String a String b → i {
+    : ~ i af 0
+    : ~ i at 0
+    : ~ i bf 0
+    : ~ i bt 0
+    ( __sort_field a af at )
+    ( __sort_field b bf bt )
+    : ~ i r 0
+    ? != 0 & g_sort_flags SORT_NUMERIC {
+        : f x ( __sort_numeric a af at )
+        : f y ( __sort_numeric b bf bt )
+        = r ( cmp_float x y )
+    } {
+        : ~ i i af
+        : ~ i j bf
+        : ~ b going T
+        ~ going {
+            ? | >= i at >= j bt {
+                = going F
+                = r ( cmp_int - at i - bt j )
+            } {
+                : ~ i ca ( string_get a i )
+                : ~ i cb ( string_get b j )
+                ? != 0 & g_sort_flags SORT_FOLD {
+                    ? & >= ca 97 <= ca 122 { = ca - ca 32 } {}
+                    ? & >= cb 97 <= cb 122 { = cb - cb 32 } {}
+                } {}
+                ? != ca cb {
+                    = r ( cmp_int ca cb )
+                    = going F
+                } {
+                    = i + i 1
+                    = j + j 1
+                }
+            }
+        }
+    }
+    // A tie on the key falls back to the whole line, which is what makes
+    // `sort -k2` deterministic instead of merely grouped.
+    ? & == r 0 != g_sort_key 0 { = r ( cmp_string a b ) } {}
+    ^ ? != 0 & g_sort_flags SORT_REVERSE - 0 r r
+}
+
+@ ap_sort ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `rnufbck:t:sz` `reverse=r,numeric-sort=n,unique=u,ignore-case=f,ignore-leading-blanks=b,check=c,key=k,field-separator=t,stable=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        = g_sort_flags 0
+        ? ( bx_has o `r` ) { = g_sort_flags | g_sort_flags SORT_REVERSE } {}
+        ? ( bx_has o `n` ) { = g_sort_flags | g_sort_flags SORT_NUMERIC } {}
+        ? ( bx_has o `f` ) { = g_sort_flags | g_sort_flags SORT_FOLD } {}
+        ? ( bx_has o `b` ) { = g_sort_flags | g_sort_flags SORT_BLANKS } {}
+        = g_sort_key 0
+        = g_sort_key_end 0
+        = g_sort_delim ? ( bx_has o `t` ) ( nurl_str_get ( bx_val o `t` ) 0 ) -1
+        ? ( bx_has o `k` ) {
+            : s spec ( bx_val o `k` )
+            : i comma ( nurl_str_find spec `,` )
+            = g_sort_key ( nurl_str_to_int ? > comma -1 ( nurl_str_slice spec 0 comma ) spec )
+            = g_sort_key_end ? > comma -1 ( nurl_str_to_int ( nurl_str_slice spec + comma 1 - ( nurl_str_len spec ) + comma 1 ) ) 0
+        } {}
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : ( Vec String ) lines ( vec_new [String] )
+        : i ni ( vec_len [String] ins )
+        : ~ i k 0
+        ~ < k ni {
+            ? ( bx_read_lines ( bx_at ins k ) lines ) {} { = rc 1 }
+            = k + k 1
+        }
+        ( bx_free_lines ins )
+        ? ( bx_has o `c` ) {
+            : i n ( vec_len [String] lines )
+            : ~ i j 1
+            ~ < j n {
+                : ~ i bad -1
+                ?? ( vec_get [String] lines - j 1 ) {
+                    T a → {
+                        ?? ( vec_get [String] lines j ) {
+                            T b → { ? > ( __sort_cmp a b ) 0 { = bad j } {} }
+                            F _ → {}
+                        }
+                    }
+                    F _ → {}
+                }
+                ? >= bad 0 {
+                    ( bx_err `disorder` )
+                    = rc 1
+                    = j n
+                } { = j + j 1 }
+            }
+        } {
+            ( sort_by [String] lines \ String a String b → i { ^ ( __sort_cmp a b ) } )
+            : String out ( string_new )
+            : i n ( vec_len [String] lines )
+            : ~ i j 0
+            : ~ i prev -1
+            ~ < j n {
+                ?? ( vec_get [String] lines j ) {
+                    T l → {
+                        : ~ b emit T
+                        ? & ( bx_has o `u` ) > j 0 {
+                            ?? ( vec_get [String] lines - j 1 ) {
+                                T p → { ? == ( __sort_cmp p l ) 0 { = emit F } {} }
+                                F _ → {}
+                            }
+                        } {}
+                        ? emit {
+                            ( string_push_bytes out # *u ( string_data l ) ( string_len l ) )
+                            ( string_push_char out ? ( bx_has o `z` ) 0 10 )
+                        } {}
+                    }
+                    F _ → {}
+                }
+                ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                = j + j 1
+            }
+            ( bx_write out )
+            ( string_free out )
+        }
+        ( bx_free_lines lines )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── uniq ──────────────────────────────────────────────────────────
+
+@ __uniq_key String line i skip_fields i skip_chars b fold String out → v {
+    ( string_clear out )
+    : i n ( string_len line )
+    : ~ i i 0
+    : ~ i f 0
+    ~ < f skip_fields {
+        ~ & < i n ( bx_is_blank ( string_get line i ) ) { = i + i 1 }
+        ~ & < i n ! ( bx_is_blank ( string_get line i ) ) { = i + i 1 }
+        = f + f 1
+    }
+    : ~ i c 0
+    ~ & < c skip_chars < i n { = i + i 1 = c + c 1 }
+    ~ < i n {
+        : ~ i ch ( string_get line i )
+        ? & fold & >= ch 65 <= ch 90 { = ch + ch 32 } {}
+        ( string_push_char out ch )
+        = i + i 1
+    }
+}
+
+@ ap_uniq ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `cduif:s:w:` `count=c,repeated=d,unique=u,ignore-case=i,skip-fields=f,skip-chars=s,check-chars=w` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i skip_fields ? ( bx_has o `f` ) ( nurl_str_to_int ( bx_val o `f` ) ) 0
+        : i skip_chars ? ( bx_has o `s` ) ( nurl_str_to_int ( bx_val o `s` ) ) 0
+        : i check ? ( bx_has o `w` ) ( nurl_str_to_int ( bx_val o `w` ) ) -1
+        : b fold ( bx_has o `i` )
+        : b want_dup ( bx_has o `d` )
+        : b want_uniq ( bx_has o `u` )
+        : b count ( bx_has o `c` )
+        : s input ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        ?? ( bx_reader input ) {
+            F _ → { = rc 1 }
+            T br → {
+                : String line ( string_new )
+                : String key ( string_new )
+                : String prev ( string_new )
+                : String prevkey ( string_new )
+                : String out ( string_new )
+                : ~ i run 0
+                : ~ b have F
+                : ~ b more T
+                ~ more {
+                    ? ( bufreader_read_line_into br line ) {
+                        ( __uniq_key line skip_fields skip_chars fold key )
+                        ? & >= check 0 > ( string_len key ) check {
+                            : String cut ( string_substr key 0 check )
+                            ( string_clear key )
+                            ( string_push_bytes key # *u ( string_data cut ) ( string_len cut ) )
+                            ( string_free cut )
+                        } {}
+                        : b same & have ( string_eq key prevkey )
+                        ? same { = run + run 1 } {
+                            ? have { ( __uniq_emit out prev run count want_dup want_uniq ) } {}
+                            ( string_clear prev )
+                            ( string_push_bytes prev # *u ( string_data line ) ( string_len line ) )
+                            ( string_clear prevkey )
+                            ( string_push_bytes prevkey # *u ( string_data key ) ( string_len key ) )
+                            = run 1
+                            = have T
+                        }
+                    } { = more F }
+                }
+                ? have { ( __uniq_emit out prev run count want_dup want_uniq ) } {}
+                ( bx_write out )
+                ( string_free out )
+                ( string_free line )
+                ( string_free key )
+                ( string_free prev )
+                ( string_free prevkey )
+                ( bufreader_close br )
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ __uniq_emit String out String line i run b count b want_dup b want_uniq → v {
+    ? & want_dup < run 2 { ^ } {}
+    ? & want_uniq > run 1 { ^ } {}
+    ? count {
+        : s d ( nurl_str_int run )
+        : ~ i pad - 7 ( nurl_str_len d )
+        ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+        ( string_push_str out d )
+        ( string_push_char out 32 )
+    } {}
+    ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+    ( string_push_char out 10 )
+}
+
+// ── tee ───────────────────────────────────────────────────────────
+
+@ ap_tee ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ai` `append=a,ignore-interrupts=i` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : ( Vec File ) outs ( vec_new [File] )
+        : ~ i i 0
+        ~ < i nops {
+            : s p ( bx_operand o i )
+            : !File IoErr r ? ( bx_has o `a` ) ( file_append p ) ( file_create p )
+            ?? r {
+                T f → { ( vec_push [File] outs f ) }
+                F e → {
+                    ( bx_err_at p ( bx_ioerr e ) )
+                    = rc 1
+                }
+            }
+            = i + i 1
+        }
+        : ~ b more T
+        ~ more {
+            : ( Vec u ) chunk ( read_n_bytes 65536 )
+            ? == ( vec_len [u] chunk ) 0 { = more F } {
+                ( bx_write_bytes chunk )
+                : i no ( vec_len [File] outs )
+                : ~ i k 0
+                ~ < k no {
+                    ?? ( vec_get [File] outs k ) {
+                        T f → {
+                            ?? ( file_write_chunk f chunk ) { T _ → {} F _ → { = rc 1 } }
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            }
+            ( vec_free [u] chunk )
+        }
+        : i no ( vec_len [File] outs )
+        : ~ i k 0
+        ~ < k no {
+            ?? ( vec_get [File] outs k ) {
+                T f → { ( file_close f ) }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        ( vec_free [File] outs )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/find.nu
+++ b/packages/nurlbox/src/find.nu
@@ -1,0 +1,798 @@
+// nurlbox/find.nu — walking a tree: stat, du, find.
+//
+// All three walk with `fs_lstat`, never `fs_stat`: a walk that follows
+// symlinks visits whatever they point at, which turns `du` into a
+// double-count and `find -delete` into a way to lose files outside the
+// tree you named.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/std/time.nu`
+$ `bx.nu`
+
+// ── stat ──────────────────────────────────────────────────────────
+
+@ __stat_kind_word i mode → s {
+    : i k ( nurl_stat_kind mode )
+    ? == k FS_KIND_DIR { ^ `directory` } {}
+    ? == k FS_KIND_SYMLINK { ^ `symbolic link` } {}
+    ? == k FS_KIND_CHARDEV { ^ `character special file` } {}
+    ? == k FS_KIND_BLOCKDEV { ^ `block special file` } {}
+    ? == k FS_KIND_FIFO { ^ `fifo` } {}
+    ? == k FS_KIND_SOCKET { ^ `socket` } {}
+    ? == k FS_KIND_FILE { ^ `regular file` } {}
+    ^ `unknown`
+}
+
+@ __stat_octal String out i v i digits → v {
+    : ~ i k digits
+    ~ > k 0 {
+        : i shift * - k 1 3
+        ( string_push_char out + 48 & 7 >> v shift )
+        = k - k 1
+    }
+}
+
+@ __stat_hex String out i v → v {
+    ? == v 0 { ( string_push_char out 48 ) ^ } {}
+    : String tmp ( string_with_cap 16 )
+    : ~ i x v
+    ~ != x 0 {
+        ( string_push_char tmp ( nurl_str_get `0123456789abcdef` & x 15 ) )
+        = x >> x 4
+    }
+    : ~ i k ( string_len tmp )
+    ~ > k 0 {
+        ( string_push_char out ( string_get tmp - k 1 ) )
+        = k - k 1
+    }
+    ( string_free tmp )
+}
+
+@ __stat_name_of i id b group → String {
+    : ?String r ? group ( fs_group_name id ) ( fs_user_name id )
+    ?? r {
+        T n → { ^ n }
+        F _ → { ^ ( string_from `UNKNOWN` ) }
+    }
+}
+
+// The `%`-directives `stat -c` understands.
+@ __stat_directive String out FileStat st s path i d → b {
+    ? == d 110 { ( string_push_str out path ) ^ T } {}
+    ? == d 115 { ( string_push_int out . st size ) ^ T } {}
+    ? == d 98 { ( string_push_int out . st blocks ) ^ T } {}
+    ? == d 66 { ( string_push_int out 512 ) ^ T } {}
+    ? == d 111 { ( string_push_int out . st blksize ) ^ T } {}
+    ? == d 102 { ( __stat_hex out . st mode ) ^ T } {}
+    // Three octal digits normally, four when setuid/setgid/sticky is
+    // set — printing a leading 0 that is always 0 helps nobody.
+    ? == d 97 { ( __stat_octal out ( stat_mode_bits st ) ? != 0 & . st mode 3584 4 3 ) ^ T } {}
+    ? == d 65 {
+        : String m ( stat_mode_string st )
+        ( string_push_bytes out # *u ( string_data m ) ( string_len m ) )
+        ( string_free m )
+        ^ T
+    } {}
+    ? == d 117 { ( string_push_int out . st uid ) ^ T } {}
+    ? == d 103 { ( string_push_int out . st gid ) ^ T } {}
+    ? == d 85 {
+        : String n ( __stat_name_of . st uid F )
+        ( string_push_bytes out # *u ( string_data n ) ( string_len n ) )
+        ( string_free n )
+        ^ T
+    } {}
+    ? == d 71 {
+        : String n ( __stat_name_of . st gid T )
+        ( string_push_bytes out # *u ( string_data n ) ( string_len n ) )
+        ( string_free n )
+        ^ T
+    } {}
+    ? == d 104 { ( string_push_int out . st nlink ) ^ T } {}
+    ? == d 105 { ( string_push_int out . st ino ) ^ T } {}
+    ? == d 100 { ( string_push_int out . st dev ) ^ T } {}
+    ? == d 70 { ( string_push_str out ( __stat_kind_word . st mode ) ) ^ T } {}
+    ? == d 88 { ( string_push_int out . st atime ) ^ T } {}
+    ? == d 89 { ( string_push_int out . st mtime ) ^ T } {}
+    ? == d 90 { ( string_push_int out . st ctime ) ^ T } {}
+    ^ F
+}
+
+@ __stat_timestamp String out i secs i nsec → v {
+    : Time t ( time_local secs )
+    : String base ( time_format t `%Y-%m-%d %H:%M:%S` )
+    ( string_push_bytes out # *u ( string_data base ) ( string_len base ) )
+    ( string_free base )
+    ( string_push_char out 46 )
+    : ~ i k 100000000
+    ~ > k 0 {
+        ( string_push_char out + 48 % / nsec k 10 )
+        = k / k 10
+    }
+    ( string_push_char out 32 )
+    : i off ( tz_offset secs )
+    ( string_push_char out ? < off 0 45 43 )
+    : i mins / ? < off 0 - 0 off off 60
+    : i hh / mins 60
+    : i mm - mins * hh 60
+    ? < hh 10 { ( string_push_char out 48 ) } {}
+    ( string_push_int out hh )
+    ? < mm 10 { ( string_push_char out 48 ) } {}
+    ( string_push_int out mm )
+}
+
+@ __stat_default String out FileStat st s path → v {
+    ( string_push_str out `  File: ` )
+    ( string_push_str out path )
+    ? ( stat_is_symlink st ) {
+        ?? ( fs_readlink path ) {
+            T t → {
+                ( string_push_str out ` -> ` )
+                ( string_push_bytes out # *u ( string_data t ) ( string_len t ) )
+                ( string_free t )
+            }
+            F _ → {}
+        }
+    } {}
+    ( string_push_str out `\n  Size: ` )
+    : String sz ( string_from ( nurl_str_int . st size ) )
+    ( string_push_bytes out # *u ( string_data sz ) ( string_len sz ) )
+    : ~ i pad - 10 ( string_len sz )
+    ( string_free sz )
+    ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+    ( string_push_str out `\tBlocks: ` )
+    : String bl ( string_from ( nurl_str_int . st blocks ) )
+    ( string_push_bytes out # *u ( string_data bl ) ( string_len bl ) )
+    : ~ i pad2 - 11 ( string_len bl )
+    ( string_free bl )
+    ~ > pad2 0 { ( string_push_char out 32 ) = pad2 - pad2 1 }
+    ( string_push_str out `IO Block: ` )
+    : String io ( string_from ( nurl_str_int . st blksize ) )
+    ( string_push_bytes out # *u ( string_data io ) ( string_len io ) )
+    : ~ i pad3 - 7 ( string_len io )
+    ( string_free io )
+    ~ > pad3 0 { ( string_push_char out 32 ) = pad3 - pad3 1 }
+    ( string_push_str out ( __stat_kind_word . st mode ) )
+    ( string_push_str out `\nDevice: ` )
+    ( __stat_hex out . st dev )
+    ( string_push_str out `h/` )
+    ( string_push_int out . st dev )
+    ( string_push_str out `d\tInode: ` )
+    : String ino ( string_from ( nurl_str_int . st ino ) )
+    ( string_push_bytes out # *u ( string_data ino ) ( string_len ino ) )
+    : ~ i pad4 - 12 ( string_len ino )
+    ( string_free ino )
+    ~ > pad4 0 { ( string_push_char out 32 ) = pad4 - pad4 1 }
+    ( string_push_str out `Links: ` )
+    ( string_push_int out . st nlink )
+    ( string_push_str out `\nAccess: (` )
+    ( __stat_octal out ( stat_mode_bits st ) 4 )
+    ( string_push_char out 47 )
+    : String ms ( stat_mode_string st )
+    ( string_push_bytes out # *u ( string_data ms ) ( string_len ms ) )
+    ( string_free ms )
+    ( string_push_str out `)  Uid: (` )
+    : String uid ( string_from ( nurl_str_int . st uid ) )
+    : ~ i up - 5 ( string_len uid )
+    ~ > up 0 { ( string_push_char out 32 ) = up - up 1 }
+    ( string_push_bytes out # *u ( string_data uid ) ( string_len uid ) )
+    ( string_free uid )
+    ( string_push_char out 47 )
+    : String un ( __stat_name_of . st uid F )
+    : ~ i unp - 8 ( string_len un )
+    ~ > unp 0 { ( string_push_char out 32 ) = unp - unp 1 }
+    ( string_push_bytes out # *u ( string_data un ) ( string_len un ) )
+    ( string_free un )
+    ( string_push_str out `)   Gid: (` )
+    : String gid ( string_from ( nurl_str_int . st gid ) )
+    : ~ i gp - 5 ( string_len gid )
+    ~ > gp 0 { ( string_push_char out 32 ) = gp - gp 1 }
+    ( string_push_bytes out # *u ( string_data gid ) ( string_len gid ) )
+    ( string_free gid )
+    ( string_push_char out 47 )
+    : String gn ( __stat_name_of . st gid T )
+    : ~ i gnp - 8 ( string_len gn )
+    ~ > gnp 0 { ( string_push_char out 32 ) = gnp - gnp 1 }
+    ( string_push_bytes out # *u ( string_data gn ) ( string_len gn ) )
+    ( string_free gn )
+    ( string_push_str out `)\nAccess: ` )
+    ( __stat_timestamp out . st atime . st atime_ns )
+    ( string_push_str out `\nModify: ` )
+    ( __stat_timestamp out . st mtime . st mtime_ns )
+    ( string_push_str out `\nChange: ` )
+    ( __stat_timestamp out . st ctime . st ctime_ns )
+    ( string_push_char out 10 )
+}
+
+@ ap_stat ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `c:Lt` `format=c,dereference=L,terse=t` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {}
+        : ~ i i 0
+        ~ < i nops {
+            : s p ( bx_operand o i )
+            : !FileStat IoErr r ? ( bx_has o `L` ) ( fs_stat p ) ( fs_lstat p )
+            ?? r {
+                F e → {
+                    ( bx_err_at p ( bx_ioerr e ) )
+                    = rc 1
+                }
+                T st → {
+                    : String out ( string_new )
+                    ? ( bx_has o `c` ) {
+                        : s fmt ( bx_val o `c` )
+                        : i fl ( nurl_str_len fmt )
+                        : ~ i k 0
+                        ~ < k fl {
+                            : i c ( nurl_str_get fmt k )
+                            ? & == c 37 < + k 1 fl {
+                                ? ( __stat_directive out st p ( nurl_str_get fmt + k 1 ) ) {} {
+                                    ( string_push_char out 37 )
+                                    ( string_push_char out ( nurl_str_get fmt + k 1 ) )
+                                }
+                                = k + k 2
+                            } {
+                                ? & == c 92 < + k 1 fl {
+                                    : i e2 ( nurl_str_get fmt + k 1 )
+                                    ? == e2 110 { ( string_push_char out 10 ) } {
+                                        ? == e2 116 { ( string_push_char out 9 ) } {
+                                            ( string_push_char out 92 )
+                                            ( string_push_char out e2 )
+                                        } }
+                                    = k + k 2
+                                } {
+                                    ( string_push_char out c )
+                                    = k + k 1
+                                }
+                            }
+                        }
+                        ( string_push_char out 10 )
+                    } {
+                        ( __stat_default out st p )
+                    }
+                    ( bx_write out )
+                    ( string_free out )
+                }
+            }
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── du ────────────────────────────────────────────────────────────
+
+: i DU_ALL 1
+: i DU_SUMMARY 2
+: i DU_HUMAN 4
+: i DU_BYTES 8
+: i DU_MEGA 16
+: i DU_TOTAL 32
+
+@ __du_emit s path i bytes_512 i flags → v {
+    : String out ( string_new )
+    ? != 0 & flags DU_HUMAN {
+        : String h ( bx_human * bytes_512 512 )
+        ( string_push_bytes out # *u ( string_data h ) ( string_len h ) )
+        ( string_free h )
+    } {
+        ? != 0 & flags DU_BYTES {
+            ( string_push_int out * bytes_512 512 )
+        } {
+            ? != 0 & flags DU_MEGA {
+                ( string_push_int out / + bytes_512 2047 2048 )
+            } {
+                ( string_push_int out / bytes_512 2 )
+            }
+        }
+    }
+    ( string_push_char out 9 )
+    ( string_push_str out path )
+    ( string_push_char out 10 )
+    ( bx_write out )
+    ( string_free out )
+}
+
+// Returns the subtree's size in 512-byte blocks; prints as it goes.
+@ __du_walk s path i flags i depth i maxdepth inout i rc → i {
+    ?? ( fs_lstat path ) {
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            = rc 1
+            ^ 0
+        }
+        T st → {
+            ? ! ( stat_is_dir st ) {
+                : i blocks . st blocks
+                ? & != 0 & flags DU_ALL <= depth maxdepth {
+                    ( __du_emit path blocks flags )
+                } {}
+                ^ blocks
+            } {}
+            : ~ i total . st blocks
+            ?? ( dir_list path ) {
+                T names → {
+                    : i n ( vec_len [String] names )
+                    : ~ i k 0
+                    ~ < k n {
+                        : String sub ( path_join path ( bx_at names k ) )
+                        = total + total ( __du_walk ( string_data sub ) flags + depth 1 maxdepth rc )
+                        ( string_free sub )
+                        = k + k 1
+                    }
+                    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                }
+                F e2 → {
+                    ( bx_err_at path ( bx_ioerr e2 ) )
+                    = rc 1
+                }
+            }
+            ? <= depth maxdepth { ( __du_emit path total flags ) } {}
+            ^ total
+        }
+    }
+}
+
+@ ap_du ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ashkmcbd:xL` `all=a,summarize=s,human-readable=h,total=c,bytes=b,max-depth=d` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i flags 0
+        ? ( bx_has o `a` ) { = flags | flags DU_ALL } {}
+        ? ( bx_has o `s` ) { = flags | flags DU_SUMMARY } {}
+        ? ( bx_has o `h` ) { = flags | flags DU_HUMAN } {}
+        ? ( bx_has o `b` ) { = flags | flags DU_BYTES } {}
+        ? ( bx_has o `m` ) { = flags | flags DU_MEGA } {}
+        ? ( bx_has o `c` ) { = flags | flags DU_TOTAL } {}
+        : ~ i maxdepth 1000000
+        ? != 0 & flags DU_SUMMARY { = maxdepth 0 } {}
+        ? ( bx_has o `d` ) { = maxdepth ( nurl_str_to_int ( bx_val o `d` ) ) } {}
+        : i nops ( bx_operand_count o )
+        : ~ i grand 0
+        ? == nops 0 {
+            = grand ( __du_walk `.` flags 0 maxdepth rc )
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                = grand + grand ( __du_walk ( bx_operand o i ) flags 0 maxdepth rc )
+                = i + i 1
+            }
+        }
+        ? != 0 & flags DU_TOTAL { ( __du_emit `total` grand flags ) } {}
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── find ──────────────────────────────────────────────────────────
+//
+// A real expression evaluator, not a flag list: `-a` / `-o` / `!` /
+// parentheses with POSIX precedence and POSIX short-circuiting, so
+// `find . -name '*.tmp' -a -delete` deletes only what matched and
+// `find . -type d -o -print` prints only what is not a directory.
+//
+// The expression is re-walked per visited entry rather than compiled
+// into a tree first. That costs a few token comparisons against a stat
+// call and a directory read, and it keeps the evaluator one function
+// deep — the shape that makes short-circuiting obviously correct.
+
+$ `stdlib/core/posix.nu`
+
+: FindCtx {
+    s path
+    s name
+    i mode
+    i size
+    i mtime
+    i depth
+    b live  // F while inside a short-circuited branch: no actions run
+}
+
+// The parser cursor. find parses one expression at a time in one
+// thread, so a cursor global is simpler than threading `inout i pos`
+// through four mutually-recursive functions.
+: ~ i g_find_pos 0
+: ~ i g_find_maxdepth 1000000
+: ~ i g_find_mindepth 0
+: ~ b g_find_has_action F
+: ~ b g_find_depth_first F
+: ~ b g_find_prune F
+: ~ i g_find_rc 0
+
+@ __find_tok ( Vec String ) toks i idx → s { ^ ( bx_at toks idx ) }
+
+@ __find_at_end ( Vec String ) toks → b { ^ >= g_find_pos ( vec_len [String] toks ) }
+
+// A size operand: `[+-]N[cwbkMG]`. Returns the comparison in `cmp`
+// (-1 less, 0 exact, 1 greater) and the value in units of `unit`.
+@ __find_num s text → i {
+    : i n ( nurl_str_len text )
+    : ~ i i 0
+    ? & > n 0 | == ( nurl_str_get text 0 ) 43 == ( nurl_str_get text 0 ) 45 { = i 1 } {}
+    : ~ i v 0
+    ~ & < i n ( bx_is_digit ( nurl_str_get text i ) ) {
+        = v + * v 10 - ( nurl_str_get text i ) 48
+        = i + i 1
+    }
+    ^ v
+}
+
+@ __find_cmpdir s text → i {
+    ? == ( nurl_str_len text ) 0 { ^ 0 } {}
+    ? == ( nurl_str_get text 0 ) 43 { ^ 1 } {}
+    ? == ( nurl_str_get text 0 ) 45 { ^ -1 } {}
+    ^ 0
+}
+
+@ __find_compare i have i want i dir → b {
+    ? > dir 0 { ^ > have want } {}
+    ? < dir 0 { ^ < have want } {}
+    ^ == have want
+}
+
+@ __find_type_char i mode i c → b {
+    : i k ( nurl_stat_kind mode )
+    ? == c 102 { ^ == k FS_KIND_FILE } {}
+    ? == c 100 { ^ == k FS_KIND_DIR } {}
+    ? == c 108 { ^ == k FS_KIND_SYMLINK } {}
+    ? == c 98 { ^ == k FS_KIND_BLOCKDEV } {}
+    ? == c 99 { ^ == k FS_KIND_CHARDEV } {}
+    ? == c 112 { ^ == k FS_KIND_FIFO } {}
+    ? == c 115 { ^ == k FS_KIND_SOCKET } {}
+    ^ F
+}
+
+// -exec CMD ... {} \;  — a real fork + exec, so the child writes to the
+// terminal itself instead of having its output captured and replayed
+// out of order.
+@ __find_exec ( Vec String ) toks i from i to s path → b {
+    : i n - to from
+    ? <= n 0 { ^ F } {}
+    ( flush )
+    : i32 pid ( fork )
+    ? == # i pid 0 {
+        : s argvbuf ( nurl_zalloc * 8 + n 1 )
+        : ~ i k 0
+        ~ < k n {
+            : s t ( __find_tok toks + from k )
+            ( nurl_poke argvbuf k # i ? ( bx_streq t `{}` ) path t )
+            = k + k 1
+        }
+        : i32 _r ( execvp # s ( nurl_peek argvbuf 0 ) # *u argvbuf )
+        ( _exit # i32 127 )
+        ^ F
+    } {}
+    ? < # i pid 0 { ^ F } {}
+    : s statusbuf ( nurl_zalloc 8 )
+    : i32 _w ( waitpid pid # *u statusbuf # i32 0 )
+    : i raw ( nurl_peek statusbuf 0 )
+    ( nurl_free statusbuf )
+    ^ == 0 ( nurl_wait_exit_status & raw 65535 )
+}
+
+@ __find_print s path i term → v {
+    : String out ( string_new )
+    ( string_push_str out path )
+    ( string_push_char out term )
+    ( bx_write out )
+    ( string_free out )
+}
+
+// One primary. Advances g_find_pos past it.
+@ __find_prim ( Vec String ) toks FindCtx c → b {
+    : s t ( __find_tok toks g_find_pos )
+    = g_find_pos + g_find_pos 1
+    ? ( bx_streq t `-name` ) {
+        : s pat ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ^ ( fs_match pat . c name )
+    } {}
+    ? ( bx_streq t `-iname` ) {
+        : s pat ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        : String lp ( string_to_lower ( string_from pat ) )
+        : String ln ( string_to_lower ( string_from . c name ) )
+        : b r ( fs_match ( string_data lp ) ( string_data ln ) )
+        ( string_free lp )
+        ( string_free ln )
+        ^ r
+    } {}
+    ? ( bx_streq t `-path` ) {
+        : s pat ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ^ ( fs_match pat . c path )
+    } {}
+    ? ( bx_streq t `-type` ) {
+        : s ty ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ^ ( __find_type_char . c mode ( nurl_str_get ty 0 ) )
+    } {}
+    ? ( bx_streq t `-maxdepth` ) {
+        = g_find_maxdepth ( nurl_str_to_int ( __find_tok toks g_find_pos ) )
+        = g_find_pos + g_find_pos 1
+        ^ T
+    } {}
+    ? ( bx_streq t `-mindepth` ) {
+        = g_find_mindepth ( nurl_str_to_int ( __find_tok toks g_find_pos ) )
+        = g_find_pos + g_find_pos 1
+        ^ T
+    } {}
+    ? ( bx_streq t `-size` ) {
+        : s spec ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        : i sl ( nurl_str_len spec )
+        : i suffix ? > sl 0 ( nurl_str_get spec - sl 1 ) 99
+        : i unit ? == suffix 99 1 ? == suffix 119 2 ? == suffix 107 1024 ? == suffix 77 1048576 ? == suffix 71 1073741824 512
+        : i want ( __find_num spec )
+        // Everything but `c` rounds UP to whole units, which is why
+        // `-size 1k` finds a one-byte file.
+        : i have ? == unit 1 . c size / + . c size - unit 1 unit
+        ^ ( __find_compare have want ( __find_cmpdir spec ) )
+    } {}
+    ? ( bx_streq t `-empty` ) {
+        ? == ( nurl_stat_kind . c mode ) FS_KIND_DIR {
+            ?? ( dir_list . c path ) {
+                T names → {
+                    : b e == 0 ( vec_len [String] names )
+                    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    ^ e
+                }
+                F _ → { ^ F }
+            }
+        } {}
+        ^ == . c size 0
+    } {}
+    ? ( bx_streq t `-newer` ) {
+        : s other ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ?? ( fs_stat other ) {
+            T st → { ^ > . c mtime . st mtime }
+            F _ → { ^ F }
+        }
+    } {}
+    ? | ( bx_streq t `-mtime` ) ( bx_streq t `-mmin` ) {
+        : s spec ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        : i unit ? ( bx_streq t `-mtime` ) 86400 60
+        : i age / - ( now_seconds ) . c mtime unit
+        ^ ( __find_compare age ( __find_num spec ) ( __find_cmpdir spec ) )
+    } {}
+    ? ( bx_streq t `-perm` ) {
+        : s spec ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        : b exact ! | == ( nurl_str_get spec 0 ) 45 == ( nurl_str_get spec 0 ) 47
+        : s bits ? exact spec ( nurl_str_slice spec 1 - ( nurl_str_len spec ) 1 )
+        : i want ( bx_parse_mode bits 0 )
+        ? < want 0 { ^ F } {}
+        : i have & . c mode 4095
+        ? exact { ^ == have want } {}
+        ? == ( nurl_str_get spec 0 ) 45 { ^ == & have want want } {}
+        ^ != 0 & have want
+    } {}
+    ? ( bx_streq t `-user` ) {
+        : s who ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ?? ( fs_lstat . c path ) {
+            T st → {
+                : String nm ( __stat_name_of . st uid F )
+                : b r | ( bx_streq ( string_data nm ) who ) ( bx_streq ( nurl_str_int . st uid ) who )
+                ( string_free nm )
+                ^ r
+            }
+            F _ → { ^ F }
+        }
+    } {}
+    ? ( bx_streq t `-group` ) {
+        : s who ( __find_tok toks g_find_pos )
+        = g_find_pos + g_find_pos 1
+        ?? ( fs_lstat . c path ) {
+            T st → {
+                : String nm ( __stat_name_of . st gid T )
+                : b r | ( bx_streq ( string_data nm ) who ) ( bx_streq ( nurl_str_int . st gid ) who )
+                ( string_free nm )
+                ^ r
+            }
+            F _ → { ^ F }
+        }
+    } {}
+    ? ( bx_streq t `-print` ) {
+        ? . c live { ( __find_print . c path 10 ) } {}
+        ^ T
+    } {}
+    ? ( bx_streq t `-print0` ) {
+        ? . c live { ( __find_print . c path 0 ) } {}
+        ^ T
+    } {}
+    ? ( bx_streq t `-delete` ) {
+        ? . c live {
+            : ~ b ok T
+            ? == ( nurl_stat_kind . c mode ) FS_KIND_DIR {
+                ?? ( dir_remove . c path ) { T _ → {} F _ → { = ok F } }
+            } {
+                ?? ( file_delete . c path ) { T _ → {} F _ → { = ok F } }
+            }
+            ? ! ok {
+                ( bx_err_at . c path `cannot delete` )
+                = g_find_rc 1
+            } {}
+        } {}
+        ^ T
+    } {}
+    ? ( bx_streq t `-prune` ) {
+        ? . c live { = g_find_prune T } {}
+        ^ T
+    } {}
+    ? | ( bx_streq t `-exec` ) ( bx_streq t `-execdir` ) {
+        : i from g_find_pos
+        : ~ i to from
+        : i n ( vec_len [String] toks )
+        ~ & < to n ! ( bx_streq ( __find_tok toks to ) `;` ) { = to + to 1 }
+        = g_find_pos ? < to n + to 1 to
+        ? . c live { ^ ( __find_exec toks from to . c path ) } {}
+        ^ T
+    } {}
+    ? ( bx_streq t `-true` ) { ^ T } {}
+    ? ( bx_streq t `-false` ) { ^ F } {}
+    ? | ( bx_streq t `-depth` ) ( bx_streq t `-d` ) {
+        = g_find_depth_first T
+        ^ T
+    } {}
+    ? ( bx_streq t `-follow` ) { ^ T } {}
+    ( bx_err_at t `unknown predicate` )
+    = g_find_rc 1
+    = g_find_pos ( vec_len [String] toks )
+    ^ F
+}
+
+@ __find_unary ( Vec String ) toks FindCtx c → b {
+    : s t ( __find_tok toks g_find_pos )
+    ? | ( bx_streq t `!` ) ( bx_streq t `-not` ) {
+        = g_find_pos + g_find_pos 1
+        ^ ! ( __find_unary toks c )
+    } {}
+    ? ( bx_streq t `(` ) {
+        = g_find_pos + g_find_pos 1
+        : b r ( __find_or toks c )
+        ? ( bx_streq ( __find_tok toks g_find_pos ) `)` ) { = g_find_pos + g_find_pos 1 } {}
+        ^ r
+    } {}
+    ^ ( __find_prim toks c )
+}
+
+@ __find_ends_group ( Vec String ) toks → b {
+    ? ( __find_at_end toks ) { ^ T } {}
+    : s t ( __find_tok toks g_find_pos )
+    ^ | | ( bx_streq t `)` ) ( bx_streq t `-o` ) ( bx_streq t `-or` )
+}
+
+@ __find_and ( Vec String ) toks FindCtx c → b {
+    : ~ b acc ( __find_unary toks c )
+    ~ ! ( __find_ends_group toks ) {
+        : s t ( __find_tok toks g_find_pos )
+        ? | ( bx_streq t `-a` ) ( bx_streq t `-and` ) { = g_find_pos + g_find_pos 1 } {}
+        ? ( __find_ends_group toks ) {} {
+            // POSIX short-circuit: the right operand still has to be
+            // PARSED (the cursor must land past it) but must not act.
+            : FindCtx c2 @ FindCtx { . c path . c name . c mode . c size . c mtime . c depth & . c live acc }
+            : b r ( __find_unary toks c2 )
+            = acc & acc r
+        }
+    }
+    ^ acc
+}
+
+@ __find_or ( Vec String ) toks FindCtx c → b {
+    : ~ b acc ( __find_and toks c )
+    ~ & ! ( __find_at_end toks ) ! ( bx_streq ( __find_tok toks g_find_pos ) `)` ) {
+        : s t ( __find_tok toks g_find_pos )
+        ? | ( bx_streq t `-o` ) ( bx_streq t `-or` ) {
+            = g_find_pos + g_find_pos 1
+            : FindCtx c2 @ FindCtx { . c path . c name . c mode . c size . c mtime . c depth & . c live ! acc }
+            : b r ( __find_and toks c2 )
+            = acc | acc r
+        } { = g_find_pos ( vec_len [String] toks ) }
+    }
+    ^ acc
+}
+
+@ __find_visit ( Vec String ) toks s path s name i depth → v {
+    ?? ( fs_lstat path ) {
+        F _ → {
+            ( bx_err_at path `No such file or directory` )
+            = g_find_rc 1
+        }
+        T st → {
+            = g_find_prune F
+            : b in_range & >= depth g_find_mindepth <= depth g_find_maxdepth
+            : ~ b matched F
+            ? in_range {
+                : FindCtx c @ FindCtx { path name . st mode . st size . st mtime depth T }
+                = g_find_pos 0
+                ? > ( vec_len [String] toks ) 0 {
+                    = matched ( __find_or toks c )
+                } { = matched T }
+                // With no action in the expression, a match prints.
+                ? & matched ! g_find_has_action { ( __find_print path 10 ) } {}
+            } {}
+            ? & ( stat_is_dir st ) & < depth g_find_maxdepth ! g_find_prune {
+                ?? ( dir_list path ) {
+                    T names → {
+                        ( sort_by [String] names \ String a String b → i { ^ ( cmp_string a b ) } )
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String sub ( path_join path ( bx_at names k ) )
+                            ( __find_visit toks ( string_data sub ) ( bx_at names k ) + depth 1 )
+                            ( string_free sub )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F e → {
+                        ( bx_err_at path ( bx_ioerr e ) )
+                        = g_find_rc 1
+                    }
+                }
+            } {}
+        }
+    }
+}
+
+@ ap_find ( Vec String ) argv → i {
+    = g_find_rc 0
+    = g_find_maxdepth 1000000
+    = g_find_mindepth 0
+    = g_find_has_action F
+    = g_find_depth_first F
+    : i n ( vec_len [String] argv )
+    // Everything before the first `-`/`(`/`!` token is a starting point.
+    : ( Vec String ) roots ( vec_new [String] )
+    : ( Vec String ) toks ( vec_new [String] )
+    : ~ i i 1
+    : ~ b in_roots T
+    ~ < i n {
+        : s t ( bx_at argv i )
+        ? in_roots {
+            : i tl ( nurl_str_len t )
+            ? | | & > tl 0 == ( nurl_str_get t 0 ) 45 ( bx_streq t `(` ) ( bx_streq t `!` ) {
+                = in_roots F
+            } { ( vec_push [String] roots ( string_from t ) ) }
+        } {}
+        ? ! in_roots { ( vec_push [String] toks ( string_from t ) ) } {}
+        = i + i 1
+    }
+    ? == ( vec_len [String] roots ) 0 { ( vec_push [String] roots ( string_from `.` ) ) } {}
+    // An expression that acts needs no implicit -print.
+    : i tn ( vec_len [String] toks )
+    : ~ i k 0
+    ~ < k tn {
+        : s t ( bx_at toks k )
+        ? | | | ( bx_streq t `-print` ) ( bx_streq t `-print0` ) ( bx_streq t `-delete` ) | ( bx_streq t `-exec` ) ( bx_streq t `-execdir` ) {
+            = g_find_has_action T
+        } {}
+        = k + k 1
+    }
+    : i rn ( vec_len [String] roots )
+    : ~ i r 0
+    ~ < r rn {
+        : s root ( bx_at roots r )
+        : String base ( path_basename root )
+        ( __find_visit toks root ( string_data base ) 0 )
+        ( string_free base )
+        = r + r 1
+    }
+    ( vec_free_with [String] roots \ String x → v { ( string_free x ) } )
+    ( vec_free_with [String] toks \ String x → v { ( string_free x ) } )
+    ^ g_find_rc
+}

--- a/packages/nurlbox/src/grep.nu
+++ b/packages/nurlbox/src/grep.nu
@@ -1,0 +1,423 @@
+// nurlbox/grep.nu — grep / egrep / fgrep.
+//
+// Three matchers behind one applet, because that is what the three
+// names mean:
+//
+//   grep    POSIX BASIC regular expressions   (`\(`, `\|`, `\+`)
+//   grep -E POSIX EXTENDED regular expressions (`(`, `|`, `+`)  = egrep
+//   grep -F fixed strings, no metacharacters at all             = fgrep
+//
+// The engine is the stdlib's `ext/regex`, which speaks ERE. Basic
+// regular expressions are therefore TRANSLATED to extended ones rather
+// than approximated: in a BRE, `(` `)` `|` `+` `?` `{` `}` are literal
+// characters and their backslashed forms are the operators, which is
+// exactly the swap `_bre_to_ere` performs. A grep that quietly treated
+// `a+` as "one or more a" would silently mis-answer every script that
+// meant a literal plus.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/ext/regex.nu`
+$ `bx.nu`
+
+: i GREP_INVERT 1
+: i GREP_IGNORE 2
+: i GREP_COUNT 4
+: i GREP_LINENO 8
+: i GREP_FILES 16
+: i GREP_NOFILES 32
+: i GREP_QUIET 64
+: i GREP_WORD 128
+: i GREP_LINE 256
+: i GREP_ONLY 512
+: i GREP_FIXED 1024
+: i GREP_WITHNAME 2048
+: i GREP_NOMATCH_FILES 4096
+: i GREP_RECURSE 8192
+: i GREP_SILENT 16384
+
+// BRE → ERE. `\(` becomes `(` and a bare `(` becomes `\(`; same for
+// `)`, `|`, `+`, `?`, `{`, `}`. Inside a bracket expression nothing is
+// special, so the scan tracks that.
+@ _bre_to_ere s pat → String {
+    : String out ( string_new )
+    : i n ( nurl_str_len pat )
+    : ~ i i 0
+    : ~ b in_class F
+    ~ < i n {
+        : i c ( nurl_str_get pat i )
+        ? in_class {
+            ( string_push_char out c )
+            ? == c 93 { = in_class F } {}
+            = i + i 1
+        } {
+            ? == c 91 {
+                ( string_push_char out c )
+                = in_class T
+                = i + i 1
+                // A `]` immediately after `[` or `[^` is a literal.
+                ? & < i n == ( nurl_str_get pat i ) 94 {
+                    ( string_push_char out 94 )
+                    = i + i 1
+                } {}
+                ? & < i n == ( nurl_str_get pat i ) 93 {
+                    ( string_push_char out 93 )
+                    = i + i 1
+                } {}
+            } {
+                ? & == c 92 < + i 1 n {
+                    : i e ( nurl_str_get pat + i 1 )
+                    ? | | | | | == e 40 == e 41 == e 124 == e 43 == e 63 | == e 123 == e 125 {
+                        // The operator forms lose their backslash.
+                        ( string_push_char out e )
+                    } {
+                        ( string_push_char out 92 )
+                        ( string_push_char out e )
+                    }
+                    = i + i 2
+                } {
+                    ? | | | | | == c 40 == c 41 == c 124 == c 43 == c 63 | == c 123 == c 125 {
+                        // …and the bare forms gain one: in a BRE they
+                        // are ordinary characters.
+                        ( string_push_char out 92 )
+                        ( string_push_char out c )
+                    } { ( string_push_char out c ) }
+                    = i + i 1
+                }
+            }
+        }
+    }
+    ^ out
+}
+
+@ __grep_is_word i c → b {
+    ^ | | & >= c 97 <= c 122 & >= c 65 <= c 90 | & >= c 48 <= c 57 == c 95
+}
+
+// One pattern, compiled or literal.
+: GrepPat {
+    Regex rx
+    String lit
+    b fixed
+}
+
+@ __grep_pat_free GrepPat p → v {
+    ? . p fixed { ( string_free . p lit ) } { ( regex_free . p rx ) ( string_free . p lit ) }
+}
+
+// Case folding is done by lowering both the pattern and the line — the
+// engine has no case-insensitive mode, and lowering the input is what
+// every grep without one does.
+@ _grep_lower s text → String {
+    : String out ( string_new )
+    : i n ( nurl_str_len text )
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get text i )
+        ( string_push_char out ? & >= c 65 <= c 90 + c 32 c )
+        = i + i 1
+    }
+    ^ out
+}
+
+// Does `line` contain a match of pattern `p`? `start`/`len` receive the
+// leftmost match when there is one.
+@ __grep_find GrepPat p s line i flags inout i mstart inout i mlen → b {
+    = mstart -1
+    = mlen 0
+    ? . p fixed {
+        : i at ( nurl_str_find line ( string_data . p lit ) )
+        ? < at 0 { ^ F } {}
+        = mstart at
+        = mlen ( string_len . p lit )
+        ^ T
+    } {}
+    ?? ( regex_find . p rx line ) {
+        T m → {
+            = mstart . m start
+            = mlen . m len
+            ^ T
+        }
+        F _ → { ^ F }
+    }
+}
+
+// -w and -x turn a match into a match WITH BOUNDARIES; a plain find is
+// not enough, because the leftmost match may fail the boundary test
+// while a later one passes.
+@ __grep_line_matches GrepPat p s line i flags inout i mstart inout i mlen → b {
+    : i n ( nurl_str_len line )
+    : ~ i from 0
+    : ~ b found F
+    ~ & ! found <= from n {
+        : s tail ( nurl_str_slice line from - n from )
+        : ~ i s0 -1
+        : ~ i l0 0
+        ? ( __grep_find p tail flags s0 l0 ) {
+            : i abs_start + from s0
+            : i abs_end + abs_start l0
+            : ~ b ok T
+            ? != 0 & flags GREP_LINE {
+                = ok & == abs_start 0 == abs_end n
+            } {}
+            ? != 0 & flags GREP_WORD {
+                ? > abs_start 0 {
+                    ? ( __grep_is_word ( nurl_str_get line - abs_start 1 ) ) { = ok F } {}
+                } {}
+                ? < abs_end n {
+                    ? ( __grep_is_word ( nurl_str_get line abs_end ) ) { = ok F } {}
+                } {}
+            } {}
+            ? ok {
+                = mstart abs_start
+                = mlen l0
+                = found T
+            } {
+                // Step past this match's first byte and look again.
+                = from + abs_start ? > l0 0 1 1
+            }
+        } { = from + n 1 }
+    }
+    ^ found
+}
+
+@ __grep_emit String out s name s line i lineno i flags b with_name b only i mstart i mlen → v {
+    ? with_name {
+        ( string_push_str out name )
+        ( string_push_char out 58 )
+    } {}
+    ? != 0 & flags GREP_LINENO {
+        ( string_push_int out lineno )
+        ( string_push_char out 58 )
+    } {}
+    ? only {
+        : ~ i k 0
+        ~ < k mlen {
+            ( string_push_char out ( nurl_str_get line + mstart k ) )
+            = k + k 1
+        }
+    } {
+        ( string_push_str out line )
+    }
+    ( string_push_char out 10 )
+}
+
+// Returns 0 when the file had at least one selected line, 1 when it had
+// none, 2 on an I/O error — grep's own exit-code alphabet.
+@ __grep_file ( Vec GrepPat ) pats s path s label i flags b with_name i maxcount inout i total → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 2 }
+        T br → {
+            : String line ( string_new )
+            : String lower ( string_new )
+            : String out ( string_new )
+            : ~ i lineno 0
+            : ~ i hits 0
+            : ~ b more T
+            : i np ( vec_len [GrepPat] pats )
+            ~ more {
+                ? ( bufreader_read_line_into br line ) {
+                    = lineno + lineno 1
+                    : ~ s probe ( string_data line )
+                    ? != 0 & flags GREP_IGNORE {
+                        ( string_clear lower )
+                        : String lo ( _grep_lower ( string_data line ) )
+                        ( string_push_bytes lower # *u ( string_data lo ) ( string_len lo ) )
+                        ( string_free lo )
+                        = probe ( string_data lower )
+                    } {}
+                    : ~ b hit F
+                    : ~ i mstart -1
+                    : ~ i mlen 0
+                    : ~ i pi 0
+                    ~ & ! hit < pi np {
+                        ?? ( vec_get [GrepPat] pats pi ) {
+                            T p → {
+                                ? ( __grep_line_matches p probe flags mstart mlen ) { = hit T } {}
+                            }
+                            F _ → {}
+                        }
+                        = pi + pi 1
+                    }
+                    ? != 0 & flags GREP_INVERT { = hit ! hit } {}
+                    ? hit {
+                        = hits + hits 1
+                        = total + total 1
+                        ? == 0 & flags | | GREP_COUNT GREP_QUIET | GREP_FILES GREP_NOMATCH_FILES {
+                            ( __grep_emit out label ( string_data line ) lineno flags with_name
+                            & != 0 & flags GREP_ONLY == 0 & flags GREP_INVERT mstart mlen )
+                            ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                        } {}
+                        ? & > maxcount 0 >= hits maxcount { = more F } {}
+                        ? != 0 & flags GREP_QUIET { = more F } {}
+                    } {}
+                } { = more F }
+            }
+            ? != 0 & flags GREP_COUNT {
+                ( string_clear out )
+                ? with_name {
+                    ( string_push_str out label )
+                    ( string_push_char out 58 )
+                } {}
+                ( string_push_int out hits )
+                ( string_push_char out 10 )
+            } {}
+            ? & != 0 & flags GREP_FILES > hits 0 {
+                ( string_clear out )
+                ( string_push_str out label )
+                ( string_push_char out 10 )
+            } {}
+            ? & != 0 & flags GREP_NOMATCH_FILES == hits 0 {
+                ( string_clear out )
+                ( string_push_str out label )
+                ( string_push_char out 10 )
+            } {}
+            ? == 0 & flags GREP_QUIET { ( bx_write out ) } {}
+            ( string_free out )
+            ( string_free line )
+            ( string_free lower )
+            ( bufreader_close br )
+            ^ ? > hits 0 0 1
+        }
+    }
+}
+
+@ __grep_walk ( Vec GrepPat ) pats s path i flags b with_name i maxcount inout i total inout i rc → v {
+    ?? ( fs_lstat path ) {
+        F e → {
+            ? == 0 & flags GREP_SILENT { ( bx_err_at path ( bx_ioerr e ) ) } {}
+            = rc 2
+        }
+        T st → {
+            ? ( stat_is_dir st ) {
+                ?? ( dir_list path ) {
+                    T names → {
+                        ( sort_by [String] names \ String a String b → i { ^ ( cmp_string a b ) } )
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String sub ( path_join path ( bx_at names k ) )
+                            ( __grep_walk pats ( string_data sub ) flags with_name maxcount total rc )
+                            ( string_free sub )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F e2 → {
+                        ? == 0 & flags GREP_SILENT { ( bx_err_at path ( bx_ioerr e2 ) ) } {}
+                        = rc 2
+                    }
+                }
+            } {
+                ? ( stat_is_symlink st ) {} {
+                    : i one ( __grep_file pats path path flags with_name maxcount total )
+                    ? & == one 2 != rc 0 {} {}
+                    ? == one 2 { = rc 2 } {}
+                }
+            }
+        }
+    }
+}
+
+@ ap_grep ( Vec String ) argv → i {
+    // egrep / fgrep are grep with a matcher preselected.
+    : s me ( bx_name )
+    : BxOpts o ( bx_getopt argv 1 `EFivnce:lLqwxohHrRsm:f:` `extended-regexp=E,fixed-strings=F,ignore-case=i,invert-match=v,line-number=n,count=c,files-with-matches=l,files-without-match=L,quiet=q,silent=q,word-regexp=w,line-regexp=x,only-matching=o,no-filename=h,with-filename=H,recursive=r,regexp=e,file=f,max-count=m` )
+    : ~ i rc 1
+    ? ! ( bx_ok o ) { = rc 2 } {
+        : ~ i flags 0
+        : ~ b extended | ( bx_has o `E` ) ( bx_streq me `egrep` )
+        ? | ( bx_has o `F` ) ( bx_streq me `fgrep` ) { = flags | flags GREP_FIXED } {}
+        ? ( bx_has o `i` ) { = flags | flags GREP_IGNORE } {}
+        ? ( bx_has o `v` ) { = flags | flags GREP_INVERT } {}
+        ? ( bx_has o `n` ) { = flags | flags GREP_LINENO } {}
+        ? ( bx_has o `c` ) { = flags | flags GREP_COUNT } {}
+        ? ( bx_has o `l` ) { = flags | flags GREP_FILES } {}
+        ? ( bx_has o `L` ) { = flags | flags GREP_NOMATCH_FILES } {}
+        ? ( bx_has o `q` ) { = flags | flags GREP_QUIET } {}
+        ? ( bx_has o `w` ) { = flags | flags GREP_WORD } {}
+        ? ( bx_has o `x` ) { = flags | flags GREP_LINE } {}
+        ? ( bx_has o `o` ) { = flags | flags GREP_ONLY } {}
+        ? | ( bx_has o `r` ) ( bx_has o `R` ) { = flags | flags GREP_RECURSE } {}
+        ? ( bx_has o `s` ) { = flags | flags GREP_SILENT } {}
+        : i maxcount ? ( bx_has o `m` ) ( nurl_str_to_int ( bx_val o `m` ) ) 0
+        // Pattern sources: -e, -f, or the first operand.
+        : ( Vec String ) rawpats ( vec_new [String] )
+        ? ( bx_has o `e` ) { ( bx_vals o `e` rawpats ) } {}
+        ? ( bx_has o `f` ) {
+            ( bx_read_lines ( bx_val o `f` ) rawpats )
+        } {}
+        : i nops ( bx_operand_count o )
+        : ~ i first_file 0
+        ? == ( vec_len [String] rawpats ) 0 {
+            ? > nops 0 {
+                ( vec_push [String] rawpats ( string_from ( bx_operand o 0 ) ) )
+                = first_file 1
+            } {}
+        } {}
+        ? == ( vec_len [String] rawpats ) 0 {
+            ( bx_err `usage: grep [-EFivncl] PATTERN [FILE]...` )
+            = rc 2
+        } {
+            : ( Vec GrepPat ) pats ( vec_new [GrepPat] )
+            : ~ b compiled T
+            : i npat ( vec_len [String] rawpats )
+            : ~ i pi 0
+            ~ < pi npat {
+                : s raw ( bx_at rawpats pi )
+                : String src ? != 0 & flags GREP_IGNORE ( _grep_lower raw ) ( string_from raw )
+                ? != 0 & flags GREP_FIXED {
+                    ( vec_push [GrepPat] pats @ GrepPat { @ Regex { # s 0 } src T } )
+                } {
+                    : String ere ? extended ( string_clone src ) ( _bre_to_ere ( string_data src ) )
+                    ?? ( regex_compile ( string_data ere ) ) {
+                        T r → { ( vec_push [GrepPat] pats @ GrepPat { r src F } ) }
+                        F _ → {
+                            ( bx_err_at ( string_data src ) `invalid regular expression` )
+                            = compiled F
+                            ( string_free src )
+                        }
+                    }
+                    ( string_free ere )
+                }
+                = pi + pi 1
+            }
+            ? ! compiled { = rc 2 } {
+                : i nfiles - nops first_file
+                : b with_name & == 0 & flags GREP_NOFILES | ( bx_has o `H` ) | > nfiles 1 != 0 & flags GREP_RECURSE
+                : ~ i total 0
+                : ~ i walkrc 0
+                ? == nfiles 0 {
+                    : i one ( __grep_file pats `-` `(standard input)` flags F maxcount total )
+                    ? == one 2 { = walkrc 2 } {}
+                } {
+                    : ~ i i first_file
+                    ~ < i nops {
+                        : s p ( bx_operand o i )
+                        ? != 0 & flags GREP_RECURSE {
+                            ( __grep_walk pats p flags with_name maxcount total walkrc )
+                        } {
+                            : i one ( __grep_file pats p p flags with_name maxcount total )
+                            ? == one 2 {
+                                ? == 0 & flags GREP_SILENT {} {}
+                                = walkrc 2
+                            } {}
+                        }
+                        = i + i 1
+                    }
+                }
+                = rc ? == walkrc 2 2 ? > total 0 0 1
+            }
+            ( vec_free_with [GrepPat] pats \ GrepPat p → v { ( __grep_pat_free p ) } )
+        }
+        ( bx_free_lines rawpats )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/hash.nu
+++ b/packages/nurlbox/src/hash.nu
@@ -1,0 +1,353 @@
+// nurlbox/hash.nu — digests and encodings.
+//
+// md5sum / sha1sum / sha256sum / sha512sum / base64 / cksum / crc32.
+//
+// Every digest here is the shipped pure-NURL implementation from the
+// stdlib — no OpenSSL, no libcrypto, nothing to link. The `-c` check
+// mode reads the same format it writes, so `sha256sum * > SUMS` and
+// `sha256sum -c SUMS` round-trip.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_md5.nu`
+$ `stdlib/std/hash_sha1.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
+$ `stdlib/std/deflate.nu`
+$ `bx.nu`
+
+: i HASH_MD5 0
+: i HASH_SHA1 1
+: i HASH_SHA256 2
+: i HASH_SHA512 3
+
+@ __hash_of i kind ( Vec u ) data → ( Vec u ) {
+    ? == kind HASH_MD5 { ^ ( md5_pure data ) } {}
+    ? == kind HASH_SHA1 { ^ ( sha1_pure data ) } {}
+    ? == kind HASH_SHA256 { ^ ( sha256_pure data ) } {}
+    ^ ( sha512_pure data )
+}
+
+@ __hex_of ( Vec u ) digest → String {
+    : String out ( string_with_cap * 2 ( vec_len [u] digest ) )
+    : i n ( vec_len [u] digest )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [u] digest i ) {
+            T b → {
+                : i v & 255 # i b
+                ( string_push_char out ( nurl_str_get `0123456789abcdef` >> v 4 ) )
+                ( string_push_char out ( nurl_str_get `0123456789abcdef` & v 15 ) )
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ^ out
+}
+
+// The digest of one input, or None when it could not be read.
+@ __hash_file i kind s path → ?String {
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp path ok )
+    ? ! ok {
+        ( vec_free [u] data )
+        ^ @ ?String { F # String 0 }
+    } {}
+    : ( Vec u ) digest ( __hash_of kind data )
+    : String hex ( __hex_of digest )
+    ( vec_free [u] digest )
+    ( vec_free [u] data )
+    ^ @ ?String { T hex }
+}
+
+// `-c`: read `HEX  NAME` lines and re-hash each named file.
+@ __hash_check i kind s listfile b quiet b status → i {
+    ?? ( bx_reader listfile ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String line ( string_new )
+            : ~ i rc 0
+            : ~ i bad 0
+            : ~ b more T
+            ~ more {
+                ? ( bufreader_read_line_into br line ) {
+                    : i n ( string_len line )
+                    ? > n 0 {
+                        // `HEX  NAME` (two spaces) or `HEX *NAME` for the
+                        // binary form; both are in the wild.
+                        : ~ i sp 0
+                        ~ & < sp n != ( string_get line sp ) 32 { = sp + sp 1 }
+                        ? >= sp n {
+                            ( bx_err_at listfile `improperly formatted checksum line` )
+                            = rc 1
+                        } {
+                            : String want ( string_substr line 0 sp )
+                            : ~ i nb sp
+                            ~ & < nb n | == ( string_get line nb ) 32 == ( string_get line nb ) 42 { = nb + nb 1 }
+                            : String name ( string_substr line nb - n nb )
+                            ?? ( __hash_file kind ( string_data name ) ) {
+                                T got → {
+                                    : b okline ( string_eq got want )
+                                    ? ! status {
+                                        ? | ! quiet ! okline {
+                                            ( nurl_print ( string_data name ) )
+                                            ( nurl_print ? okline `: OK\n` `: FAILED\n` )
+                                        } {}
+                                    } {}
+                                    ? ! okline { = bad + bad 1 = rc 1 } {}
+                                    ( string_free got )
+                                }
+                                F _ → {
+                                    = rc 1
+                                    = bad + bad 1
+                                }
+                            }
+                            ( string_free want )
+                            ( string_free name )
+                        }
+                    } {}
+                } { = more F }
+            }
+            ? & > bad 0 ! status {
+                ( nurl_eprint ( bx_name ) )
+                ( nurl_eprint `: WARNING: ` )
+                ( nurl_eprint ( nurl_str_int bad ) )
+                ( nurl_eprint ` of the computed checksums did NOT match\n` )
+            } {}
+            ( string_free line )
+            ( bufreader_close br )
+            ^ rc
+        }
+    }
+}
+
+@ bx_sum i kind ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `cbtsw` `check=c,binary=b,text=t,status=s,warn=w` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? ( bx_has o `c` ) {
+            : ~ i i 0
+            ~ < i ? > nops 0 nops 1 {
+                : i one ( __hash_check kind ? > nops 0 ( bx_operand o i ) `-` F ( bx_has o `s` ) )
+                ? != one 0 { = rc 1 } {}
+                = i + i 1
+            }
+        } {
+            : ~ i i 0
+            ~ < i ? > nops 0 nops 1 {
+                : s p ? > nops 0 ( bx_operand o i ) `-`
+                ?? ( __hash_file kind p ) {
+                    T hex → {
+                        : String out ( string_new )
+                        ( string_push_bytes out # *u ( string_data hex ) ( string_len hex ) )
+                        ( string_push_str out `  ` )
+                        ( string_push_str out p )
+                        ( string_push_char out 10 )
+                        ( bx_write out )
+                        ( string_free out )
+                        ( string_free hex )
+                    }
+                    F _ → { = rc 1 }
+                }
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_md5sum ( Vec String ) argv → i { ^ ( bx_sum HASH_MD5 argv ) }
+
+@ ap_sha1sum ( Vec String ) argv → i { ^ ( bx_sum HASH_SHA1 argv ) }
+
+@ ap_sha256sum ( Vec String ) argv → i { ^ ( bx_sum HASH_SHA256 argv ) }
+
+@ ap_sha512sum ( Vec String ) argv → i { ^ ( bx_sum HASH_SHA512 argv ) }
+
+// ── base64 ────────────────────────────────────────────────────────
+
+@ ap_base64 ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `dw:` `decode=d,wrap=w` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : s path ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        : ~ b ok T
+        : ( Vec u ) data ( bx_slurp path ok )
+        ? ! ok { = rc 1 } {
+            ? ( bx_has o `d` ) {
+                // Whitespace is not data: a wrapped encoding must decode.
+                : String packed ( string_new )
+                : i n ( vec_len [u] data )
+                : ~ i i 0
+                ~ < i n {
+                    ?? ( vec_get [u] data i ) {
+                        T b → {
+                            : i c & 255 # i b
+                            ? ! | == c 10 | == c 13 | == c 32 == c 9 { ( string_push_char packed c ) } {}
+                        }
+                        F _ → {}
+                    }
+                    = i + i 1
+                }
+                ?? ( b64_decode_vec ( string_data packed ) ) {
+                    T raw → {
+                        ( bx_write_bytes raw )
+                        ( vec_free [u] raw )
+                    }
+                    F _ → {
+                        ( bx_err `invalid input` )
+                        = rc 1
+                    }
+                }
+                ( string_free packed )
+            } {
+                : String enc ( b64_encode_vec data )
+                : i width ? ( bx_has o `w` ) ( nurl_str_to_int ( bx_val o `w` ) ) 76
+                : String out ( string_new )
+                : i n ( string_len enc )
+                ? <= width 0 {
+                    ( string_push_bytes out # *u ( string_data enc ) n )
+                    ( string_push_char out 10 )
+                } {
+                    : ~ i i 0
+                    ~ < i n {
+                        : i take ? < - n i width - n i width
+                        ( string_push_bytes out # *u + # i ( string_data enc ) i take )
+                        ( string_push_char out 10 )
+                        = i + i take
+                    }
+                }
+                ( bx_write out )
+                ( string_free out )
+                ( string_free enc )
+            }
+        }
+        ( vec_free [u] data )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── cksum / crc32 ─────────────────────────────────────────────────
+
+// POSIX cksum is NOT crc32: a different polynomial order, the length
+// folded in at the end, and no final inversion of the same shape. It is
+// its own algorithm and gets its own table.
+@ __cksum_table → ( Vec i ) {
+    : ( Vec i ) t ( vec_new [i] )
+    : ~ i n 0
+    ~ < n 256 {
+        : ~ i c << n 24
+        : ~ i k 0
+        ~ < k 8 {
+            = c ? != 0 & c 2147483648 & ^^ << c 1 79764919 4294967295 & << c 1 4294967295
+            = k + k 1
+        }
+        ( vec_push [i] t & c 4294967295 )
+        = n + n 1
+    }
+    ^ t
+}
+
+@ __cksum ( Vec u ) data → i {
+    : ( Vec i ) tbl ( __cksum_table )
+    : ~ i crc 0
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : ~ i i 0
+    ~ < i n {
+        : i b & 255 # i . p i
+        : i idx & 255 ^^ >> crc 24 b
+        : ~ i tv 0
+        ?? ( vec_get [i] tbl idx ) { T x → { = tv x } F _ → {} }
+        = crc & ^^ << crc 8 tv 4294967295
+        = i + i 1
+    }
+    // The length is appended, low byte first, then the whole thing is
+    // complemented — that trailing step is what makes cksum cksum.
+    : ~ i len n
+    ~ != len 0 {
+        : i idx & 255 ^^ >> crc 24 & len 255
+        : ~ i tv 0
+        ?? ( vec_get [i] tbl idx ) { T x → { = tv x } F _ → {} }
+        = crc & ^^ << crc 8 tv 4294967295
+        = len >> len 8
+    }
+    ( vec_free [i] tbl )
+    ^ & ~ crc 4294967295
+}
+
+@ ap_cksum ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        ~ < i ? > nops 0 nops 1 {
+            : s p ? > nops 0 ( bx_operand o i ) `-`
+            : ~ b ok T
+            : ( Vec u ) data ( bx_slurp p ok )
+            ? ok {
+                : String out ( string_new )
+                ( string_push_int out ( __cksum data ) )
+                ( string_push_char out 32 )
+                ( string_push_int out ( vec_len [u] data ) )
+                ? > nops 0 {
+                    ( string_push_char out 32 )
+                    ( string_push_str out p )
+                } {}
+                ( string_push_char out 10 )
+                ( bx_write out )
+                ( string_free out )
+            } { = rc 1 }
+            ( vec_free [u] data )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_crc32 ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        ~ < i ? > nops 0 nops 1 {
+            : s p ? > nops 0 ( bx_operand o i ) `-`
+            : ~ b ok T
+            : ( Vec u ) data ( bx_slurp p ok )
+            ? ok {
+                : String out ( string_new )
+                // busybox prints crc32 as eight lowercase hex digits;
+                // cksum prints its own checksum in decimal. Two tools,
+                // two conventions, both long-standing.
+                : i v ( crc32 data )
+                : ~ i sh 28
+                ~ >= sh 0 {
+                    ( string_push_char out ( nurl_str_get `0123456789abcdef` & 15 >> v sh ) )
+                    = sh - sh 4
+                }
+                ? > nops 0 {
+                    ( string_push_char out 32 )
+                    ( string_push_str out p )
+                } {}
+                ( string_push_char out 10 )
+                ( bx_write out )
+                ( string_free out )
+            } { = rc 1 }
+            ( vec_free [u] data )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/main.nu
+++ b/packages/nurlbox/src/main.nu
@@ -1,0 +1,277 @@
+// nurlbox — one binary, many utilities.
+//
+// The busybox idea, in NURL: a single executable that decides which
+// utility it is from the name it was invoked under. Symlink `cat` at it
+// and it is `cat`; run `nurlbox cat` and it is `cat` too. Everything is
+// pure NURL over the shipped stdlib — no shelling out, nothing that
+// needs a system `coreutils` underneath.
+//
+//     nurlbox                  list the applets
+//     nurlbox cat file         run one, by name
+//     nurlbox --install DIR    populate DIR with a symlink per applet
+//     ln -s nurlbox /bin/cat   the busybox way, thereafter `cat file`
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/ext/env.nu`
+$ `bx.nu`
+$ `text.nu`
+$ `sys.nu`
+$ `fileops.nu`
+$ `find.nu`
+$ `filter.nu`
+$ `hash.nu`
+$ `grep.nu`
+$ `shell.nu`
+$ `sed.nu`
+
+: s NURLBOX_VERSION `0.1.0`
+
+// Every applet, in the order `nurlbox` lists them.
+@ __applet_names → ( Vec String ) {
+    : ( Vec String ) v ( vec_new [String] )
+    ( vec_push [String] v ( string_from `[` ) )
+    ( vec_push [String] v ( string_from `arch` ) )
+    ( vec_push [String] v ( string_from `base64` ) )
+    ( vec_push [String] v ( string_from `basename` ) )
+    ( vec_push [String] v ( string_from `cat` ) )
+    ( vec_push [String] v ( string_from `chmod` ) )
+    ( vec_push [String] v ( string_from `cksum` ) )
+    ( vec_push [String] v ( string_from `clear` ) )
+    ( vec_push [String] v ( string_from `cp` ) )
+    ( vec_push [String] v ( string_from `crc32` ) )
+    ( vec_push [String] v ( string_from `cut` ) )
+    ( vec_push [String] v ( string_from `date` ) )
+    ( vec_push [String] v ( string_from `dirname` ) )
+    ( vec_push [String] v ( string_from `du` ) )
+    ( vec_push [String] v ( string_from `echo` ) )
+    ( vec_push [String] v ( string_from `egrep` ) )
+    ( vec_push [String] v ( string_from `env` ) )
+    ( vec_push [String] v ( string_from `expr` ) )
+    ( vec_push [String] v ( string_from `false` ) )
+    ( vec_push [String] v ( string_from `fgrep` ) )
+    ( vec_push [String] v ( string_from `find` ) )
+    ( vec_push [String] v ( string_from `grep` ) )
+    ( vec_push [String] v ( string_from `groups` ) )
+    ( vec_push [String] v ( string_from `head` ) )
+    ( vec_push [String] v ( string_from `hostname` ) )
+    ( vec_push [String] v ( string_from `id` ) )
+    ( vec_push [String] v ( string_from `ln` ) )
+    ( vec_push [String] v ( string_from `logname` ) )
+    ( vec_push [String] v ( string_from `ls` ) )
+    ( vec_push [String] v ( string_from `md5sum` ) )
+    ( vec_push [String] v ( string_from `mkdir` ) )
+    ( vec_push [String] v ( string_from `mktemp` ) )
+    ( vec_push [String] v ( string_from `mv` ) )
+    ( vec_push [String] v ( string_from `nl` ) )
+    ( vec_push [String] v ( string_from `nproc` ) )
+    ( vec_push [String] v ( string_from `printenv` ) )
+    ( vec_push [String] v ( string_from `printf` ) )
+    ( vec_push [String] v ( string_from `pwd` ) )
+    ( vec_push [String] v ( string_from `readlink` ) )
+    ( vec_push [String] v ( string_from `realpath` ) )
+    ( vec_push [String] v ( string_from `rev` ) )
+    ( vec_push [String] v ( string_from `rm` ) )
+    ( vec_push [String] v ( string_from `rmdir` ) )
+    ( vec_push [String] v ( string_from `sed` ) )
+    ( vec_push [String] v ( string_from `seq` ) )
+    ( vec_push [String] v ( string_from `sha1sum` ) )
+    ( vec_push [String] v ( string_from `sha256sum` ) )
+    ( vec_push [String] v ( string_from `sha512sum` ) )
+    ( vec_push [String] v ( string_from `sleep` ) )
+    ( vec_push [String] v ( string_from `sort` ) )
+    ( vec_push [String] v ( string_from `stat` ) )
+    ( vec_push [String] v ( string_from `sync` ) )
+    ( vec_push [String] v ( string_from `tac` ) )
+    ( vec_push [String] v ( string_from `tail` ) )
+    ( vec_push [String] v ( string_from `tee` ) )
+    ( vec_push [String] v ( string_from `test` ) )
+    ( vec_push [String] v ( string_from `touch` ) )
+    ( vec_push [String] v ( string_from `tr` ) )
+    ( vec_push [String] v ( string_from `true` ) )
+    ( vec_push [String] v ( string_from `truncate` ) )
+    ( vec_push [String] v ( string_from `tty` ) )
+    ( vec_push [String] v ( string_from `uname` ) )
+    ( vec_push [String] v ( string_from `uniq` ) )
+    ( vec_push [String] v ( string_from `usleep` ) )
+    ( vec_push [String] v ( string_from `wc` ) )
+    ( vec_push [String] v ( string_from `which` ) )
+    ( vec_push [String] v ( string_from `whoami` ) )
+    ( vec_push [String] v ( string_from `xargs` ) )
+    ( vec_push [String] v ( string_from `yes` ) )
+    ^ v
+}
+
+// argv[0]'s basename, with a `.exe` suffix and any `nurlbox-` prefix
+// stripped — the three spellings an installed multi-call binary meets.
+@ __invoked_as ( Vec String ) argv → String {
+    : s a0 ( bx_at argv 0 )
+    : String base ( path_basename a0 )
+    ? ( string_ends_with base `.exe` ) {
+        : String cut ( string_substr base 0 - ( string_len base ) 4 )
+        ( string_free base )
+        ^ cut
+    } {}
+    ^ base
+}
+
+// The dispatcher. `argv` is the applet's own argument vector: argv[0]
+// is the applet name, exactly as a directly-executed utility sees it.
+@ __run s name ( Vec String ) argv → i {
+    ( bx_set_name name )
+    ? ( bx_streq name `[` ) { ^ ( ap_test argv ) } {}
+    ? ( bx_streq name `arch` ) { ^ ( ap_arch argv ) } {}
+    ? ( bx_streq name `base64` ) { ^ ( ap_base64 argv ) } {}
+    ? ( bx_streq name `basename` ) { ^ ( ap_basename argv ) } {}
+    ? ( bx_streq name `cat` ) { ^ ( ap_cat argv ) } {}
+    ? ( bx_streq name `chmod` ) { ^ ( ap_chmod argv ) } {}
+    ? ( bx_streq name `cksum` ) { ^ ( ap_cksum argv ) } {}
+    ? ( bx_streq name `clear` ) { ^ ( ap_clear argv ) } {}
+    ? ( bx_streq name `cp` ) { ^ ( ap_cp argv ) } {}
+    ? ( bx_streq name `crc32` ) { ^ ( ap_crc32 argv ) } {}
+    ? ( bx_streq name `cut` ) { ^ ( ap_cut argv ) } {}
+    ? ( bx_streq name `date` ) { ^ ( ap_date argv ) } {}
+    ? ( bx_streq name `dirname` ) { ^ ( ap_dirname argv ) } {}
+    ? ( bx_streq name `du` ) { ^ ( ap_du argv ) } {}
+    ? ( bx_streq name `echo` ) { ^ ( ap_echo argv ) } {}
+    ? ( bx_streq name `egrep` ) { ^ ( ap_grep argv ) } {}
+    ? ( bx_streq name `env` ) { ^ ( ap_env argv ) } {}
+    ? ( bx_streq name `expr` ) { ^ ( ap_expr argv ) } {}
+    ? ( bx_streq name `false` ) { ^ 1 } {}
+    ? ( bx_streq name `fgrep` ) { ^ ( ap_grep argv ) } {}
+    ? ( bx_streq name `find` ) { ^ ( ap_find argv ) } {}
+    ? ( bx_streq name `grep` ) { ^ ( ap_grep argv ) } {}
+    ? ( bx_streq name `groups` ) { ^ ( ap_groups argv ) } {}
+    ? ( bx_streq name `head` ) { ^ ( ap_head argv ) } {}
+    ? ( bx_streq name `hostname` ) { ^ ( ap_hostname argv ) } {}
+    ? ( bx_streq name `id` ) { ^ ( ap_id argv ) } {}
+    ? ( bx_streq name `ln` ) { ^ ( ap_ln argv ) } {}
+    ? ( bx_streq name `logname` ) { ^ ( ap_logname argv ) } {}
+    ? ( bx_streq name `ls` ) { ^ ( ap_ls argv ) } {}
+    ? ( bx_streq name `md5sum` ) { ^ ( ap_md5sum argv ) } {}
+    ? ( bx_streq name `mkdir` ) { ^ ( ap_mkdir argv ) } {}
+    ? ( bx_streq name `mktemp` ) { ^ ( ap_mktemp argv ) } {}
+    ? ( bx_streq name `mv` ) { ^ ( ap_mv argv ) } {}
+    ? ( bx_streq name `nl` ) { ^ ( ap_nl argv ) } {}
+    ? ( bx_streq name `nproc` ) { ^ ( ap_nproc argv ) } {}
+    ? ( bx_streq name `printenv` ) { ^ ( ap_printenv argv ) } {}
+    ? ( bx_streq name `printf` ) { ^ ( ap_printf argv ) } {}
+    ? ( bx_streq name `pwd` ) { ^ ( ap_pwd argv ) } {}
+    ? ( bx_streq name `readlink` ) { ^ ( ap_readlink argv ) } {}
+    ? ( bx_streq name `realpath` ) { ^ ( ap_realpath argv ) } {}
+    ? ( bx_streq name `rev` ) { ^ ( ap_rev argv ) } {}
+    ? ( bx_streq name `rm` ) { ^ ( ap_rm argv ) } {}
+    ? ( bx_streq name `rmdir` ) { ^ ( ap_rmdir argv ) } {}
+    ? ( bx_streq name `sed` ) { ^ ( ap_sed argv ) } {}
+    ? ( bx_streq name `seq` ) { ^ ( ap_seq argv ) } {}
+    ? ( bx_streq name `sha1sum` ) { ^ ( ap_sha1sum argv ) } {}
+    ? ( bx_streq name `sha256sum` ) { ^ ( ap_sha256sum argv ) } {}
+    ? ( bx_streq name `sha512sum` ) { ^ ( ap_sha512sum argv ) } {}
+    ? ( bx_streq name `sleep` ) { ^ ( ap_sleep argv ) } {}
+    ? ( bx_streq name `sort` ) { ^ ( ap_sort argv ) } {}
+    ? ( bx_streq name `stat` ) { ^ ( ap_stat argv ) } {}
+    ? ( bx_streq name `sync` ) { ^ ( ap_sync argv ) } {}
+    ? ( bx_streq name `tac` ) { ^ ( ap_tac argv ) } {}
+    ? ( bx_streq name `tail` ) { ^ ( ap_tail argv ) } {}
+    ? ( bx_streq name `tee` ) { ^ ( ap_tee argv ) } {}
+    ? ( bx_streq name `test` ) { ^ ( ap_test argv ) } {}
+    ? ( bx_streq name `touch` ) { ^ ( ap_touch argv ) } {}
+    ? ( bx_streq name `tr` ) { ^ ( ap_tr argv ) } {}
+    ? ( bx_streq name `true` ) { ^ 0 } {}
+    ? ( bx_streq name `truncate` ) { ^ ( ap_truncate argv ) } {}
+    ? ( bx_streq name `tty` ) { ^ ( ap_tty argv ) } {}
+    ? ( bx_streq name `uname` ) { ^ ( ap_uname argv ) } {}
+    ? ( bx_streq name `uniq` ) { ^ ( ap_uniq argv ) } {}
+    ? ( bx_streq name `usleep` ) { ^ ( ap_usleep argv ) } {}
+    ? ( bx_streq name `wc` ) { ^ ( ap_wc argv ) } {}
+    ? ( bx_streq name `which` ) { ^ ( ap_which argv ) } {}
+    ? ( bx_streq name `whoami` ) { ^ ( ap_whoami argv ) } {}
+    ? ( bx_streq name `xargs` ) { ^ ( ap_xargs argv ) } {}
+    ? ( bx_streq name `yes` ) { ^ ( ap_yes argv ) } {}
+    ( bx_set_name `nurlbox` )
+    ( bx_err_at name `applet not found` )
+    ^ 127
+}
+
+@ __list_applets → v {
+    ( nurl_print `nurlbox ` )
+    ( nurl_print NURLBOX_VERSION )
+    ( nurl_print ` — a multi-call binary of UNIX utilities, in NURL.\n\n` )
+    ( nurl_print `Usage: nurlbox [applet] [arguments]...\n` )
+    ( nurl_print `   or: applet [arguments]...\n\n` )
+    ( nurl_print `Currently defined applets:\n` )
+    : ( Vec String ) names ( __applet_names )
+    : i n ( vec_len [String] names )
+    : ~ i i 0
+    : ~ i col 0
+    ~ < i n {
+        ( nurl_print ? == col 0 `\t` `, ` )
+        ( nurl_print ( bx_at names i ) )
+        = col + col 1
+        ? >= col 8 { ( nurl_print `\n` ) = col 0 } {}
+        = i + i 1
+    }
+    ? > col 0 { ( nurl_print `\n` ) } {}
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+}
+
+// Is `name` one of ours? A binary invoked under a name it does not
+// implement is the MULTIPLEXER — that is how `nurlbox` behaves when the
+// unikernel's loader calls it `main`, and how a copy named anything else
+// still works.
+@ __is_applet s name → b {
+    : ( Vec String ) names ( __applet_names )
+    : i n ( vec_len [String] names )
+    : ~ b found F
+    : ~ i i 0
+    ~ < i n {
+        ? ( bx_streq ( bx_at names i ) name ) { = found T } {}
+        = i + i 1
+    }
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+    ^ found
+}
+
+@ main → i {
+    : ( Vec String ) argv ( env_args_list )
+    : String me ( __invoked_as argv )
+    : ~ i rc 0
+    ? ! ( __is_applet ( string_data me ) ) {
+        ? < ( vec_len [String] argv ) 2 {
+            ( __list_applets )
+            = rc 0
+        } {
+            : s sub ( bx_at argv 1 )
+            ? | ( bx_streq sub `--help` ) ( bx_streq sub `-h` ) {
+                ( __list_applets )
+                = rc 0
+            } {
+                ? | ( bx_streq sub `--version` ) ( bx_streq sub `-V` ) {
+                    ( nurl_print `nurlbox ` )
+                    ( nurl_print NURLBOX_VERSION )
+                    ( nurl_print `\n` )
+                    = rc 0
+                } {
+                    // shift: the applet sees argv[0] = its own name
+                    : ( Vec String ) sub_argv ( vec_new [String] )
+                    : i n ( vec_len [String] argv )
+                    : ~ i i 1
+                    ~ < i n {
+                        ( vec_push [String] sub_argv ( string_from ( bx_at argv i ) ) )
+                        = i + i 1
+                    }
+                    = rc ( __run sub sub_argv )
+                    ( vec_free_with [String] sub_argv \ String x → v { ( string_free x ) } )
+                }
+            }
+        }
+    } {
+        = rc ( __run ( string_data me ) argv )
+    }
+    ( string_free me )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}

--- a/packages/nurlbox/src/sed.nu
+++ b/packages/nurlbox/src/sed.nu
@@ -1,0 +1,824 @@
+// nurlbox/sed.nu — the stream editor.
+//
+// Addresses (`N`, `$`, `/re/`, ranges, `!`), the substitute command with
+// its `g` / `p` / `i` / Nth-occurrence flags and `&` / `\1` back
+// references, the hold space, transliteration, branches and labels, and
+// `{ }` blocks.
+//
+// Back references are why `stdlib/ext/regex.nu` grew capture groups: a
+// sed whose `s/\(a\)\(b\)/\2\1/` silently produced nothing would be a
+// sed nobody could use, and the honest place to fix that was the engine,
+// not this file.
+//
+// Regular expressions follow POSIX: `sed` is BASIC (so `\(` groups and a
+// bare `+` is a literal plus), `sed -E` is EXTENDED. The translation is
+// grep.nu's `_bre_to_ere`, shared rather than written twice.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/ext/regex.nu`
+$ `bx.nu`
+$ `grep.nu`
+
+: i SED_ADDR_NONE 0
+: i SED_ADDR_LINE 1
+: i SED_ADDR_LAST 2
+: i SED_ADDR_RE 3
+
+: SedCmd {
+    i a1kind
+    i a1line
+    Regex a1re
+    i a2kind
+    i a2line
+    Regex a2re
+    b negate
+    i cmd  // the command letter's byte
+    Regex re  // s/// pattern
+    b has_re
+    String arg1  // s replacement / y source / a,i,c text / label / filename
+    String arg2  // y destination
+    i sflags  // 1 = g, 2 = p, 4 = i
+    i soccur  // Nth occurrence (0 = first)
+    i jump  // `{` → index just past the matching `}`
+}
+
+: i SED_S_GLOBAL 1
+: i SED_S_PRINT 2
+: i SED_S_ICASE 4
+
+@ __sed_cmd_free SedCmd c → v {
+    ? . c has_re { ( regex_free . c re ) } {}
+    ? == . c a1kind SED_ADDR_RE { ( regex_free . c a1re ) } {}
+    ? == . c a2kind SED_ADDR_RE { ( regex_free . c a2re ) } {}
+    ( string_free . c arg1 )
+    ( string_free . c arg2 )
+}
+
+// ── Script parsing ────────────────────────────────────────────────
+
+: ~ i g_sed_pos 0
+: ~ b g_sed_bad F
+: ~ b g_sed_ere F
+
+@ __sed_at s src i n → i { ^ ? < g_sed_pos n ( nurl_str_get src g_sed_pos ) 0 }
+
+@ __sed_skip_ws s src i n → v {
+    ~ & < g_sed_pos n | | == ( nurl_str_get src g_sed_pos ) 32 == ( nurl_str_get src g_sed_pos ) 9 == ( nurl_str_get src g_sed_pos ) 59 {
+        = g_sed_pos + g_sed_pos 1
+    }
+}
+
+// Read a delimited chunk starting just past the delimiter; `\<delim>`
+// escapes it, and the delimiter itself ends the chunk.
+@ __sed_chunk s src i n i delim String out → b {
+    ( string_clear out )
+    ~ < g_sed_pos n {
+        : i c ( nurl_str_get src g_sed_pos )
+        ? == c delim {
+            = g_sed_pos + g_sed_pos 1
+            ^ T
+        } {}
+        ? & == c 92 < + g_sed_pos 1 n {
+            : i e ( nurl_str_get src + g_sed_pos 1 )
+            ? == e delim {
+                ( string_push_char out delim )
+            } {
+                ( string_push_char out 92 )
+                ( string_push_char out e )
+            }
+            = g_sed_pos + g_sed_pos 2
+        } {
+            ( string_push_char out c )
+            = g_sed_pos + g_sed_pos 1
+        }
+    }
+    ^ F
+}
+
+@ __sed_compile_re String pat b icase → Regex {
+    : String work ? icase ( _grep_lower ( string_data pat ) ) ( string_clone pat )
+    : String ere ? g_sed_ere ( string_clone work ) ( _bre_to_ere ( string_data work ) )
+    : ~ Regex out @ Regex { # s 0 }
+    ?? ( regex_compile ( string_data ere ) ) {
+        T r → { = out r }
+        F _ → { = g_sed_bad T }
+    }
+    ( string_free ere )
+    ( string_free work )
+    ^ out
+}
+
+// One address, if there is one at the cursor.
+@ __sed_addr s src i n inout i kind inout i line inout Regex re → v {
+    = kind SED_ADDR_NONE
+    = line 0
+    : i c ( __sed_at src n )
+    ? == c 36 {
+        = kind SED_ADDR_LAST
+        = g_sed_pos + g_sed_pos 1
+        ^
+    } {}
+    ? ( bx_is_digit c ) {
+        : ~ i v 0
+        ~ & < g_sed_pos n ( bx_is_digit ( nurl_str_get src g_sed_pos ) ) {
+            = v + * v 10 - ( nurl_str_get src g_sed_pos ) 48
+            = g_sed_pos + g_sed_pos 1
+        }
+        = kind SED_ADDR_LINE
+        = line v
+        ^
+    } {}
+    ? == c 47 {
+        = g_sed_pos + g_sed_pos 1
+        : String pat ( string_new )
+        ? ! ( __sed_chunk src n 47 pat ) { = g_sed_bad T } {}
+        // A trailing `I` asks for a case-insensitive address.
+        : ~ b icase F
+        ? & < g_sed_pos n == ( nurl_str_get src g_sed_pos ) 73 {
+            = icase T
+            = g_sed_pos + g_sed_pos 1
+        } {}
+        = re ( __sed_compile_re pat icase )
+        = kind SED_ADDR_RE
+        ( string_free pat )
+        ^
+    } {}
+}
+
+// Text for `a` / `i` / `c`: either `a\` + newline + text, or the GNU
+// one-liner `a text`.
+@ __sed_text s src i n String out → v {
+    ( string_clear out )
+    ? & < g_sed_pos n == ( nurl_str_get src g_sed_pos ) 92 { = g_sed_pos + g_sed_pos 1 } {}
+    ? & < g_sed_pos n == ( nurl_str_get src g_sed_pos ) 10 { = g_sed_pos + g_sed_pos 1 } {}
+    ~ & < g_sed_pos n | == ( nurl_str_get src g_sed_pos ) 32 == ( nurl_str_get src g_sed_pos ) 9 {
+        = g_sed_pos + g_sed_pos 1
+    }
+    ~ < g_sed_pos n {
+        : i c ( nurl_str_get src g_sed_pos )
+        ? == c 10 {
+            = g_sed_pos + g_sed_pos 1
+            ^
+        } {}
+        ? & == c 92 < + g_sed_pos 1 n {
+            ( string_push_char out ( nurl_str_get src + g_sed_pos 1 ) )
+            = g_sed_pos + g_sed_pos 2
+        } {
+            ( string_push_char out c )
+            = g_sed_pos + g_sed_pos 1
+        }
+    }
+}
+
+@ __sed_word s src i n String out → v {
+    ( string_clear out )
+    ~ & < g_sed_pos n | == ( nurl_str_get src g_sed_pos ) 32 == ( nurl_str_get src g_sed_pos ) 9 {
+        = g_sed_pos + g_sed_pos 1
+    }
+    ~ < g_sed_pos n {
+        : i c ( nurl_str_get src g_sed_pos )
+        ? | | | == c 10 == c 59 == c 32 == c 125 { ^ } {}
+        ( string_push_char out c )
+        = g_sed_pos + g_sed_pos 1
+    }
+}
+
+@ __sed_parse s src ( Vec SedCmd ) out → v {
+    : i n ( nurl_str_len src )
+    = g_sed_pos 0
+    ~ < g_sed_pos n {
+        ( __sed_skip_ws src n )
+        ~ & < g_sed_pos n == ( nurl_str_get src g_sed_pos ) 10 { = g_sed_pos + g_sed_pos 1 ( __sed_skip_ws src n ) }
+        ? >= g_sed_pos n { ^ } {}
+        // A comment runs to end of line.
+        ? == ( nurl_str_get src g_sed_pos ) 35 {
+            ~ & < g_sed_pos n != ( nurl_str_get src g_sed_pos ) 10 { = g_sed_pos + g_sed_pos 1 }
+        } {
+            : ~ i a1kind 0
+            : ~ i a1line 0
+            : ~ Regex a1re @ Regex { # s 0 }
+            : ~ i a2kind 0
+            : ~ i a2line 0
+            : ~ Regex a2re @ Regex { # s 0 }
+            ( __sed_addr src n a1kind a1line a1re )
+            ? & != a1kind SED_ADDR_NONE == ( __sed_at src n ) 44 {
+                = g_sed_pos + g_sed_pos 1
+                ( __sed_addr src n a2kind a2line a2re )
+            } {}
+            : ~ b negate F
+            ~ & < g_sed_pos n == ( nurl_str_get src g_sed_pos ) 33 {
+                = negate ! negate
+                = g_sed_pos + g_sed_pos 1
+            }
+            ( __sed_skip_ws src n )
+            ? >= g_sed_pos n { ^ } {}
+            : i cmd ( nurl_str_get src g_sed_pos )
+            = g_sed_pos + g_sed_pos 1
+            : String arg1 ( string_new )
+            : String arg2 ( string_new )
+            : ~ Regex re @ Regex { # s 0 }
+            : ~ b has_re F
+            : ~ i sflags 0
+            : ~ i soccur 0
+            ? == cmd 115 {  // s
+                : i delim ( __sed_at src n )
+                = g_sed_pos + g_sed_pos 1
+                : String pat ( string_new )
+                ? ! ( __sed_chunk src n delim pat ) { = g_sed_bad T } {}
+                ? ! ( __sed_chunk src n delim arg1 ) { = g_sed_bad T } {}
+                // Flags run until the command separator.
+                : ~ b more T
+                ~ & more < g_sed_pos n {
+                    : i f ( nurl_str_get src g_sed_pos )
+                    ? == f 103 { = sflags | sflags SED_S_GLOBAL = g_sed_pos + g_sed_pos 1 } {
+                        ? == f 112 { = sflags | sflags SED_S_PRINT = g_sed_pos + g_sed_pos 1 } {
+                            ? | == f 105 == f 73 { = sflags | sflags SED_S_ICASE = g_sed_pos + g_sed_pos 1 } {
+                                ? ( bx_is_digit f ) {
+                                    : ~ i v 0
+                                    ~ & < g_sed_pos n ( bx_is_digit ( nurl_str_get src g_sed_pos ) ) {
+                                        = v + * v 10 - ( nurl_str_get src g_sed_pos ) 48
+                                        = g_sed_pos + g_sed_pos 1
+                                    }
+                                    = soccur ? > v 0 - v 1 0
+                                } { = more F } } } }
+                }
+                = re ( __sed_compile_re pat != 0 & sflags SED_S_ICASE )
+                = has_re T
+                ( string_free pat )
+            } {
+                ? == cmd 121 {  // y
+                    : i delim ( __sed_at src n )
+                    = g_sed_pos + g_sed_pos 1
+                    ? ! ( __sed_chunk src n delim arg1 ) { = g_sed_bad T } {}
+                    ? ! ( __sed_chunk src n delim arg2 ) { = g_sed_bad T } {}
+                } {
+                    ? | | == cmd 97 == cmd 105 == cmd 99 {  // a i c
+                        ( __sed_text src n arg1 )
+                    } {
+                        ? | | | | == cmd 98 == cmd 116 == cmd 58 == cmd 114 == cmd 119 {  // b t : r w
+                            ( __sed_word src n arg1 )
+                        } {}
+                    }
+                }
+            }
+            ( vec_push [SedCmd] out @ SedCmd {
+                a1kind a1line a1re a2kind a2line a2re negate cmd re has_re arg1 arg2 sflags soccur -1
+            } )
+        }
+    }
+}
+
+// Resolve every `{` to the index just past its `}`.
+@ __sed_link ( Vec SedCmd ) cmds → v {
+    : i n ( vec_len [SedCmd] cmds )
+    : ( Vec i ) stack ( vec_new [i] )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [SedCmd] cmds i ) {
+            T c → {
+                ? == . c cmd 123 { ( vec_push [i] stack i ) } {}
+                ? == . c cmd 125 {
+                    ?? ( vec_pop [i] stack ) {
+                        T open → {
+                            ?? ( vec_get [SedCmd] cmds open ) {
+                                T oc → {
+                                    : b _ok ( vec_set [SedCmd] cmds open @ SedCmd {
+                                        . oc a1kind . oc a1line . oc a1re . oc a2kind . oc a2line . oc a2re
+                                        . oc negate . oc cmd . oc re . oc has_re . oc arg1 . oc arg2
+                                        . oc sflags . oc soccur + i 1
+                                    } )
+                                }
+                                F _ → {}
+                            }
+                        }
+                        F _ → {}
+                    }
+                } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ( vec_free [i] stack )
+}
+
+// ── Execution ─────────────────────────────────────────────────────
+
+@ __sed_re_hit Regex r b icase String line → b {
+    ? icase {
+        : String lo ( _grep_lower ( string_data line ) )
+        : b h ( regex_test r ( string_data lo ) )
+        ( string_free lo )
+        ^ h
+    } {}
+    ^ ( regex_test r ( string_data line ) )
+}
+
+// Does this command apply to the current line? `ranges` carries each
+// command's open/closed range state across lines.
+@ __sed_selects SedCmd c ( Vec i ) ranges i idx i lineno b is_last String line → b {
+    : ~ b hit F
+    ? == . c a1kind SED_ADDR_NONE {
+        = hit T
+    } {
+        : ~ i state 0
+        ?? ( vec_get [i] ranges idx ) { T x → { = state x } F _ → {} }
+        ? == . c a2kind SED_ADDR_NONE {
+            ? == . c a1kind SED_ADDR_LINE { = hit == lineno . c a1line } {}
+            ? == . c a1kind SED_ADDR_LAST { = hit is_last } {}
+            ? == . c a1kind SED_ADDR_RE { = hit ( __sed_re_hit . c a1re F line ) } {}
+        } {
+            ? == state 0 {
+                : ~ b starts F
+                ? == . c a1kind SED_ADDR_LINE { = starts == lineno . c a1line } {}
+                ? == . c a1kind SED_ADDR_LAST { = starts is_last } {}
+                ? == . c a1kind SED_ADDR_RE { = starts ( __sed_re_hit . c a1re F line ) } {}
+                ? starts {
+                    = hit T
+                    // A numeric end address already passed means the
+                    // range covers exactly this one line.
+                    : ~ b closes F
+                    ? == . c a2kind SED_ADDR_LINE { = closes <= . c a2line lineno } {}
+                    : b _s ( vec_set [i] ranges idx ? closes 0 1 )
+                } {}
+            } {
+                = hit T
+                : ~ b ends F
+                ? == . c a2kind SED_ADDR_LINE { = ends >= lineno . c a2line } {}
+                ? == . c a2kind SED_ADDR_LAST { = ends is_last } {}
+                ? == . c a2kind SED_ADDR_RE { = ends ( __sed_re_hit . c a2re F line ) } {}
+                ? ends { : b _s ( vec_set [i] ranges idx 0 ) } {}
+            }
+        }
+    }
+    ^ ? . c negate ! hit hit
+}
+
+// s/// over the pattern space. Returns T when anything changed.
+@ __sed_subst SedCmd c String space → b {
+    : b global != 0 & . c sflags SED_S_GLOBAL
+    : b icase != 0 & . c sflags SED_S_ICASE
+    : String probe ? icase ( _grep_lower ( string_data space ) ) ( string_clone space )
+    : String out ( string_new )
+    : ( Vec i ) slots ( vec_new [i] )
+    : i n ( string_len space )
+    : ~ i pos 0
+    : ~ i seen 0
+    : ~ b changed F
+    : ~ b more T
+    ~ & more <= pos n {
+        : s tail ( nurl_str_slice ( string_data probe ) pos - n pos )
+        ?? ( regex_find_caps . c re tail slots ) {
+            T m → {
+                : i abs + pos . m start
+                : i len . m len
+                // Copy the untouched run before the match.
+                : ~ i k pos
+                ~ < k abs {
+                    ( string_push_char out ( string_get space k ) )
+                    = k + k 1
+                }
+                : b use | global >= seen . c soccur
+                ? & use | global == seen . c soccur {
+                    // The slots are relative to `tail`; shift them onto
+                    // the pattern space before expanding.
+                    : i ns ( vec_len [i] slots )
+                    : ~ i j 0
+                    ~ < j ns {
+                        ?? ( vec_get [i] slots j ) {
+                            T v → { ? >= v 0 { : b _q ( vec_set [i] slots j + v pos ) } {} }
+                            F _ → {}
+                        }
+                        = j + j 1
+                    }
+                    : String rep ( regex_expand ( string_data space ) slots ( string_data . c arg1 ) )
+                    ( string_push_bytes out # *u ( string_data rep ) ( string_len rep ) )
+                    ( string_free rep )
+                    = changed T
+                } {
+                    : ~ i k2 abs
+                    ~ < k2 + abs len {
+                        ( string_push_char out ( string_get space k2 ) )
+                        = k2 + k2 1
+                    }
+                }
+                = seen + seen 1
+                ? == len 0 {
+                    ? < + abs 0 n { ( string_push_char out ( string_get space abs ) ) } {}
+                    = pos + abs 1
+                } { = pos + abs len }
+                ? & changed ! global { = more F } {}
+            }
+            F _ → { = more F }
+        }
+    }
+    : ~ i k3 pos
+    ~ < k3 n {
+        ( string_push_char out ( string_get space k3 ) )
+        = k3 + k3 1
+    }
+    ? changed {
+        ( string_clear space )
+        ( string_push_bytes space # *u ( string_data out ) ( string_len out ) )
+    } {}
+    ( vec_free [i] slots )
+    ( string_free out )
+    ( string_free probe )
+    ^ changed
+}
+
+@ __sed_translit SedCmd c String space → v {
+    : s from ( string_data . c arg1 )
+    : s to ( string_data . c arg2 )
+    : i fn ( nurl_str_len from )
+    : i tn ( nurl_str_len to )
+    : i n ( string_len space )
+    : String out ( string_new )
+    : ~ i i 0
+    ~ < i n {
+        : i ch ( string_get space i )
+        : ~ i outc ch
+        : ~ i j 0
+        ~ < j fn {
+            ? == ( nurl_str_get from j ) ch {
+                = outc ? < j tn ( nurl_str_get to j ) ch
+                = j fn
+            } { = j + j 1 }
+        }
+        ( string_push_char out outc )
+        = i + i 1
+    }
+    ( string_clear space )
+    ( string_push_bytes space # *u ( string_data out ) ( string_len out ) )
+    ( string_free out )
+}
+
+// A file whose last line has no newline must not grow one — `sed` is a
+// filter, and a filter that silently appends a byte breaks every
+// checksum downstream of it. The missing terminator is therefore
+// remembered rather than invented: if anything else is printed after
+// such a line, the newline that separates them is emitted then.
+: ~ b g_sed_nonl F
+
+@ __sed_out_prep String out → v {
+    ? g_sed_nonl {
+        ( string_push_char out 10 )
+        = g_sed_nonl F
+    } {}
+}
+
+@ __sed_emit String out String line b had_nl → v {
+    ( __sed_out_prep out )
+    ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+    ? had_nl { ( string_push_char out 10 ) } { = g_sed_nonl T }
+}
+
+// Read one line, keeping whether it carried a terminator.
+@ __sed_read BufReader br String raw String dst inout b had_nl → b {
+    ? ! ( bufreader_read_line_raw br raw ) {
+        = had_nl F
+        ^ F
+    } {}
+    : i n ( string_len raw )
+    : ~ i body n
+    = had_nl F
+    // Only '\n' is a terminator: a '\r' is DATA, and every sed keeps it
+    // in the pattern space so `s/\r$//` has something to remove.
+    ? & > body 0 == ( string_get raw - body 1 ) 10 {
+        = body - body 1
+        = had_nl T
+    } {}
+    ( string_clear dst )
+    ( string_push_bytes dst # *u ( string_data raw ) body )
+    ^ T
+}
+
+// Find the index of a label, or -1.
+@ __sed_label ( Vec SedCmd ) cmds String name → i {
+    : i n ( vec_len [SedCmd] cmds )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [SedCmd] cmds i ) {
+            T c → {
+                ? & == . c cmd 58 ( string_eq . c arg1 name ) { ^ i } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ^ -1
+}
+
+: ~ b g_sed_quit F
+: ~ i g_sed_rc 0
+
+@ __sed_stream ( Vec SedCmd ) cmds ( Vec i ) ranges s path b quiet String out → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String space ( string_new )
+            : String ahead ( string_new )
+            : String raw ( string_new )
+            : ~ b space_nl T
+            : ~ b ahead_nl T
+            : String hold ( string_new )
+            : String append ( string_new )
+            : ~ b have_space F
+            : ~ b have_ahead F
+            : ~ i lineno 0
+            : i ncmds ( vec_len [SedCmd] cmds )
+            = g_sed_nonl F
+            = have_space ( __sed_read br raw space space_nl )
+            = have_ahead ( __sed_read br raw ahead ahead_nl )
+            ~ & have_space ! g_sed_quit {
+                = lineno + lineno 1
+                : ~ b is_last ! have_ahead
+                : ~ b deleted F
+                : ~ b tflag F
+                : ~ b restart T
+                ~ restart {
+                    = restart F
+                    : ~ i pc 0
+                    ~ & < pc ncmds ! deleted {
+                        : ~ i next + pc 1
+                        ?? ( vec_get [SedCmd] cmds pc ) {
+                            T c → {
+                                : b sel ( __sed_selects c ranges pc lineno is_last space )
+                                : i k . c cmd
+                                // A flat chain of guarded statements, not
+                                // a nested ternary: the dispatch is two
+                                // dozen arms deep and one mis-nested
+                                // brace in a prefix-ternary tower is a
+                                // bug you find by counting.
+                                ? & == k 123 ! sel { = next . c jump } {}
+                                ? & sel == k 115 {
+                                    ? ( __sed_subst c space ) {
+                                        = tflag T
+                                        ? != 0 & . c sflags SED_S_PRINT { ( __sed_emit out space space_nl ) } {}
+                                    } {}
+                                } {}
+                                ? & sel == k 112 { ( __sed_emit out space space_nl ) } {}
+                                ? & sel == k 80 {
+                                    : i pn ( string_len space )
+                                    : ~ i e 0
+                                    ~ & < e pn != ( string_get space e ) 10 { = e + e 1 }
+                                    ( __sed_out_prep out )
+                                    ( string_push_bytes out # *u ( string_data space ) e )
+                                    ( string_push_char out 10 )
+                                } {}
+                                ? & sel == k 100 { = deleted T } {}
+                                ? & sel == k 68 {
+                                    : i pn ( string_len space )
+                                    : ~ i e 0
+                                    ~ & < e pn != ( string_get space e ) 10 { = e + e 1 }
+                                    ? >= e pn { = deleted T } {
+                                        : String rest ( string_substr space + e 1 - pn + e 1 )
+                                        ( string_clear space )
+                                        ( string_push_bytes space # *u ( string_data rest ) ( string_len rest ) )
+                                        ( string_free rest )
+                                        = restart T
+                                        = next ncmds
+                                    }
+                                } {}
+                                ? & sel == k 113 {
+                                    ? ! quiet { ( __sed_emit out space space_nl ) } {}
+                                    = g_sed_quit T
+                                    = deleted T
+                                } {}
+                                ? & sel == k 110 {
+                                    ? ! quiet { ( __sed_emit out space space_nl ) } {}
+                                    ? have_ahead {
+                                        ( string_clear space )
+                                        ( string_push_bytes space # *u ( string_data ahead ) ( string_len ahead ) )
+                                        = space_nl ahead_nl
+                                        = lineno + lineno 1
+                                        = have_ahead ( __sed_read br raw ahead ahead_nl )
+                                        = is_last ! have_ahead
+                                    } {
+                                        = deleted T
+                                        = have_space F
+                                    }
+                                } {}
+                                ? & sel == k 78 {
+                                    ? have_ahead {
+                                        ( string_push_char space 10 )
+                                        ( string_push_bytes space # *u ( string_data ahead ) ( string_len ahead ) )
+                                        = space_nl ahead_nl
+                                        = lineno + lineno 1
+                                        = have_ahead ( __sed_read br raw ahead ahead_nl )
+                                        = is_last ! have_ahead
+                                    } { = next ncmds }
+                                } {}
+                                ? & sel == k 61 {
+                                    ( __sed_out_prep out )
+                                    ( string_push_int out lineno )
+                                    ( string_push_char out 10 )
+                                } {}
+                                ? & sel == k 97 {
+                                    ( string_push_bytes append # *u ( string_data . c arg1 ) ( string_len . c arg1 ) )
+                                    ( string_push_char append 10 )
+                                } {}
+                                ? & sel == k 105 {
+                                    ( __sed_out_prep out )
+                                    ( string_push_bytes out # *u ( string_data . c arg1 ) ( string_len . c arg1 ) )
+                                    ( string_push_char out 10 )
+                                } {}
+                                ? & sel == k 99 {
+                                    ( __sed_out_prep out )
+                                    ( string_push_bytes out # *u ( string_data . c arg1 ) ( string_len . c arg1 ) )
+                                    ( string_push_char out 10 )
+                                    = deleted T
+                                } {}
+                                ? & sel == k 121 { ( __sed_translit c space ) } {}
+                                ? & sel == k 104 {
+                                    ( string_clear hold )
+                                    ( string_push_bytes hold # *u ( string_data space ) ( string_len space ) )
+                                } {}
+                                ? & sel == k 72 {
+                                    ( string_push_char hold 10 )
+                                    ( string_push_bytes hold # *u ( string_data space ) ( string_len space ) )
+                                } {}
+                                ? & sel == k 103 {
+                                    ( string_clear space )
+                                    ( string_push_bytes space # *u ( string_data hold ) ( string_len hold ) )
+                                } {}
+                                ? & sel == k 71 {
+                                    ( string_push_char space 10 )
+                                    ( string_push_bytes space # *u ( string_data hold ) ( string_len hold ) )
+                                } {}
+                                ? & sel == k 120 {
+                                    : String tmp ( string_clone space )
+                                    ( string_clear space )
+                                    ( string_push_bytes space # *u ( string_data hold ) ( string_len hold ) )
+                                    ( string_clear hold )
+                                    ( string_push_bytes hold # *u ( string_data tmp ) ( string_len tmp ) )
+                                    ( string_free tmp )
+                                } {}
+                                ? & sel == k 98 {
+                                    ? == ( string_len . c arg1 ) 0 { = next ncmds } {
+                                        : i t ( __sed_label cmds . c arg1 )
+                                        = next ? >= t 0 t ncmds
+                                    }
+                                } {}
+                                ? & sel == k 116 {
+                                    ? tflag {
+                                        = tflag F
+                                        ? == ( string_len . c arg1 ) 0 { = next ncmds } {
+                                            : i t ( __sed_label cmds . c arg1 )
+                                            = next ? >= t 0 t ncmds
+                                        }
+                                    } {}
+                                } {}
+                                ? & sel == k 114 {
+                                    ?? ( read_file ( string_data . c arg1 ) ) {
+                                        T txt → {
+                                            ( string_push_bytes append # *u ( string_data txt ) ( string_len txt ) )
+                                            ( string_free txt )
+                                        }
+                                        F _ → {}
+                                    }
+                                } {}
+                                ? & sel == k 119 {
+                                    ?? ( file_append ( string_data . c arg1 ) ) {
+                                        T f → {
+                                            : ( Vec u ) bytes ( vec_new [u] )
+                                            : i sn ( string_len space )
+                                            : ~ i q 0
+                                            ~ < q sn { ( vec_push [u] bytes # u ( string_get space q ) ) = q + q 1 }
+                                            ( vec_push [u] bytes # u 10 )
+                                            ?? ( file_write_chunk f bytes ) { T _ → {} F _ → {} }
+                                            ( vec_free [u] bytes )
+                                            ( file_close f )
+                                        }
+                                        F _ → {}
+                                    }
+                                } {}
+                            }
+                            F _ → {}
+                        }
+                        = pc next
+                    }
+                }
+                ? & ! deleted ! quiet { ( __sed_emit out space space_nl ) } {}
+                ? > ( string_len append ) 0 {
+                    ( __sed_out_prep out )
+                    ( string_push_bytes out # *u ( string_data append ) ( string_len append ) )
+                    ( string_clear append )
+                } {}
+                ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                ? & have_space ! g_sed_quit {
+                    ? have_ahead {
+                        ( string_clear space )
+                        ( string_push_bytes space # *u ( string_data ahead ) ( string_len ahead ) )
+                        = space_nl ahead_nl
+                        = have_ahead ( __sed_read br raw ahead ahead_nl )
+                    } { = have_space F }
+                } {}
+            }
+            ( string_free space )
+            ( string_free ahead )
+            ( string_free raw )
+            ( string_free hold )
+            ( string_free append )
+            ( bufreader_close br )
+            ^ 0
+        }
+    }
+}
+
+@ ap_sed ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ne:f:iErs` `quiet=n,silent=n,expression=e,file=f,in-place=i,regexp-extended=E,separate=s` )
+    : ~ i rc 0
+    = g_sed_quit F
+    = g_sed_rc 0
+    = g_sed_bad F
+    = g_sed_ere | ( bx_has o `E` ) ( bx_has o `r` )
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : String script ( string_new )
+        : ( Vec String ) exprs ( vec_new [String] )
+        ? ( bx_has o `e` ) { ( bx_vals o `e` exprs ) } {}
+        ? ( bx_has o `f` ) {
+            ?? ( read_file ( bx_val o `f` ) ) {
+                T txt → {
+                    ( vec_push [String] exprs txt )
+                }
+                F e → {
+                    ( bx_err_at ( bx_val o `f` ) ( bx_ioerr e ) )
+                    = rc 1
+                }
+            }
+        } {}
+        : i nops ( bx_operand_count o )
+        : ~ i first_file 0
+        ? == ( vec_len [String] exprs ) 0 {
+            ? > nops 0 {
+                ( vec_push [String] exprs ( string_from ( bx_operand o 0 ) ) )
+                = first_file 1
+            } {
+                ( bx_err `no script` )
+                = rc 1
+            }
+        } {}
+        : i ne ( vec_len [String] exprs )
+        : ~ i k 0
+        ~ < k ne {
+            ? > k 0 { ( string_push_char script 10 ) } {}
+            ( string_push_str script ( bx_at exprs k ) )
+            = k + k 1
+        }
+        ( bx_free_lines exprs )
+        ? == rc 0 {
+            : ( Vec SedCmd ) cmds ( vec_new [SedCmd] )
+            ( __sed_parse ( string_data script ) cmds )
+            ( __sed_link cmds )
+            ? g_sed_bad {
+                ( bx_err `invalid script` )
+                = rc 1
+            } {
+                : ( Vec i ) ranges ( vec_new [i] )
+                : ~ i q 0
+                ~ < q ( vec_len [SedCmd] cmds ) { ( vec_push [i] ranges 0 ) = q + q 1 }
+                : b quiet ( bx_has o `n` )
+                : i nfiles - nops first_file
+                : String out ( string_new )
+                ? == nfiles 0 {
+                    : i one ( __sed_stream cmds ranges `-` quiet out )
+                    ? != one 0 { = rc 1 } {}
+                    ( bx_write out )
+                } {
+                    : ~ i i first_file
+                    ~ & < i nops ! g_sed_quit {
+                        : s p ( bx_operand o i )
+                        ( string_clear out )
+                        : i one ( __sed_stream cmds ranges p quiet out )
+                        ? != one 0 { = rc 1 } {}
+                        ? ( bx_has o `i` ) {
+                            // -i replaces the file with what the script
+                            // produced. The write is a whole-file
+                            // replacement, so a script that fails part
+                            // way leaves the original untouched.
+                            ?? ( write_file p ( string_data out ) ) {
+                                T _ → {}
+                                F e → {
+                                    ( bx_err_at p ( bx_ioerr e ) )
+                                    = rc 1
+                                }
+                            }
+                        } { ( bx_write out ) }
+                        = i + i 1
+                    }
+                }
+                ( string_free out )
+                ( vec_free [i] ranges )
+            }
+            ( vec_free_with [SedCmd] cmds \ SedCmd c → v { ( __sed_cmd_free c ) } )
+        } {}
+        ( string_free script )
+    }
+    ( bx_opts_free o )
+    ^ ? != g_sed_rc 0 g_sed_rc rc
+}

--- a/packages/nurlbox/src/shell.nu
+++ b/packages/nurlbox/src/shell.nu
@@ -1,0 +1,619 @@
+// nurlbox/shell.nu — the applets a shell script is made of.
+//
+// test / [ / expr / xargs / timeout / nohup / basename-style plumbing.
+//
+// `test` and `expr` are where a clone earns its keep: they are called
+// once per loop iteration by every script in existence, and their
+// grammar is small but exact. Both are implemented as real parsers with
+// POSIX precedence, not as flag lists.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/regex.nu`
+$ `bx.nu`
+
+// ── test / [ ──────────────────────────────────────────────────────
+//
+// Grammar (POSIX):
+//   expr  := term ( '-o' term )*
+//   term  := factor ( '-a' factor )*
+//   factor:= '!' factor | '(' expr ')' | binary | unary | string
+//
+// A bare string is true when non-empty — which is why `test -n` with no
+// operand is true (the string "-n" is non-empty), a quirk POSIX
+// mandates and scripts rely on.
+
+: ~ i g_test_pos 0
+
+@ __test_tok ( Vec String ) t i idx → s { ^ ( bx_at t idx ) }
+
+@ __test_left ( Vec String ) t → i { ^ - ( vec_len [String] t ) g_test_pos }
+
+@ __test_is_unary s op → b {
+    ? != ( nurl_str_len op ) 2 { ^ F } {}
+    ? != ( nurl_str_get op 0 ) 45 { ^ F } {}
+    : i c ( nurl_str_get op 1 )
+    ^ | | | | | | | | | | | | | | == c 101 == c 102 == c 100 == c 114 == c 119 == c 120 == c 115 == c 76 == c 104 == c 98 == c 99 == c 112 == c 83 == c 116 | == c 122 == c 110
+}
+
+@ __test_is_binary s op → b {
+    ? | ( bx_streq op `=` ) | ( bx_streq op `!=` ) ( bx_streq op `==` ) { ^ T } {}
+    ? | ( bx_streq op `-eq` ) | ( bx_streq op `-ne` ) | ( bx_streq op `-lt` ) | ( bx_streq op `-le` ) | ( bx_streq op `-gt` ) ( bx_streq op `-ge` ) { ^ T } {}
+    ? | ( bx_streq op `-nt` ) | ( bx_streq op `-ot` ) ( bx_streq op `-ef` ) { ^ T } {}
+    ^ F
+}
+
+@ __test_unary s op s arg → b {
+    : i c ( nurl_str_get op 1 )
+    ? == c 122 { ^ == ( nurl_str_len arg ) 0 } {}
+    ? == c 110 { ^ != ( nurl_str_len arg ) 0 } {}
+    ? == c 116 { ^ ( term_is_tty ( nurl_str_to_int arg ) ) } {}
+    // Everything else asks the filesystem. -h / -L look at the link
+    // itself; the rest resolve it, which is what the shell does.
+    : !FileStat IoErr r ? | == c 104 == c 76 ( fs_lstat arg ) ( fs_stat arg )
+    ?? r {
+        F _ → { ^ F }
+        T st → {
+            ? == c 101 { ^ T } {}
+            ? == c 102 { ^ ( stat_is_file st ) } {}
+            ? == c 100 { ^ ( stat_is_dir st ) } {}
+            ? | == c 104 == c 76 { ^ ( stat_is_symlink st ) } {}
+            ? == c 115 { ^ > . st size 0 } {}
+            ? == c 98 { ^ == ( stat_kind st ) FS_KIND_BLOCKDEV } {}
+            ? == c 99 { ^ == ( stat_kind st ) FS_KIND_CHARDEV } {}
+            ? == c 112 { ^ == ( stat_kind st ) FS_KIND_FIFO } {}
+            ? == c 83 { ^ == ( stat_kind st ) FS_KIND_SOCKET } {}
+            // -r / -w / -x against the caller's own ids. The owner bits
+            // apply to the owner, the group bits to a member, otherwise
+            // the other bits — the same three-way choice the kernel makes.
+            : i m ( stat_mode_bits st )
+            : i uid # i ( geteuid )
+            : i gid # i ( getegid )
+            : ~ i bits & m 7
+            ? == . st uid uid { = bits & >> m 6 7 } {
+                ? == . st gid gid { = bits & >> m 3 7 } {}
+            }
+            ? == uid 0 {
+                // root reads and writes anything; execute still needs a
+                // bit set somewhere.
+                ? | == c 114 == c 119 { ^ T } {}
+                ? == c 120 { ^ != 0 & m 73 } {}
+            } {}
+            ? == c 114 { ^ != 0 & bits 4 } {}
+            ? == c 119 { ^ != 0 & bits 2 } {}
+            ? == c 120 { ^ != 0 & bits 1 } {}
+            ^ F
+        }
+    }
+}
+
+@ __test_binary s a s op s b → b {
+    ? | ( bx_streq op `=` ) ( bx_streq op `==` ) { ^ ( bx_streq a b ) } {}
+    ? ( bx_streq op `!=` ) { ^ ! ( bx_streq a b ) } {}
+    ? ( bx_streq op `-eq` ) { ^ == ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? ( bx_streq op `-ne` ) { ^ != ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? ( bx_streq op `-lt` ) { ^ < ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? ( bx_streq op `-le` ) { ^ <= ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? ( bx_streq op `-gt` ) { ^ > ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? ( bx_streq op `-ge` ) { ^ >= ( nurl_str_to_int a ) ( nurl_str_to_int b ) } {}
+    ? | | ( bx_streq op `-nt` ) ( bx_streq op `-ot` ) ( bx_streq op `-ef` ) {
+        ?? ( fs_stat a ) {
+            F _ → { ^ F }
+            T sa → {
+                ?? ( fs_stat b ) {
+                    F _ → { ^ ( bx_streq op `-nt` ) }
+                    T sb → {
+                        ? ( bx_streq op `-nt` ) { ^ > . sa mtime . sb mtime } {}
+                        ? ( bx_streq op `-ot` ) { ^ < . sa mtime . sb mtime } {}
+                        ^ & == . sa dev . sb dev == . sa ino . sb ino
+                    }
+                }
+            }
+        }
+    } {}
+    ^ F
+}
+
+@ __test_factor ( Vec String ) t → b {
+    ? <= ( __test_left t ) 0 { ^ F } {}
+    : s tok ( __test_tok t g_test_pos )
+    ? ( bx_streq tok `!` ) {
+        = g_test_pos + g_test_pos 1
+        ^ ! ( __test_factor t )
+    } {}
+    ? ( bx_streq tok `(` ) {
+        = g_test_pos + g_test_pos 1
+        : b r ( __test_expr t )
+        ? ( bx_streq ( __test_tok t g_test_pos ) `)` ) { = g_test_pos + g_test_pos 1 } {}
+        ^ r
+    } {}
+    // A binary operator two tokens ahead beats a unary one here: POSIX
+    // says `test -f = -f` compares two strings, and only the three-token
+    // reading gets that right.
+    ? >= ( __test_left t ) 3 {
+        : s op ( __test_tok t + g_test_pos 1 )
+        ? ( __test_is_binary op ) {
+            : s a ( __test_tok t g_test_pos )
+            : s b ( __test_tok t + g_test_pos 2 )
+            = g_test_pos + g_test_pos 3
+            ^ ( __test_binary a op b )
+        } {}
+    } {}
+    ? >= ( __test_left t ) 2 {
+        ? ( __test_is_unary tok ) {
+            : s arg ( __test_tok t + g_test_pos 1 )
+            = g_test_pos + g_test_pos 2
+            ^ ( __test_unary tok arg )
+        } {}
+    } {}
+    = g_test_pos + g_test_pos 1
+    ^ != ( nurl_str_len tok ) 0
+}
+
+@ __test_term ( Vec String ) t → b {
+    : ~ b acc ( __test_factor t )
+    ~ & > ( __test_left t ) 0 ( bx_streq ( __test_tok t g_test_pos ) `-a` ) {
+        = g_test_pos + g_test_pos 1
+        : b r ( __test_factor t )
+        = acc & acc r
+    }
+    ^ acc
+}
+
+@ __test_expr ( Vec String ) t → b {
+    : ~ b acc ( __test_term t )
+    ~ & > ( __test_left t ) 0 ( bx_streq ( __test_tok t g_test_pos ) `-o` ) {
+        = g_test_pos + g_test_pos 1
+        : b r ( __test_term t )
+        = acc | acc r
+    }
+    ^ acc
+}
+
+@ ap_test ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    : ( Vec String ) t ( vec_new [String] )
+    : ~ i last n
+    // `[ ... ]` must close; `test ... ` must not.
+    ? ( bx_streq ( bx_name ) `[` ) {
+        ? | < n 2 ! ( bx_streq ( bx_at argv - n 1 ) `]` ) {
+            ( bx_err `missing ]` )
+            ( vec_free [String] t )
+            ^ 2
+        } {}
+        = last - n 1
+    } {}
+    : ~ i i 1
+    ~ < i last {
+        ( vec_push [String] t ( string_from ( bx_at argv i ) ) )
+        = i + i 1
+    }
+    = g_test_pos 0
+    : ~ i rc 1
+    ? == ( vec_len [String] t ) 0 { = rc 1 } {
+        : b r ( __test_expr t )
+        = rc ? r 0 1
+    }
+    ( vec_free_with [String] t \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// ── expr ──────────────────────────────────────────────────────────
+//
+//   expr := or
+//   or   := and ( '|' and )*
+//   and  := cmp ( '&' cmp )*
+//   cmp  := sum ( ('='|'!='|'<'|'<='|'>'|'>=') sum )*
+//   sum  := term ( ('+'|'-') term )*
+//   term := match ( ('*'|'/'|'%') match )*
+//   match:= atom ( ':' atom )*
+//   atom := '(' or ')' | 'length' S | 'substr' S P L | 'index' S C | STRING
+
+: ~ i g_expr_pos 0
+: ~ b g_expr_err F
+
+@ __expr_tok ( Vec String ) t i idx → s { ^ ( bx_at t idx ) }
+
+@ __expr_left ( Vec String ) t → i { ^ - ( vec_len [String] t ) g_expr_pos }
+
+// expr has no types: every value is a string, and an operator that
+// wants a number parses one out. A string that is not a number is 0 for
+// arithmetic, which is what every expr does.
+@ __expr_num s v → i { ^ ( nurl_str_to_int v ) }
+
+@ __expr_is_num s v → b {
+    : i n ( nurl_str_len v )
+    ? == n 0 { ^ F } {}
+    : ~ i i ? == ( nurl_str_get v 0 ) 45 1 0
+    ? >= i n { ^ F } {}
+    ~ < i n {
+        ? ! ( bx_is_digit ( nurl_str_get v i ) ) { ^ F } {}
+        = i + i 1
+    }
+    ^ T
+}
+
+@ __expr_atom ( Vec String ) t → String {
+    ? <= ( __expr_left t ) 0 {
+        = g_expr_err T
+        ^ ( string_new )
+    } {}
+    : s tok ( __expr_tok t g_expr_pos )
+    ? ( bx_streq tok `(` ) {
+        = g_expr_pos + g_expr_pos 1
+        : String r ( __expr_or t )
+        ? & > ( __expr_left t ) 0 ( bx_streq ( __expr_tok t g_expr_pos ) `)` ) { = g_expr_pos + g_expr_pos 1 } { = g_expr_err T }
+        ^ r
+    } {}
+    ? & ( bx_streq tok `length` ) > ( __expr_left t ) 1 {
+        = g_expr_pos + g_expr_pos 2
+        ^ ( string_from ( nurl_str_int ( nurl_str_len ( __expr_tok t - g_expr_pos 1 ) ) ) )
+    } {}
+    ? & ( bx_streq tok `substr` ) > ( __expr_left t ) 3 {
+        : s src ( __expr_tok t + g_expr_pos 1 )
+        : i from ( __expr_num ( __expr_tok t + g_expr_pos 2 ) )
+        : i len ( __expr_num ( __expr_tok t + g_expr_pos 3 ) )
+        = g_expr_pos + g_expr_pos 4
+        : i n ( nurl_str_len src )
+        ? | | < from 1 > from n <= len 0 { ^ ( string_new ) } {}
+        : i take ? > + - from 1 len n - n - from 1 len
+        ^ ( string_from ( nurl_str_slice src - from 1 take ) )
+    } {}
+    ? & ( bx_streq tok `index` ) > ( __expr_left t ) 2 {
+        : s src ( __expr_tok t + g_expr_pos 1 )
+        : s set ( __expr_tok t + g_expr_pos 2 )
+        = g_expr_pos + g_expr_pos 3
+        : i n ( nurl_str_len src )
+        : i m ( nurl_str_len set )
+        : ~ i i 0
+        ~ < i n {
+            : ~ i j 0
+            ~ < j m {
+                ? == ( nurl_str_get src i ) ( nurl_str_get set j ) {
+                    ^ ( string_from ( nurl_str_int + i 1 ) )
+                } {}
+                = j + j 1
+            }
+            = i + i 1
+        }
+        ^ ( string_from `0` )
+    } {}
+    = g_expr_pos + g_expr_pos 1
+    ^ ( string_from tok )
+}
+
+// `S : REGEX` — an anchored match; the result is the match length (or
+// the first captured group, which this engine does not offer, so the
+// length is what it always returns).
+@ __expr_match ( Vec String ) t → String {
+    : ~ String acc ( __expr_atom t )
+    ~ & > ( __expr_left t ) 0 ( bx_streq ( __expr_tok t g_expr_pos ) `:` ) {
+        = g_expr_pos + g_expr_pos 1
+        : String pat ( __expr_atom t )
+        : String anchored ( string_from `^` )
+        ( string_push_bytes anchored # *u ( string_data pat ) ( string_len pat ) )
+        : String bre ( _bre_to_ere ( string_data anchored ) )
+        : ~ i len 0
+        ?? ( regex_compile ( string_data bre ) ) {
+            T r → {
+                ?? ( regex_find r ( string_data acc ) ) {
+                    T m → { ? == . m start 0 { = len . m len } {} }
+                    F _ → {}
+                }
+                ( regex_free r )
+            }
+            F _ → { = g_expr_err T }
+        }
+        ( string_free bre )
+        ( string_free anchored )
+        ( string_free pat )
+        ( string_free acc )
+        = acc ( string_from ( nurl_str_int len ) )
+    }
+    ^ acc
+}
+
+@ __expr_arith String a s op String b → String {
+    : i x ( __expr_num ( string_data a ) )
+    : i y ( __expr_num ( string_data b ) )
+    : ~ i r 0
+    ? ( bx_streq op `+` ) { = r + x y } {}
+    ? ( bx_streq op `-` ) { = r - x y } {}
+    ? ( bx_streq op `*` ) { = r * x y } {}
+    ? ( bx_streq op `/` ) {
+        ? == y 0 { = g_expr_err T } { = r / x y }
+    } {}
+    ? ( bx_streq op `%` ) {
+        ? == y 0 { = g_expr_err T } { = r - x * y / x y }
+    } {}
+    ^ ( string_from ( nurl_str_int r ) )
+}
+
+@ __expr_term ( Vec String ) t → String {
+    : ~ String acc ( __expr_match t )
+    ~ & > ( __expr_left t ) 0 | ( bx_streq ( __expr_tok t g_expr_pos ) `*` ) | ( bx_streq ( __expr_tok t g_expr_pos ) `/` ) ( bx_streq ( __expr_tok t g_expr_pos ) `%` ) {
+        : s op ( __expr_tok t g_expr_pos )
+        = g_expr_pos + g_expr_pos 1
+        : String b ( __expr_match t )
+        : String r ( __expr_arith acc op b )
+        ( string_free acc )
+        ( string_free b )
+        = acc r
+    }
+    ^ acc
+}
+
+@ __expr_sum ( Vec String ) t → String {
+    : ~ String acc ( __expr_term t )
+    ~ & > ( __expr_left t ) 0 | ( bx_streq ( __expr_tok t g_expr_pos ) `+` ) ( bx_streq ( __expr_tok t g_expr_pos ) `-` ) {
+        : s op ( __expr_tok t g_expr_pos )
+        = g_expr_pos + g_expr_pos 1
+        : String b ( __expr_term t )
+        : String r ( __expr_arith acc op b )
+        ( string_free acc )
+        ( string_free b )
+        = acc r
+    }
+    ^ acc
+}
+
+@ __expr_cmp_op s op → b {
+    ^ | | ( bx_streq op `=` ) | ( bx_streq op `!=` ) ( bx_streq op `<` ) | ( bx_streq op `<=` ) | ( bx_streq op `>` ) ( bx_streq op `>=` )
+}
+
+@ __expr_cmp ( Vec String ) t → String {
+    : ~ String acc ( __expr_sum t )
+    ~ & > ( __expr_left t ) 0 ( __expr_cmp_op ( __expr_tok t g_expr_pos ) ) {
+        : s op ( __expr_tok t g_expr_pos )
+        = g_expr_pos + g_expr_pos 1
+        : String b ( __expr_sum t )
+        // Two numbers compare numerically, anything else compares as
+        // text — POSIX's rule, and the reason `expr 10 '>' 9` is 1 while
+        // `expr a10 '>' a9` is 0.
+        : b numeric & ( __expr_is_num ( string_data acc ) ) ( __expr_is_num ( string_data b ) )
+        : ~ i c 0
+        ? numeric {
+            : i x ( __expr_num ( string_data acc ) )
+            : i y ( __expr_num ( string_data b ) )
+            = c ? < x y -1 ? > x y 1 0
+        } { = c ( nurl_str_cmp ( string_data acc ) ( string_data b ) ) }
+        : ~ b r F
+        ? ( bx_streq op `=` ) { = r == c 0 } {}
+        ? ( bx_streq op `!=` ) { = r != c 0 } {}
+        ? ( bx_streq op `<` ) { = r < c 0 } {}
+        ? ( bx_streq op `<=` ) { = r <= c 0 } {}
+        ? ( bx_streq op `>` ) { = r > c 0 } {}
+        ? ( bx_streq op `>=` ) { = r >= c 0 } {}
+        ( string_free acc )
+        ( string_free b )
+        = acc ( string_from ? r `1` `0` )
+    }
+    ^ acc
+}
+
+@ __expr_truthy String v → b {
+    ? == ( string_len v ) 0 { ^ F } {}
+    ? ( bx_streq ( string_data v ) `0` ) { ^ F } {}
+    ^ T
+}
+
+@ __expr_and ( Vec String ) t → String {
+    : ~ String acc ( __expr_cmp t )
+    ~ & > ( __expr_left t ) 0 ( bx_streq ( __expr_tok t g_expr_pos ) `&` ) {
+        = g_expr_pos + g_expr_pos 1
+        : String b ( __expr_cmp t )
+        : b both & ( __expr_truthy acc ) ( __expr_truthy b )
+        ? ! both {
+            ( string_free acc )
+            = acc ( string_from `0` )
+        } {}
+        ( string_free b )
+    }
+    ^ acc
+}
+
+@ __expr_or ( Vec String ) t → String {
+    : ~ String acc ( __expr_and t )
+    ~ & > ( __expr_left t ) 0 ( bx_streq ( __expr_tok t g_expr_pos ) `|` ) {
+        = g_expr_pos + g_expr_pos 1
+        : String b ( __expr_and t )
+        ? ! ( __expr_truthy acc ) {
+            ( string_free acc )
+            = acc ( string_clone b )
+        } {}
+        ( string_free b )
+    }
+    ^ acc
+}
+
+@ ap_expr ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    ? < n 2 {
+        ( bx_err `missing operand` )
+        ^ 2
+    } {}
+    : ( Vec String ) t ( vec_new [String] )
+    : ~ i i 1
+    ~ < i n {
+        ( vec_push [String] t ( string_from ( bx_at argv i ) ) )
+        = i + i 1
+    }
+    = g_expr_pos 0
+    = g_expr_err F
+    : String r ( __expr_or t )
+    : ~ i rc 0
+    ? g_expr_err {
+        ( bx_err `syntax error` )
+        = rc 2
+    } {
+        ( nurl_print ( string_data r ) )
+        ( nurl_print `\n` )
+        = rc ? ( __expr_truthy r ) 0 1
+    }
+    ( string_free r )
+    ( vec_free_with [String] t \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// ── xargs ─────────────────────────────────────────────────────────
+
+@ __xargs_run ( Vec String ) cmd b trace → i {
+    : i n ( vec_len [String] cmd )
+    ? == n 0 { ^ 0 } {}
+    ? trace {
+        : ~ i k 0
+        ~ < k n {
+            ? > k 0 { ( nurl_eprint ` ` ) } {}
+            ( nurl_eprint ( bx_at cmd k ) )
+            = k + k 1
+        }
+        ( nurl_eprint `\n` )
+    } {}
+    ( flush )
+    : i32 pid ( fork )
+    ? == # i pid 0 {
+        : s argvbuf ( nurl_zalloc * 8 + n 1 )
+        : ~ i k 0
+        ~ < k n {
+            ( nurl_poke argvbuf k # i ( bx_at cmd k ) )
+            = k + k 1
+        }
+        : i32 _r ( execvp ( bx_at cmd 0 ) # *u argvbuf )
+        ( _exit # i32 127 )
+        ^ 127
+    } {}
+    ? < # i pid 0 { ^ 127 } {}
+    : s statusbuf ( nurl_zalloc 8 )
+    : i32 _w ( waitpid pid # *u statusbuf # i32 0 )
+    : i raw ( nurl_peek statusbuf 0 )
+    ( nurl_free statusbuf )
+    ^ ( nurl_wait_exit_status & raw 65535 )
+}
+
+// Split stdin into items: whitespace-separated, or NUL-separated with
+// -0. Quoting is honoured for the whitespace form, because `xargs` is
+// most often fed `ls` output and a quoted name must survive.
+@ __xargs_items b nul ( Vec String ) out → v {
+    : ( Vec u ) data ( read_all_stdin_bytes )
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : String cur ( string_new )
+    : ~ b any F
+    : ~ i quote 0
+    : ~ i i 0
+    ~ < i n {
+        : i c & 255 # i . p i
+        ? nul {
+            ? == c 0 {
+                ( vec_push [String] out ( string_clone cur ) )
+                ( string_clear cur )
+                = any F
+            } {
+                ( string_push_char cur c )
+                = any T
+            }
+        } {
+            ? != quote 0 {
+                ? == c quote { = quote 0 } { ( string_push_char cur c ) = any T }
+            } {
+                ? | == c 34 == c 39 { = quote c = any T } {
+                    ? | | == c 32 == c 9 | == c 10 == c 13 {
+                        ? any {
+                            ( vec_push [String] out ( string_clone cur ) )
+                            ( string_clear cur )
+                            = any F
+                        } {}
+                    } {
+                        ( string_push_char cur c )
+                        = any T
+                    }
+                }
+            }
+        }
+        = i + i 1
+    }
+    ? any { ( vec_push [String] out ( string_clone cur ) ) } {}
+    ( string_free cur )
+    ( vec_free [u] data )
+}
+
+@ ap_xargs ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `0n:I:rtes:` `null=0,max-args=n,replace=I,no-run-if-empty=r,verbose=t` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ( Vec String ) items ( vec_new [String] )
+        ( __xargs_items ( bx_has o `0` ) items )
+        : i ni ( vec_len [String] items )
+        : i nops ( bx_operand_count o )
+        // With no command, xargs runs `echo`.
+        : ( Vec String ) base ( vec_new [String] )
+        ? == nops 0 {
+            ( vec_push [String] base ( string_from `echo` ) )
+        } {
+            : ~ i k 0
+            ~ < k nops {
+                ( vec_push [String] base ( string_from ( bx_operand o k ) ) )
+                = k + k 1
+            }
+        }
+        : b trace ( bx_has o `t` )
+        ? & == ni 0 ( bx_has o `r` ) {} {
+            ? ( bx_has o `I` ) {
+                : s repl ( bx_val o `I` )
+                : ~ i k 0
+                ~ < k ni {
+                    : ( Vec String ) cmd ( vec_new [String] )
+                    : i nb ( vec_len [String] base )
+                    : ~ i j 0
+                    ~ < j nb {
+                        : s piece ( bx_at base j )
+                        : i at ( nurl_str_find piece repl )
+                        ? >= at 0 {
+                            : String sub ( string_from ( nurl_str_slice piece 0 at ) )
+                            ( string_push_str sub ( bx_at items k ) )
+                            ( string_push_str sub ( nurl_str_slice piece + at ( nurl_str_len repl ) - ( nurl_str_len piece ) + at ( nurl_str_len repl ) ) )
+                            ( vec_push [String] cmd sub )
+                        } { ( vec_push [String] cmd ( string_from piece ) ) }
+                        = j + j 1
+                    }
+                    : i one ( __xargs_run cmd trace )
+                    ? != one 0 { = rc one } {}
+                    ( vec_free_with [String] cmd \ String x → v { ( string_free x ) } )
+                    = k + k 1
+                }
+            } {
+                : i batch ? ( bx_has o `n` ) ( nurl_str_to_int ( bx_val o `n` ) ) 0
+                : ~ i k 0
+                : ~ b once F
+                ~ | < k ni & ! once == ni 0 {
+                    = once T
+                    : ( Vec String ) cmd ( vec_new [String] )
+                    : i nb ( vec_len [String] base )
+                    : ~ i j 0
+                    ~ < j nb {
+                        ( vec_push [String] cmd ( string_from ( bx_at base j ) ) )
+                        = j + j 1
+                    }
+                    : ~ i taken 0
+                    ~ & < k ni | <= batch 0 < taken batch {
+                        ( vec_push [String] cmd ( string_from ( bx_at items k ) ) )
+                        = k + k 1
+                        = taken + taken 1
+                    }
+                    : i one ( __xargs_run cmd trace )
+                    ? != one 0 { = rc one } {}
+                    ( vec_free_with [String] cmd \ String x → v { ( string_free x ) } )
+                }
+            }
+        }
+        ( vec_free_with [String] base \ String x → v { ( string_free x ) } )
+        ( vec_free_with [String] items \ String x → v { ( string_free x ) } )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/sys.nu
+++ b/packages/nurlbox/src/sys.nu
@@ -1,0 +1,1053 @@
+// nurlbox/sys.nu — the applets that ask the system about itself.
+//
+// pwd / basename / dirname / env / printenv / printf / sleep / usleep /
+// uname / arch / hostname / whoami / id / groups / logname / nproc /
+// which / date / sync / clear / tty.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/std/sysinfo.nu`
+$ `stdlib/ext/env.nu`
+$ `bx.nu`
+
+& `c` @ getuid → i32
+
+& `c` @ geteuid → i32
+
+& `c` @ getgid → i32
+
+& `c` @ getegid → i32
+
+& `c` @ getgroups i32 size *u list → i32
+
+// ── pwd ───────────────────────────────────────────────────────────
+
+@ ap_pwd ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `LP` `logical=L,physical=P` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        // -L honours $PWD when it still names this directory; -P (and
+        // the default here) is what getcwd(3) answers, with every
+        // symlink already resolved.
+        : ~ b used F
+        ? ( bx_has o `L` ) {
+            ?? ( env_get `PWD` ) {
+                T p → {
+                    ? ( path_is_absolute ( string_data p ) ) {
+                        ( nurl_print ( string_data p ) )
+                        ( nurl_print `\n` )
+                        = used T
+                    } {}
+                    ( string_free p )
+                }
+                F _ → {}
+            }
+        } {}
+        ? ! used {
+            ?? ( env_cwd ) {
+                T c → {
+                    ( nurl_print ( string_data c ) )
+                    ( nurl_print `\n` )
+                    ( string_free c )
+                }
+                F e → {
+                    ( bx_err ( bx_ioerr e ) )
+                    = rc 1
+                }
+            }
+        } {}
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── basename / dirname ────────────────────────────────────────────
+
+// POSIX basename: strip trailing slashes, take the last component,
+// then remove `suffix` unless that would leave nothing.
+@ __basename_of s p s suffix → String {
+    : String base ( path_basename p )
+    : i sl ( nurl_str_len suffix )
+    ? > sl 0 {
+        : i bl ( string_len base )
+        ? & > bl sl ( string_ends_with base suffix ) {
+            : String cut ( string_substr base 0 - bl sl )
+            ( string_free base )
+            ^ cut
+        } {}
+    } {}
+    ^ base
+}
+
+@ ap_basename ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `as:z` `multiple=a,suffix=s,zero=z` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {
+            : b multi | ( bx_has o `a` ) ( bx_has o `s` )
+            : i term ? ( bx_has o `z` ) 0 10
+            ? multi {
+                : ~ i i 0
+                ~ < i nops {
+                    : String b ( __basename_of ( bx_operand o i ) ( bx_val o `s` ) )
+                    ( nurl_print_bytes ( string_data b ) ( string_len b ) )
+                    ( nurl_print ? == term 0 `` `\n` )
+                    ( string_free b )
+                    = i + i 1
+                }
+            } {
+                : String b ( __basename_of ( bx_operand o 0 ) ? > nops 1 ( bx_operand o 1 ) `` )
+                ( nurl_print_bytes ( string_data b ) ( string_len b ) )
+                ( nurl_print ? == term 0 `` `\n` )
+                ( string_free b )
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_dirname ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `z` `zero=z` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 1
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                : String d ( path_dirname ( bx_operand o i ) )
+                ( nurl_print ( string_data d ) )
+                ( nurl_print ? ( bx_has o `z` ) `` `\n` )
+                ( string_free d )
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── env / printenv ────────────────────────────────────────────────
+
+@ __env_dump s sep → v {
+    : ( Vec String ) all ( env_list )
+    : i n ( vec_len [String] all )
+    : ~ i i 0
+    ~ < i n {
+        ( nurl_print ( bx_at all i ) )
+        ( nurl_print sep )
+        = i + i 1
+    }
+    ( vec_free_with [String] all \ String x → v { ( string_free x ) } )
+}
+
+// Hand the process over to `cmd`. On success this never returns — the
+// image is replaced, which is exactly what `env VAR=x prog` means.
+@ __exec_argv ( Vec String ) args i from → i {
+    : i n - ( vec_len [String] args ) from
+    ? <= n 0 { ^ 127 } {}
+    : s argvbuf ( nurl_zalloc * 8 + n 1 )
+    : ~ i k 0
+    ~ < k n {
+        ( nurl_poke argvbuf k # i ( bx_at args + from k ) )
+        = k + k 1
+    }
+    : s cmd ( bx_at args from )
+    : i32 _rc ( execvp cmd # *u argvbuf )
+    : i err ( nurl_errno_get )
+    ( nurl_free argvbuf )
+    ( bx_err_at cmd ? == err ( posix_const `ENOENT` ) `No such file or directory` `Permission denied` )
+    ^ ? == err ( posix_const `ENOENT` ) 127 126
+}
+
+@ ap_env ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `iu:0` `ignore-environment=i,unset=u,null=0` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        ? ( bx_has o `i` ) {
+            : ( Vec String ) all ( env_list )
+            : i n ( vec_len [String] all )
+            : ~ i i 0
+            ~ < i n {
+                : s e ( bx_at all i )
+                : i eq ( nurl_str_find e `=` )
+                ? > eq 0 {
+                    : s nm ( nurl_str_slice e 0 eq )
+                    ?? ( env_unset nm ) { T _ → {} F _ → {} }
+                } {}
+                = i + i 1
+            }
+            ( vec_free_with [String] all \ String x → v { ( string_free x ) } )
+        } {}
+        ? ( bx_has o `u` ) {
+            ?? ( env_unset ( bx_val o `u` ) ) { T _ → {} F _ → {} }
+        } {}
+        // Leading NAME=VALUE operands are assignments; the first operand
+        // without an `=` starts the command.
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        : ~ b assigning T
+        ~ & assigning < i nops {
+            : s e ( bx_operand o i )
+            : i eq ( nurl_str_find e `=` )
+            ? > eq 0 {
+                : s nm ( nurl_str_slice e 0 eq )
+                : s val ( nurl_str_slice e + eq 1 - ( nurl_str_len e ) + eq 1 )
+                ?? ( env_set nm val ) { T _ → {} F _ → {} }
+                = i + i 1
+            } { = assigning F }
+        }
+        ? < i nops {
+            = rc ( __exec_argv . o args i )
+        } {
+            ( __env_dump ? ( bx_has o `0` ) `` `\n` )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_printenv ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `0` `null=0` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        : s sep ? ( bx_has o `0` ) `` `\n`
+        ? == nops 0 {
+            ( __env_dump sep )
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                ?? ( env_get ( bx_operand o i ) ) {
+                    T v → {
+                        ( nurl_print ( string_data v ) )
+                        ( nurl_print sep )
+                        ( string_free v )
+                    }
+                    F _ → { = rc 1 }
+                }
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── printf ────────────────────────────────────────────────────────
+
+// One `\`-escape at `i` (which points at the backslash), appended to
+// `out`; returns the index just past it. Shared by printf's format
+// string and by its %b conversion.
+@ __pf_one_escape String out s text i i i to → i {
+    ? >= + i 1 to {
+        ( string_push_char out 92 )
+        ^ + i 1
+    } {}
+    : i e ( nurl_str_get text + i 1 )
+    : ~ i k + i 2
+    ? == e 110 { ( string_push_char out 10 ) } {
+        ? == e 116 { ( string_push_char out 9 ) } {
+            ? == e 114 { ( string_push_char out 13 ) } {
+                ? == e 92 { ( string_push_char out 92 ) } {
+                    ? == e 97 { ( string_push_char out 7 ) } {
+                        ? == e 98 { ( string_push_char out 8 ) } {
+                            ? == e 102 { ( string_push_char out 12 ) } {
+                                ? == e 118 { ( string_push_char out 11 ) } {
+                                    ? == e 34 { ( string_push_char out 34 ) } {
+                                        ? == e 120 {
+                                            : ~ i val 0
+                                            : ~ i got 0
+                                            ~ & < got 2 & < k to ( bx_is_hex ( nurl_str_get text k ) ) {
+                                                = val + * val 16 ( bx_hex_val ( nurl_str_get text k ) )
+                                                = k + k 1
+                                                = got + got 1
+                                            }
+                                            ? == got 0 {
+                                                ( string_push_char out 92 )
+                                                ( string_push_char out e )
+                                            } { ( string_push_char out & val 255 ) }
+                                        } {
+                                            ? & >= e 48 <= e 55 {
+                                                : ~ i val - e 48
+                                                : ~ i got 1
+                                                ~ & < got 3 & < k to & >= ( nurl_str_get text k ) 48 <= ( nurl_str_get text k ) 55 {
+                                                    = val + * val 8 - ( nurl_str_get text k ) 48
+                                                    = k + k 1
+                                                    = got + got 1
+                                                }
+                                                ( string_push_char out & val 255 )
+                                            } {
+                                                ( string_push_char out 92 )
+                                                ( string_push_char out e )
+                                            } } } } } } } } } } }
+    ^ k
+}
+
+// Every escape in text[from, to).
+@ __pf_escape String out s text i from i to → i {
+    : ~ i i from
+    ~ < i to {
+        ? == ( nurl_str_get text i ) 92 {
+            = i ( __pf_one_escape out text i to )
+        } {
+            ( string_push_char out ( nurl_str_get text i ) )
+            = i + i 1
+        }
+    }
+    ^ i
+}
+
+// An unsigned integer in `base`, upper- or lower-case for hex.
+@ __pf_uint String out i val i base b upper → v {
+    ? == val 0 { ( string_push_char out 48 ) ^ } {}
+    : s digits ? upper `0123456789ABCDEF` `0123456789abcdef`
+    : String tmp ( string_with_cap 24 )
+    : ~ i v val
+    ~ != v 0 {
+        : i q ( __pf_udiv v base )
+        : i r - v * q base
+        ( string_push_char tmp ( nurl_str_get digits r ) )
+        = v q
+    }
+    : ~ i k ( string_len tmp )
+    ~ > k 0 {
+        ( string_push_char out ( string_get tmp - k 1 ) )
+        = k - k 1
+    }
+    ( string_free tmp )
+}
+
+// Unsigned division of a value whose top bit may be set, done in i64.
+@ __pf_udiv i v i base → i {
+    ? >= v 0 { ^ / v base } {}
+    : i half >> & v 9223372036854775807 1
+    : i q / half base
+    : i r - half * q base
+    : i lo | << r 1 & v 1
+    ^ + * q 2 / lo base
+}
+
+@ __pf_pad String out i width b left String body → v {
+    : i n ( string_len body )
+    ? & ! left > width n {
+        : ~ i k - width n
+        ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+    } {}
+    ( string_push_bytes out # *u ( string_data body ) n )
+    ? & left > width n {
+        : ~ i k - width n
+        ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+    } {}
+}
+
+@ ap_printf ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    ? < n 2 {
+        ( bx_err `usage: printf FORMAT [ARGUMENT]...` )
+        ^ 1
+    } {}
+    : s fmt ( bx_at argv 1 )
+    : i fl ( nurl_str_len fmt )
+    : String out ( string_new )
+    : ~ i ai 2
+    : ~ b again T
+    ~ again {
+        = again F
+        : ~ i i 0
+        ~ < i fl {
+            : i c ( nurl_str_get fmt i )
+            ? == c 92 {
+                = i ( __pf_one_escape out fmt i fl )
+            } {
+                ? == c 37 {
+                    ? & < + i 1 fl == ( nurl_str_get fmt + i 1 ) 37 {
+                        ( string_push_char out 37 )
+                        = i + i 2
+                    } {
+                        : ~ i k + i 1
+                        : ~ b left F
+                        : ~ b zero F
+                        : ~ b plus F
+                        : ~ b space F
+                        : ~ b more T
+                        ~ & more < k fl {
+                            : i f ( nurl_str_get fmt k )
+                            ? == f 45 { = left T = k + k 1 } {
+                                ? == f 48 { = zero T = k + k 1 } {
+                                    ? == f 43 { = plus T = k + k 1 } {
+                                        ? == f 32 { = space T = k + k 1 } {
+                                            ? == f 35 { = k + k 1 } { = more F } } } } }
+                        }
+                        : ~ i width 0
+                        ~ & < k fl ( bx_is_digit ( nurl_str_get fmt k ) ) {
+                            = width + * width 10 - ( nurl_str_get fmt k ) 48
+                            = k + k 1
+                        }
+                        : ~ i prec -1
+                        ? & < k fl == ( nurl_str_get fmt k ) 46 {
+                            = k + k 1
+                            = prec 0
+                            ~ & < k fl ( bx_is_digit ( nurl_str_get fmt k ) ) {
+                                = prec + * prec 10 - ( nurl_str_get fmt k ) 48
+                                = k + k 1
+                            }
+                        } {}
+                        // Skip the C length modifiers a script may carry.
+                        ~ & < k fl | | == ( nurl_str_get fmt k ) 108 == ( nurl_str_get fmt k ) 104 == ( nurl_str_get fmt k ) 113 {
+                            = k + k 1
+                        }
+                        ? >= k fl {
+                            ( string_push_char out 37 )
+                            = i k
+                        } {
+                            : i conv ( nurl_str_get fmt k )
+                            : s arg ? < ai n ( bx_at argv ai ) ``
+                            : b consumed T
+                            : String body ( string_new )
+                            ? | == conv 100 == conv 105 {
+                                : i v ( nurl_str_to_int arg )
+                                ? < v 0 {
+                                    ( string_push_char body 45 )
+                                    ( __pf_uint body - 0 v 10 F )
+                                } {
+                                    ? plus { ( string_push_char body 43 ) } {
+                                        ? space { ( string_push_char body 32 ) } {}
+                                    }
+                                    ( __pf_uint body v 10 F )
+                                }
+                            } {
+                                ? == conv 117 { ( __pf_uint body ( nurl_str_to_int arg ) 10 F ) } {
+                                    ? == conv 120 { ( __pf_uint body ( nurl_str_to_int arg ) 16 F ) } {
+                                        ? == conv 88 { ( __pf_uint body ( nurl_str_to_int arg ) 16 T ) } {
+                                            ? == conv 111 { ( __pf_uint body ( nurl_str_to_int arg ) 8 F ) } {
+                                                ? == conv 99 {
+                                                    ? > ( nurl_str_len arg ) 0 { ( string_push_char body ( nurl_str_get arg 0 ) ) } {}
+                                                } {
+                                                    ? == conv 115 {
+                                                        : i al ( nurl_str_len arg )
+                                                        : i take ? & >= prec 0 < prec al prec al
+                                                        ( string_push_bytes body # *u arg take )
+                                                    } {
+                                                        ? == conv 98 {
+                                                            : i _e ( __pf_escape body arg 0 ( nurl_str_len arg ) )
+                                                        } {
+                                                            ? | == conv 102 | == conv 101 == conv 103 {
+                                                                ( string_push_float body ( nurl_str_to_float arg ) )
+                                                            } {
+                                                                ( string_push_char body 37 )
+                                                                ( string_push_char body conv )
+                                                            } } } } } } } } }
+                            ? & zero ! left {
+                                : i bn ( string_len body )
+                                ? > width bn {
+                                    : String padded ( string_new )
+                                    : ~ i pk - width bn
+                                    // A sign keeps its place in front of
+                                    // the zeros, as C's %05d does.
+                                    : ~ i st 0
+                                    ? > bn 0 {
+                                        : i c0 ( string_get body 0 )
+                                        ? | == c0 45 | == c0 43 == c0 32 {
+                                            ( string_push_char padded c0 )
+                                            = st 1
+                                        } {}
+                                    } {}
+                                    ~ > pk 0 { ( string_push_char padded 48 ) = pk - pk 1 }
+                                    ( string_push_bytes padded # *u + # i ( string_data body ) st - bn st )
+                                    ( string_clear body )
+                                    ( string_push_bytes body # *u ( string_data padded ) ( string_len padded ) )
+                                    ( string_free padded )
+                                } {}
+                            } {}
+                            ( __pf_pad out width left body )
+                            ( string_free body )
+                            ? consumed { = ai + ai 1 } {}
+                            = i + k 1
+                        }
+                    }
+                } {
+                    ( string_push_char out c )
+                    = i + i 1
+                }
+            }
+        }
+        // POSIX: while arguments remain, the format is reused.
+        ? & < ai n > ( __pf_conversions fmt ) 0 { = again T } {}
+    }
+    ( bx_write out )
+    ( string_free out )
+    ^ 0
+}
+
+// How many argument-consuming conversions the format has — zero means
+// reusing it would loop forever.
+@ __pf_conversions s fmt → i {
+    : i n ( nurl_str_len fmt )
+    : ~ i i 0
+    : ~ i k 0
+    ~ < i n {
+        ? == ( nurl_str_get fmt i ) 37 {
+            ? & < + i 1 n == ( nurl_str_get fmt + i 1 ) 37 { = i + i 1 } { = k + k 1 }
+        } {}
+        = i + i 1
+    }
+    ^ k
+}
+
+// ── sleep / usleep ────────────────────────────────────────────────
+
+@ ap_sleep ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    ? < n 2 {
+        ( bx_err `missing operand` )
+        ^ 1
+    } {}
+    : ~ f total 0.0
+    : ~ i i 1
+    : ~ i rc 0
+    ~ < i n {
+        : s a ( bx_at argv i )
+        : i al ( nurl_str_len a )
+        : i last ? > al 0 ( nurl_str_get a - al 1 ) 0
+        : ~ f mult 1.0
+        : ~ i cut al
+        ? == last 115 { = cut - al 1 } {}
+        ? == last 109 { = mult 60.0 = cut - al 1 } {}
+        ? == last 104 { = mult 3600.0 = cut - al 1 } {}
+        ? == last 100 { = mult 86400.0 = cut - al 1 } {}
+        : s num ( nurl_str_slice a 0 cut )
+        ? == ( nurl_str_len num ) 0 {
+            ( bx_err_at a `invalid number` )
+            = rc 1
+        } {
+            = total + total * ( nurl_str_to_float num ) mult
+        }
+        = i + i 1
+    }
+    ? == rc 0 { ( sleep_ms # i * total 1000.0 ) } {}
+    ^ rc
+}
+
+@ ap_usleep ( Vec String ) argv → i {
+    ? < ( vec_len [String] argv ) 2 {
+        ( bx_err `missing operand` )
+        ^ 1
+    } {}
+    : i us ( nurl_str_to_int ( bx_at argv 1 ) )
+    ( sleep_ms / us 1000 )
+    ^ 0
+}
+
+// ── uname / arch / hostname ───────────────────────────────────────
+
+@ __uname_or ? String o s dflt → String {
+    ?? o {
+        T s0 → { ^ s0 }
+        F _ → { ^ ( string_from dflt ) }
+    }
+}
+
+@ ap_uname ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `asnrvmpioA` `all=a,kernel-name=s,nodename=n,kernel-release=r,kernel-version=v,machine=m,processor=p,hardware-platform=i,operating-system=o` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b all ( bx_has o `a` )
+        : ~ b any F
+        ? | all ( bx_has o `s` ) { = any T } {}
+        ? | ( bx_has o `n` ) | ( bx_has o `r` ) | ( bx_has o `v` ) | ( bx_has o `m` ) | ( bx_has o `p` ) | ( bx_has o `i` ) ( bx_has o `o` ) { = any T } {}
+        // Bare `uname` is `uname -s`.
+        : b want_s | all | ( bx_has o `s` ) ! any
+        : String out ( string_new )
+        ? want_s {
+            : String v ( __uname_or ( sys_uname_field SYS_SYSNAME ) `unknown` )
+            ( string_push_bytes out # *u ( string_data v ) ( string_len v ) )
+            ( string_free v )
+        } {}
+        ? | all ( bx_has o `n` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            : String v ( __uname_or ( sys_uname_field SYS_NODENAME ) `unknown` )
+            ( string_push_bytes out # *u ( string_data v ) ( string_len v ) )
+            ( string_free v )
+        } {}
+        ? | all ( bx_has o `r` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            : String v ( __uname_or ( sys_uname_field SYS_RELEASE ) `unknown` )
+            ( string_push_bytes out # *u ( string_data v ) ( string_len v ) )
+            ( string_free v )
+        } {}
+        ? | all ( bx_has o `v` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            : String v ( __uname_or ( sys_uname_field SYS_VERSION ) `unknown` )
+            ( string_push_bytes out # *u ( string_data v ) ( string_len v ) )
+            ( string_free v )
+        } {}
+        ? | all ( bx_has o `m` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            : String v ( __uname_or ( sys_uname_field SYS_MACHINE ) `unknown` )
+            ( string_push_bytes out # *u ( string_data v ) ( string_len v ) )
+            ( string_free v )
+        } {}
+        ? ( bx_has o `p` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            ( string_push_str out `unknown` )
+        } {}
+        ? ( bx_has o `i` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            ( string_push_str out `unknown` )
+        } {}
+        ? | all ( bx_has o `o` ) {
+            ? > ( string_len out ) 0 { ( string_push_char out 32 ) } {}
+            ( string_push_str out `GNU/Linux` )
+        } {}
+        ( string_push_char out 10 )
+        ( bx_write out )
+        ( string_free out )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_arch ( Vec String ) argv → i {
+    : String v ( __uname_or ( sys_uname_field SYS_MACHINE ) `unknown` )
+    ( nurl_print ( string_data v ) )
+    ( nurl_print `\n` )
+    ( string_free v )
+    ^ 0
+}
+
+@ ap_hostname ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `sifd` `short=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : String h ( __uname_or ( sys_hostname ) `unknown` )
+        ? | ( bx_has o `s` ) ( bx_has o `d` ) {
+            : i dot ( nurl_str_find ( string_data h ) `.` )
+            ? > dot 0 {
+                ? ( bx_has o `s` ) {
+                    : String sh ( string_substr h 0 dot )
+                    ( nurl_print ( string_data sh ) )
+                    ( string_free sh )
+                } {
+                    : String dm ( string_substr h + dot 1 - ( string_len h ) + dot 1 )
+                    ( nurl_print ( string_data dm ) )
+                    ( string_free dm )
+                }
+            } {
+                ? ( bx_has o `s` ) { ( nurl_print ( string_data h ) ) } {}
+            }
+        } {
+            ( nurl_print ( string_data h ) )
+        }
+        ( nurl_print `\n` )
+        ( string_free h )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── whoami / id / groups / logname ────────────────────────────────
+
+@ __name_of_uid i uid → String {
+    ?? ( fs_user_name uid ) {
+        T n → { ^ n }
+        F _ → { ^ ( string_from ( nurl_str_int uid ) ) }
+    }
+}
+
+@ __name_of_gid i gid → String {
+    ?? ( fs_group_name gid ) {
+        T n → { ^ n }
+        F _ → { ^ ( string_from ( nurl_str_int gid ) ) }
+    }
+}
+
+@ ap_whoami ( Vec String ) argv → i {
+    : String n ( __name_of_uid # i ( geteuid ) )
+    ( nurl_print ( string_data n ) )
+    ( nurl_print `\n` )
+    ( string_free n )
+    ^ 0
+}
+
+@ ap_logname ( Vec String ) argv → i {
+    ?? ( env_get `LOGNAME` ) {
+        T v → {
+            ( nurl_print ( string_data v ) )
+            ( nurl_print `\n` )
+            ( string_free v )
+            ^ 0
+        }
+        F _ → {}
+    }
+    ^ ( ap_whoami argv )
+}
+
+// The caller's supplementary groups, as gids.
+@ __group_ids → ( Vec i ) {
+    : ( Vec i ) out ( vec_new [i] )
+    : i32 n ( getgroups # i32 0 # *u 0 )
+    ? <= # i n 0 { ^ out } {}
+    : s buf ( nurl_zalloc * 4 + # i n 1 )
+    : i32 got ( getgroups n # *u buf )
+    : ~ i k 0
+    ~ < k # i got {
+        // gid_t is a 32-bit int; read four little-endian bytes.
+        : *u p # *u buf
+        : i off * k 4
+        : i g | | | & 255 # i . p off << & 255 # i . p + off 1 8 << & 255 # i . p + off 2 16 << & 255 # i . p + off 3 24
+        ( vec_push [i] out g )
+        = k + k 1
+    }
+    ( nurl_free buf )
+    ^ out
+}
+
+@ ap_groups ( Vec String ) argv → i {
+    // The effective group first, then the supplementary ones — the
+    // order every `groups` prints, and not the order getgroups(2)
+    // happens to return.
+    : i egid # i ( getegid )
+    : String primary ( __name_of_gid egid )
+    ( nurl_print ( string_data primary ) )
+    ( string_free primary )
+    : ( Vec i ) gs ( __group_ids )
+    : i n ( vec_len [i] gs )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [i] gs k ) {
+            T g → {
+                ? != g egid {
+                    ( nurl_print ` ` )
+                    : String nm ( __name_of_gid g )
+                    ( nurl_print ( string_data nm ) )
+                    ( string_free nm )
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( nurl_print `\n` )
+    ( vec_free [i] gs )
+    ^ 0
+}
+
+@ __id_pair String out s label i id → v {
+    ( string_push_str out label )
+    ( string_push_int out id )
+    : String nm ( __name_of_gid id )
+    // `1000(wau)` — the number is the fact, the name is the courtesy.
+    ? ! ( bx_streq ( string_data nm ) ( nurl_str_int id ) ) {
+        ( string_push_char out 40 )
+        ( string_push_bytes out # *u ( string_data nm ) ( string_len nm ) )
+        ( string_push_char out 41 )
+    } {}
+    ( string_free nm )
+}
+
+@ ap_id ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ugGnr` `user=u,group=g,groups=G,name=n,real=r` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b real ( bx_has o `r` )
+        : i uid ? real # i ( getuid ) # i ( geteuid )
+        : i gid ? real # i ( getgid ) # i ( getegid )
+        : b nameform ( bx_has o `n` )
+        : String out ( string_new )
+        ? ( bx_has o `u` ) {
+            ? nameform {
+                : String nm ( __name_of_uid uid )
+                ( string_push_bytes out # *u ( string_data nm ) ( string_len nm ) )
+                ( string_free nm )
+            } { ( string_push_int out uid ) }
+        } {
+            ? ( bx_has o `g` ) {
+                ? nameform {
+                    : String nm ( __name_of_gid gid )
+                    ( string_push_bytes out # *u ( string_data nm ) ( string_len nm ) )
+                    ( string_free nm )
+                } { ( string_push_int out gid ) }
+            } {
+                ? ( bx_has o `G` ) {
+                    : ( Vec i ) gs ( __group_ids )
+                    : i gn ( vec_len [i] gs )
+                    : ~ i k 0
+                    ~ < k gn {
+                        ?? ( vec_get [i] gs k ) {
+                            T g → {
+                                ? > k 0 { ( string_push_char out 32 ) } {}
+                                ? nameform {
+                                    : String nm ( __name_of_gid g )
+                                    ( string_push_bytes out # *u ( string_data nm ) ( string_len nm ) )
+                                    ( string_free nm )
+                                } { ( string_push_int out g ) }
+                            }
+                            F _ → {}
+                        }
+                        = k + k 1
+                    }
+                    ( vec_free [i] gs )
+                } {
+                    : String un ( __name_of_uid uid )
+                    ( string_push_str out `uid=` )
+                    ( string_push_int out uid )
+                    ? ! ( bx_streq ( string_data un ) ( nurl_str_int uid ) ) {
+                        ( string_push_char out 40 )
+                        ( string_push_bytes out # *u ( string_data un ) ( string_len un ) )
+                        ( string_push_char out 41 )
+                    } {}
+                    ( string_free un )
+                    ( string_push_char out 32 )
+                    ( __id_pair out `gid=` gid )
+                    : ( Vec i ) gs ( __group_ids )
+                    : i gn ( vec_len [i] gs )
+                    ? > gn 0 {
+                        ( string_push_str out ` groups=` )
+                        : ~ i k 0
+                        ~ < k gn {
+                            ?? ( vec_get [i] gs k ) {
+                                T g → {
+                                    ? > k 0 { ( string_push_char out 44 ) } {}
+                                    ( __id_pair out `` g )
+                                }
+                                F _ → {}
+                            }
+                            = k + k 1
+                        }
+                    } {}
+                    ( vec_free [i] gs )
+                } } }
+        ( string_push_char out 10 )
+        ( bx_write out )
+        ( string_free out )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── nproc ─────────────────────────────────────────────────────────
+
+@ ap_nproc ( Vec String ) argv → i {
+    ( nurl_print ( nurl_str_int ( sys_cpu_count ) ) )
+    ( nurl_print `\n` )
+    ^ 0
+}
+
+// ── which ─────────────────────────────────────────────────────────
+
+@ __is_executable s p → b {
+    ?? ( fs_stat p ) {
+        T st → { ^ & ( stat_is_file st ) != 0 & ( stat_mode_bits st ) 73 }
+        F _ → { ^ F }
+    }
+}
+
+@ ap_which ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `a` `all=a` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : String path ( env_var_or `PATH` `/bin:/usr/bin` )
+        : ( Vec String ) dirs ( string_split path `:` )
+        : i nd ( vec_len [String] dirs )
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        ~ < i nops {
+            : s want ( bx_operand o i )
+            : ~ b found F
+            ? > ( nurl_str_find want `/` ) -1 {
+                ? ( __is_executable want ) {
+                    ( nurl_print want )
+                    ( nurl_print `\n` )
+                    = found T
+                } {}
+            } {
+                : ~ i d 0
+                ~ < d nd {
+                    ? | ! found ( bx_has o `a` ) {
+                        : String full ( path_join ( bx_at dirs d ) want )
+                        ? ( __is_executable ( string_data full ) ) {
+                            ( nurl_print ( string_data full ) )
+                            ( nurl_print `\n` )
+                            = found T
+                        } {}
+                        ( string_free full )
+                    } {}
+                    = d + d 1
+                }
+            }
+            ? ! found { = rc 1 } {}
+            = i + i 1
+        }
+        ( vec_free_with [String] dirs \ String x → v { ( string_free x ) } )
+        ( string_free path )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── date ──────────────────────────────────────────────────────────
+
+// %Z, %z, %s and %N need the instant, not the calendar, so they are
+// substituted here and the rest handed to `time_format`.
+@ __date_prepass s fmt i epoch b utc → String {
+    : String out ( string_new )
+    : i n ( nurl_str_len fmt )
+    : i off ? utc 0 ( tz_offset epoch )
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get fmt i )
+        ? & == c 37 < + i 1 n {
+            : i d ( nurl_str_get fmt + i 1 )
+            ? == d 90 {
+                ? utc { ( string_push_str out `UTC` ) } {
+                    ?? ( tz_name epoch ) {
+                        T z → {
+                            ( string_push_bytes out # *u ( string_data z ) ( string_len z ) )
+                            ( string_free z )
+                        }
+                        F _ → { ( string_push_str out `UTC` ) }
+                    }
+                }
+                = i + i 2
+            } {
+                ? == d 122 {
+                    : i mins / ? < off 0 - 0 off off 60
+                    ( string_push_char out ? < off 0 45 43 )
+                    : i hh / mins 60
+                    : i mm - mins * hh 60
+                    ? < hh 10 { ( string_push_char out 48 ) } {}
+                    ( string_push_int out hh )
+                    ? < mm 10 { ( string_push_char out 48 ) } {}
+                    ( string_push_int out mm )
+                    = i + i 2
+                } {
+                    ? == d 115 {
+                        ( string_push_int out epoch )
+                        = i + i 2
+                    } {
+                        ? == d 78 {
+                            ( string_push_str out `000000000` )
+                            = i + i 2
+                        } {
+                            ( string_push_char out c )
+                            ( string_push_char out d )
+                            = i + i 2
+                        } } } }
+        } {
+            ( string_push_char out c )
+            = i + i 1
+        }
+    }
+    ^ out
+}
+
+@ ap_date ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `uRd:r:` `utc=u,universal=u,rfc-2822=R,date=d,reference=r` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i epoch ( now_seconds )
+        ? ( bx_has o `r` ) {
+            ?? ( fs_stat ( bx_val o `r` ) ) {
+                T st → { = epoch . st mtime }
+                F e → {
+                    ( bx_err_at ( bx_val o `r` ) ( bx_ioerr e ) )
+                    = rc 1
+                }
+            }
+        } {}
+        ? ( bx_has o `d` ) {
+            ?? ( time_parse_iso ( bx_val o `d` ) ) {
+                T secs → { = epoch secs }
+                F _ → {
+                    ( bx_err_at ( bx_val o `d` ) `invalid date` )
+                    = rc 1
+                }
+            }
+        } {}
+        ? == rc 0 {
+            : b utc ( bx_has o `u` )
+            // A leading `+` operand is the format; busybox and coreutils
+            // both spell it that way.
+            : String fmt ( string_from `%a %b %e %H:%M:%S %Z %Y` )
+            ? ( bx_has o `R` ) {
+                ( string_clear fmt )
+                ( string_push_str fmt `%a, %d %b %Y %H:%M:%S %z` )
+            } {}
+            ? > ( bx_operand_count o ) 0 {
+                : s op ( bx_operand o 0 )
+                ? == ( nurl_str_get op 0 ) 43 {
+                    ( string_clear fmt )
+                    ( string_push_str fmt ( nurl_str_slice op 1 - ( nurl_str_len op ) 1 ) )
+                } {}
+            } {}
+            : String pre ( __date_prepass ( string_data fmt ) epoch utc )
+            : Time t ? utc ( time_from_unix epoch ) ( time_local epoch )
+            : String txt ( time_format t ( string_data pre ) )
+            ( bx_write txt )
+            ( nurl_print `\n` )
+            ( string_free txt )
+            ( string_free pre )
+            ( string_free fmt )
+        } {}
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── sync / clear / tty ────────────────────────────────────────────
+
+@ ap_sync ( Vec String ) argv → i {
+    ( flush )
+    : i nops - ( vec_len [String] argv ) 1
+    : ~ i i 1
+    ~ <= i nops {
+        ?? ( file_open ( bx_at argv i ) ) {
+            T f → {
+                ?? ( file_sync f ) { T _ → {} F _ → {} }
+                ( file_close f )
+            }
+            F e → { ( bx_err_at ( bx_at argv i ) ( bx_ioerr e ) ) }
+        }
+        = i + i 1
+    }
+    ^ 0
+}
+
+@ ap_clear ( Vec String ) argv → i {
+    // ESC [ H  — home; ESC [ 2J — erase screen; ESC [ 3J — erase the
+    // scrollback, which is what makes `clear` clear rather than scroll.
+    : String out ( string_new )
+    ( string_push_char out 27 )
+    ( string_push_str out `[H` )
+    ( string_push_char out 27 )
+    ( string_push_str out `[2J` )
+    ( string_push_char out 27 )
+    ( string_push_str out `[3J` )
+    ( bx_write out )
+    ( string_free out )
+    ( flush )
+    ^ 0
+}
+
+@ ap_tty ( Vec String ) argv → i {
+    ? ( term_is_tty 0 ) {
+        ( nurl_print `/dev/tty\n` )
+        ^ 0
+    } {}
+    ( nurl_print `not a tty\n` )
+    ^ 1
+}

--- a/packages/nurlbox/src/text.nu
+++ b/packages/nurlbox/src/text.nu
@@ -1,0 +1,767 @@
+// nurlbox/text.nu — the stream utilities.
+//
+// cat / echo / head / tail / wc / seq / yes. Every one of them is a
+// byte-exact filter: a line is copied with the terminator the input
+// carried, so a CRLF file survives a `head` and a file with no final
+// newline does not grow one.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `bx.nu`
+
+// ── echo ──────────────────────────────────────────────────────────
+//
+// Options are only options while they form an unbroken leading run of
+// -n / -e / -E; `echo -x` prints `-x`, as every shell's echo does.
+
+@ __echo_is_opt s tok → b {
+    : i n ( nurl_str_len tok )
+    ? < n 2 { ^ F } {}
+    ? != ( nurl_str_get tok 0 ) 45 { ^ F } {}
+    : ~ i k 1
+    : ~ b all T
+    ~ < k n {
+        : i c ( nurl_str_get tok k )
+        ? ! | == c 110 | == c 101 == c 69 { = all F } {}
+        = k + k 1
+    }
+    ^ all
+}
+
+// Expand the C escapes `echo -e` understands, in place into `out`.
+@ __echo_escapes String out s text → v {
+    : i n ( nurl_str_len text )
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get text i )
+        ? & == c 92 < + i 1 n {
+            : i e ( nurl_str_get text + i 1 )
+            = i + i 2
+            ? == e 110 { ( string_push_char out 10 ) } {
+                ? == e 116 { ( string_push_char out 9 ) } {
+                    ? == e 114 { ( string_push_char out 13 ) } {
+                        ? == e 92 { ( string_push_char out 92 ) } {
+                            ? == e 97 { ( string_push_char out 7 ) } {
+                                ? == e 98 { ( string_push_char out 8 ) } {
+                                    ? == e 102 { ( string_push_char out 12 ) } {
+                                        ? == e 118 { ( string_push_char out 11 ) } {
+                                            ? == e 48 {
+                                                // \0NNN — up to three octal digits
+                                                : ~ i val 0
+                                                : ~ i k 0
+                                                ~ & < k 3 & < i n & >= ( nurl_str_get text i ) 48 <= ( nurl_str_get text i ) 55 {
+                                                    = val + * val 8 - ( nurl_str_get text i ) 48
+                                                    = i + i 1
+                                                    = k + k 1
+                                                }
+                                                ( string_push_char out & val 255 )
+                                            } {
+                                                ( string_push_char out 92 )
+                                                ( string_push_char out e )
+                                            } } } } } } } } }
+        } {
+            ( string_push_char out c )
+            = i + i 1
+        }
+    }
+}
+
+@ ap_echo ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    : ~ b newline T
+    : ~ b escapes F
+    : ~ i i 1
+    : ~ b scanning T
+    ~ & scanning < i n {
+        : s tok ( bx_at argv i )
+        ? ( __echo_is_opt tok ) {
+            : i tn ( nurl_str_len tok )
+            : ~ i k 1
+            ~ < k tn {
+                : i c ( nurl_str_get tok k )
+                ? == c 110 { = newline F } {}
+                ? == c 101 { = escapes T } {}
+                ? == c 69 { = escapes F } {}
+                = k + k 1
+            }
+            = i + i 1
+        } { = scanning F }
+    }
+    : String out ( string_new )
+    : ~ b first T
+    ~ < i n {
+        ? first { = first F } { ( string_push_char out 32 ) }
+        ? escapes {
+            ( __echo_escapes out ( bx_at argv i ) )
+        } {
+            ( string_push_str out ( bx_at argv i ) )
+        }
+        = i + i 1
+    }
+    ? newline { ( string_push_char out 10 ) } {}
+    ( bx_write out )
+    ( string_free out )
+    ^ 0
+}
+
+// ── cat ───────────────────────────────────────────────────────────
+
+: i CAT_NUMBER 1  // -n
+: i CAT_NONBLANK 2  // -b
+: i CAT_ENDS 4  // -E
+: i CAT_TABS 8  // -T
+: i CAT_NONPRINT 16  // -v
+: i CAT_SQUEEZE 32  // -s
+
+// Straight copy — no rewriting at all, so cat is a byte pipe.
+@ __cat_raw s path → i {
+    ? ( bx_is_stdin path ) {
+        : ~ b more T
+        ~ more {
+            : ( Vec u ) chunk ( read_n_bytes 65536 )
+            ? == ( vec_len [u] chunk ) 0 { = more F } { ( bx_write_bytes chunk ) }
+            ( vec_free [u] chunk )
+        }
+        ^ 0
+    } {}
+    ?? ( file_open path ) {
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            ^ 1
+        }
+        T f → {
+            : ~ i rc 0
+            : ~ b more T
+            ~ more {
+                ?? ( file_read_chunk f 65536 ) {
+                    T chunk → {
+                        ? == ( vec_len [u] chunk ) 0 { = more F } { ( bx_write_bytes chunk ) }
+                        ( vec_free [u] chunk )
+                    }
+                    F e2 → {
+                        ( bx_err_at path ( bx_ioerr e2 ) )
+                        = rc 1
+                        = more F
+                    }
+                }
+            }
+            ( file_close f )
+            ^ rc
+        }
+    }
+}
+
+// `%6d\t` — the numbering coreutils emits.
+@ __cat_number String out i lineno → v {
+    : s digits ( nurl_str_int lineno )
+    : i w ( nurl_str_len digits )
+    : ~ i pad - 6 w
+    ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+    ( string_push_str out digits )
+    ( string_push_char out 9 )
+}
+
+// One byte, rendered the way -v / -T / -E ask for.
+@ __cat_byte String out i c i flags → v {
+    ? & != 0 & flags CAT_TABS == c 9 {
+        ( string_push_str out `^I` )
+    } {
+        ? & != 0 & flags CAT_NONPRINT ! | == c 9 == c 10 {
+            : ~ i b c
+            ? >= b 128 {
+                ( string_push_str out `M-` )
+                = b - b 128
+            } {}
+            ? < b 32 {
+                ( string_push_char out 94 )
+                ( string_push_char out + b 64 )
+            } {
+                ? == b 127 {
+                    ( string_push_str out `^?` )
+                } {
+                    ( string_push_char out b )
+                }
+            }
+        } {
+            ( string_push_char out c )
+        }
+    }
+}
+
+@ __cat_cooked s path i flags inout i lineno inout i blanks → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String line ( string_new )
+            : String out ( string_new )
+            : ~ b more T
+            ~ more {
+                ? ( bufreader_read_line_raw br line ) {
+                    : i ln ( string_len line )
+                    // The payload is the line without its terminator.
+                    : ~ i body ln
+                    : ~ b had_nl F
+                    ? & > body 0 == ( string_get line - body 1 ) 10 {
+                        = body - body 1
+                        = had_nl T
+                        ? & > body 0 == ( string_get line - body 1 ) 13 { = body - body 1 } {}
+                    } {}
+                    : b blank == body 0
+                    : ~ b skip F
+                    ? & != 0 & flags CAT_SQUEEZE blank {
+                        = blanks + blanks 1
+                        ? > blanks 1 { = skip T } {}
+                    } {}
+                    ? ! blank { = blanks 0 } {}
+                    ? ! skip {
+                        ( string_clear out )
+                        ? != 0 & flags CAT_NONBLANK {
+                            ? ! blank {
+                                = lineno + lineno 1
+                                ( __cat_number out lineno )
+                            } {}
+                        } {
+                            ? != 0 & flags CAT_NUMBER {
+                                = lineno + lineno 1
+                                ( __cat_number out lineno )
+                            } {}
+                        }
+                        : ~ i k 0
+                        ~ < k body {
+                            ( __cat_byte out ( string_get line k ) flags )
+                            = k + k 1
+                        }
+                        ? != 0 & flags CAT_ENDS { ( string_push_char out 36 ) } {}
+                        // The terminator is copied verbatim: a CRLF file
+                        // stays CRLF, a file with no final newline gains
+                        // none.
+                        : ~ i t body
+                        ~ < t ln {
+                            ( string_push_char out ( string_get line t ) )
+                            = t + t 1
+                        }
+                        ( bx_write out )
+                    } {}
+                } { = more F }
+            }
+            ( string_free line )
+            ( string_free out )
+            ( bufreader_close br )
+            ^ 0
+        }
+    }
+}
+
+@ ap_cat ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `nbeEtTvAsu` `number=n,number-nonblank=b,show-ends=E,show-tabs=T,show-nonprinting=v,show-all=A,squeeze-blank=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i flags 0
+        ? ( bx_has o `n` ) { = flags | flags CAT_NUMBER } {}
+        ? ( bx_has o `b` ) { = flags | flags CAT_NONBLANK } {}
+        ? ( bx_has o `E` ) { = flags | flags CAT_ENDS } {}
+        ? ( bx_has o `T` ) { = flags | flags CAT_TABS } {}
+        ? ( bx_has o `v` ) { = flags | flags CAT_NONPRINT } {}
+        ? ( bx_has o `s` ) { = flags | flags CAT_SQUEEZE } {}
+        ? ( bx_has o `e` ) { = flags | flags | CAT_NONPRINT CAT_ENDS } {}
+        ? ( bx_has o `t` ) { = flags | flags | CAT_NONPRINT CAT_TABS } {}
+        ? ( bx_has o `A` ) { = flags | flags | CAT_NONPRINT | CAT_ENDS CAT_TABS } {}
+        : i nops ( bx_operand_count o )
+        : ~ i lineno 0
+        : ~ i blanks 0
+        ? == nops 0 {
+            ? == flags 0 {
+                = rc ( __cat_raw `-` )
+            } {
+                = rc ( __cat_cooked `-` flags lineno blanks )
+            }
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                : ~ i one 0
+                ? == flags 0 {
+                    = one ( __cat_raw p )
+                } {
+                    = one ( __cat_cooked p flags lineno blanks )
+                }
+                ? != one 0 { = rc 1 } {}
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── head ──────────────────────────────────────────────────────────
+
+@ __head_banner b show s path b first → v {
+    ? show {
+        ? ! first { ( nurl_print `\n` ) } {}
+        ( nurl_print `==> ` )
+        ( nurl_print ? ( bx_is_stdin path ) `standard input` path )
+        ( nurl_print ` <==\n` )
+    } {}
+}
+
+@ __head_lines s path i count → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String line ( string_new )
+            : ~ i seen 0
+            : ~ b more T
+            ~ & more < seen count {
+                ? ( bufreader_read_line_raw br line ) {
+                    ( bx_write line )
+                    = seen + seen 1
+                } { = more F }
+            }
+            ( string_free line )
+            ( bufreader_close br )
+            ^ 0
+        }
+    }
+}
+
+@ __head_bytes s path i count → i {
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp path ok )
+    : ~ i rc 0
+    ? ok {
+        : i n ( vec_len [u] data )
+        : i take ? < count n count n
+        ? > take 0 { ( nurl_print_bytes # s ( vec_data [u] data ) take ) } {}
+    } { = rc 1 }
+    ( vec_free [u] data )
+    ^ rc
+}
+
+@ ap_head ( Vec String ) argv → i {
+    // `head -5` is the historical spelling and still in every script.
+    : ( Vec String ) av ( vec_new [String] )
+    : i argn ( vec_len [String] argv )
+    : ~ i ai 0
+    ~ < ai argn {
+        : s tok ( bx_at argv ai )
+        : i tl ( nurl_str_len tok )
+        ? & & > ai 0 > tl 1 & == ( nurl_str_get tok 0 ) 45 ( bx_is_digit ( nurl_str_get tok 1 ) ) {
+            ( vec_push [String] av ( string_from `-n` ) )
+            ( vec_push [String] av ( string_from ( nurl_str_slice tok 1 - tl 1 ) ) )
+        } {
+            ( vec_push [String] av ( string_from tok ) )
+        }
+        = ai + ai 1
+    }
+    : BxOpts o ( bx_getopt av 1 `c:n:qv` `bytes=c,lines=n,quiet=q,silent=q,verbose=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i lines 10
+        : ~ i bytes -1
+        : ~ b bad F
+        ? ( bx_has o `n` ) {
+            : i v ( bx_count ( bx_val o `n` ) )
+            ? < v 0 { ( bx_err_at ( bx_val o `n` ) `invalid number of lines` ) = bad T } { = lines v }
+        } {}
+        ? ( bx_has o `c` ) {
+            : i v ( bx_count ( bx_val o `c` ) )
+            ? < v 0 { ( bx_err_at ( bx_val o `c` ) `invalid number of bytes` ) = bad T } { = bytes v }
+        } {}
+        ? bad { = rc 1 } {
+            : i nops ( bx_operand_count o )
+            : b show & ! ( bx_has o `q` ) | ( bx_has o `v` ) > nops 1
+            ? == nops 0 {
+                = rc ? >= bytes 0 ( __head_bytes `-` bytes ) ( __head_lines `-` lines )
+            } {
+                : ~ i i 0
+                ~ < i nops {
+                    : s p ( bx_operand o i )
+                    ( __head_banner show p == i 0 )
+                    : i one ? >= bytes 0 ( __head_bytes p bytes ) ( __head_lines p lines )
+                    ? != one 0 { = rc 1 } {}
+                    = i + i 1
+                }
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ( vec_free_with [String] av \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// ── tail ──────────────────────────────────────────────────────────
+
+// Keep the last `count` lines in a ring of Strings so an input far
+// larger than memory still costs only the window.
+@ __tail_lines s path i count b from_start → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String line ( string_new )
+            ? from_start {
+                : ~ i seen 0
+                : ~ b more T
+                ~ more {
+                    ? ( bufreader_read_line_raw br line ) {
+                        = seen + seen 1
+                        ? >= seen count { ( bx_write line ) } {}
+                    } { = more F }
+                }
+            } {
+                : ( Vec String ) ring ( vec_new [String] )
+                : ~ i head 0
+                : ~ i held 0
+                : ~ b more T
+                ~ more {
+                    ? ( bufreader_read_line_raw br line ) {
+                        ? < held count {
+                            ( vec_push [String] ring ( string_clone line ) )
+                            = held + held 1
+                        } {
+                            ?? ( vec_get [String] ring head ) {
+                                T slot → {
+                                    ( string_clear slot )
+                                    ( string_push_bytes slot # *u ( string_data line ) ( string_len line ) )
+                                }
+                                F _ → {}
+                            }
+                            = head + head 1
+                            ? >= head count { = head 0 } {}
+                        }
+                    } { = more F }
+                }
+                : ~ i k 0
+                ~ < k held {
+                    : i idx ? >= held count % + head k count k
+                    ?? ( vec_get [String] ring idx ) {
+                        T slot → { ( bx_write slot ) }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+                ( vec_free_with [String] ring \ String x → v { ( string_free x ) } )
+            }
+            ( string_free line )
+            ( bufreader_close br )
+            ^ 0
+        }
+    }
+}
+
+@ __tail_bytes s path i count b from_start → i {
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp path ok )
+    : ~ i rc 0
+    ? ok {
+        : i n ( vec_len [u] data )
+        : ~ i from 0
+        ? from_start {
+            = from ? > count 0 - count 1 0
+            ? > from n { = from n } {}
+        } {
+            = from ? > - n count 0 - n count 0
+        }
+        : i take - n from
+        ? > take 0 { ( nurl_print_bytes # s + # i ( vec_data [u] data ) from take ) } {}
+    } { = rc 1 }
+    ( vec_free [u] data )
+    ^ rc
+}
+
+@ ap_tail ( Vec String ) argv → i {
+    : ( Vec String ) av ( vec_new [String] )
+    : i argn ( vec_len [String] argv )
+    : ~ i ai 0
+    ~ < ai argn {
+        : s tok ( bx_at argv ai )
+        : i tl ( nurl_str_len tok )
+        ? & & > ai 0 > tl 1 & == ( nurl_str_get tok 0 ) 45 ( bx_is_digit ( nurl_str_get tok 1 ) ) {
+            ( vec_push [String] av ( string_from `-n` ) )
+            ( vec_push [String] av ( string_from ( nurl_str_slice tok 1 - tl 1 ) ) )
+        } {
+            ( vec_push [String] av ( string_from tok ) )
+        }
+        = ai + ai 1
+    }
+    : BxOpts o ( bx_getopt av 1 `c:n:qv` `bytes=c,lines=n,quiet=q,silent=q,verbose=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i lines 10
+        : ~ i bytes -1
+        : ~ b from_start F
+        : ~ b bad F
+        ? ( bx_has o `n` ) {
+            : s raw ( bx_val o `n` )
+            : b plus == ( nurl_str_get raw 0 ) 43
+            : i v ( bx_count ? plus ( nurl_str_slice raw 1 - ( nurl_str_len raw ) 1 ) raw )
+            ? < v 0 { ( bx_err_at raw `invalid number of lines` ) = bad T } {
+                = lines v
+                = from_start plus
+            }
+        } {}
+        ? ( bx_has o `c` ) {
+            : s raw ( bx_val o `c` )
+            : b plus == ( nurl_str_get raw 0 ) 43
+            : i v ( bx_count ? plus ( nurl_str_slice raw 1 - ( nurl_str_len raw ) 1 ) raw )
+            ? < v 0 { ( bx_err_at raw `invalid number of bytes` ) = bad T } {
+                = bytes v
+                = from_start plus
+            }
+        } {}
+        ? bad { = rc 1 } {
+            : i nops ( bx_operand_count o )
+            : b show & ! ( bx_has o `q` ) | ( bx_has o `v` ) > nops 1
+            ? == nops 0 {
+                = rc ? >= bytes 0 ( __tail_bytes `-` bytes from_start ) ( __tail_lines `-` lines from_start )
+            } {
+                : ~ i i 0
+                ~ < i nops {
+                    : s p ( bx_operand o i )
+                    ( __head_banner show p == i 0 )
+                    : i one ? >= bytes 0 ( __tail_bytes p bytes from_start ) ( __tail_lines p lines from_start )
+                    ? != one 0 { = rc 1 } {}
+                    = i + i 1
+                }
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ( vec_free_with [String] av \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// ── wc ────────────────────────────────────────────────────────────
+
+: WcCount {
+    i lines
+    i words
+    i bytes
+    i chars
+    i longest
+}
+
+@ __wc_one s path inout i lines inout i words inout i bytes inout i chars inout i longest → i {
+    ?? ( bx_reader path ) {
+        F _ → { ^ 1 }
+        T br → {
+            : String line ( string_new )
+            : ~ b more T
+            ~ more {
+                ? ( bufreader_read_line_raw br line ) {
+                    : i n ( string_len line )
+                    = bytes + bytes n
+                    : ~ i body n
+                    ? & > body 0 == ( string_get line - body 1 ) 10 {
+                        = lines + lines 1
+                        = body - body 1
+                        ? & > body 0 == ( string_get line - body 1 ) 13 { = body - body 1 } {}
+                    } {}
+                    ? > body longest { = longest body } {}
+                    : ~ b in_word F
+                    : ~ i k 0
+                    ~ < k n {
+                        : i c ( string_get line k )
+                        // A UTF-8 continuation byte is not a character.
+                        ? != 128 & c 192 { = chars + chars 1 } {}
+                        : b sp | | | == c 32 == c 9 == c 10 | == c 13 | == c 11 == c 12
+                        ? sp { = in_word F } {
+                            ? ! in_word { = words + words 1 = in_word T } {}
+                        }
+                        = k + k 1
+                    }
+                } { = more F }
+            }
+            ( string_free line )
+            ( bufreader_close br )
+            ^ 0
+        }
+    }
+}
+
+// busybox's column rule: a lone counter over at most one file prints
+// bare, anything else pads every field to 9 columns.
+@ __wc_field String out i val b pad → v {
+    ? pad {
+        : s d ( nurl_str_int val )
+        : ~ i k - 9 ( nurl_str_len d )
+        ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+        ( string_push_str out d )
+    } {
+        ( string_push_int out val )
+    }
+}
+
+@ __wc_emit String out i flags b pad i lines i words i bytes i chars i longest s label → v {
+    : ~ b first T
+    ? != 0 & flags 1 {
+        ( __wc_field out lines pad )
+        = first F
+    } {}
+    ? != 0 & flags 2 {
+        ? ! first { ( string_push_char out 32 ) } {}
+        ( __wc_field out words pad )
+        = first F
+    } {}
+    ? != 0 & flags 4 {
+        ? ! first { ( string_push_char out 32 ) } {}
+        ( __wc_field out bytes pad )
+        = first F
+    } {}
+    ? != 0 & flags 8 {
+        ? ! first { ( string_push_char out 32 ) } {}
+        ( __wc_field out chars pad )
+        = first F
+    } {}
+    ? != 0 & flags 16 {
+        ? ! first { ( string_push_char out 32 ) } {}
+        ( __wc_field out longest pad )
+        = first F
+    } {}
+    ? > ( nurl_str_len label ) 0 {
+        ( string_push_char out 32 )
+        ( string_push_str out label )
+    } {}
+    ( string_push_char out 10 )
+}
+
+@ ap_wc ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `clwmL` `lines=l,bytes=c,words=w,chars=m,max-line-length=L` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i flags 0
+        ? ( bx_has o `l` ) { = flags | flags 1 } {}
+        ? ( bx_has o `w` ) { = flags | flags 2 } {}
+        ? ( bx_has o `c` ) { = flags | flags 4 } {}
+        ? ( bx_has o `m` ) { = flags | flags 8 } {}
+        ? ( bx_has o `L` ) { = flags | flags 16 } {}
+        ? == flags 0 { = flags 7 } {}
+        : i nfields ( nurl_popcnt flags )
+        : i nops ( bx_operand_count o )
+        : b pad ! & == nfields 1 <= nops 1
+        : String out ( string_new )
+        : ~ i tl 0
+        : ~ i tw 0
+        : ~ i tb 0
+        : ~ i tc 0
+        : ~ i tm 0
+        ? == nops 0 {
+            : ~ i l 0
+            : ~ i w 0
+            : ~ i b 0
+            : ~ i c 0
+            : ~ i m 0
+            = rc ( __wc_one `-` l w b c m )
+            ( string_clear out )
+            ( __wc_emit out flags pad l w b c m `` )
+            ( bx_write out )
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                : ~ i l 0
+                : ~ i w 0
+                : ~ i b 0
+                : ~ i c 0
+                : ~ i m 0
+                : i one ( __wc_one p l w b c m )
+                ? != one 0 { = rc 1 } {
+                    ( string_clear out )
+                    ( __wc_emit out flags pad l w b c m p )
+                    ( bx_write out )
+                    = tl + tl l
+                    = tw + tw w
+                    = tb + tb b
+                    = tc + tc c
+                    ? > m tm { = tm m } {}
+                }
+                = i + i 1
+            }
+            ? > nops 1 {
+                ( string_clear out )
+                ( __wc_emit out flags pad tl tw tb tc tm `total` )
+                ( bx_write out )
+            } {}
+        }
+        ( string_free out )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── seq ───────────────────────────────────────────────────────────
+
+@ ap_seq ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ws:` `separator=s,equal-width=w` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i nops ( bx_operand_count o )
+        ? | == nops 0 > nops 3 {
+            ( bx_err `usage: seq [FIRST [INCREMENT]] LAST` )
+            = rc 1
+        } {
+            : f first ? > nops 1 ( nurl_str_to_float ( bx_operand o 0 ) ) 1.0
+            : f incr ? > nops 2 ( nurl_str_to_float ( bx_operand o 1 ) ) 1.0
+            : f last ( nurl_str_to_float ( bx_operand o - nops 1 ) )
+            : s sep ? ( bx_has o `s` ) ( bx_val o `s` ) `\n`
+            ? == incr 0.0 {
+                ( bx_err `increment may not be zero` )
+                = rc 1
+            } {
+                : String out ( string_new )
+                : ~ f x first
+                : ~ b more T
+                : ~ b any F
+                ~ more {
+                    ? > incr 0.0 { = more <= x last } { = more >= x last }
+                    ? more {
+                        // The separator goes BETWEEN the numbers; the
+                        // line ends with a newline whatever -s said.
+                        ? any { ( string_push_str out sep ) } {}
+                        ( string_push_float out x )
+                        = any T
+                        = x + x incr
+                    } {}
+                    ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                }
+                ? any { ( string_push_char out 10 ) } {}
+                ( bx_write out )
+                ( string_free out )
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── yes ───────────────────────────────────────────────────────────
+
+@ ap_yes ( Vec String ) argv → i {
+    : String unit ( string_new )
+    : i n ( vec_len [String] argv )
+    ? <= n 1 {
+        ( string_push_str unit `y` )
+    } {
+        : ~ i i 1
+        ~ < i n {
+            ? > i 1 { ( string_push_char unit 32 ) } {}
+            ( string_push_str unit ( bx_at argv i ) )
+            = i + i 1
+        }
+    }
+    ( string_push_char unit 10 )
+    // One large block per write beats one write per line by an order of
+    // magnitude, and `yes` exists to saturate a pipe.
+    : String block ( string_new )
+    ~ < ( string_len block ) 8192 {
+        ( string_push_bytes block # *u ( string_data unit ) ( string_len unit ) )
+    }
+    : ~ b more T
+    ~ more { ( bx_write block ) }
+    ( string_free block )
+    ( string_free unit )
+    ^ 0
+}

--- a/packages/nurlbox/tests/cases.sh
+++ b/packages/nurlbox/tests/cases.sh
@@ -1,0 +1,316 @@
+# tests/cases.sh — the case list, sourced by nurlbox_test.sh.
+#
+# Grouped by applet. `dt` compares text output, `dtb` compares raw bytes
+# (so a missing or extra trailing newline fails), `expect` states an
+# answer outright.
+
+echo "[echo]"
+dt  echo hello world
+dt  echo -n no trailing newline
+dt  echo -e 'tab\there\nand a line'
+dt  echo -E 'literal\tbackslash'
+dt  echo
+dt  echo -- --not-an-option
+dt  echo -x -- keeps the dash
+
+echo "[cat]"
+dtb cat four.txt
+dtb cat four.txt words.txt
+dtb cat nonl.txt
+dtb cat crlf.txt
+dtb cat binary.bin
+dtb cat empty.txt
+dtb --stdin four.txt cat
+dtb --stdin four.txt cat -
+dtb cat -n four.txt
+dtb cat -b words.txt
+dtg cat -E four.txt
+dtg cat -T tabs.txt
+dtb cat -A tabs.txt
+dtg cat -s words.txt
+dtg cat -n nonl.txt
+dtb cat -n crlf.txt
+
+echo "[head]"
+dtb head four.txt
+dtb head -n 2 four.txt
+dtb head -2 four.txt
+dtb head -n 0 four.txt
+dtb head -n 99 four.txt
+dtb head -c 5 four.txt
+dtb head four.txt words.txt
+dtb head -q four.txt words.txt
+dtb head -v four.txt
+dtb --stdin hundred.txt head -n 3
+dtb head -n 3 nonl.txt
+
+echo "[tail]"
+dtb tail four.txt
+dtb tail -n 2 four.txt
+dtb tail -2 four.txt
+dtb tail -n 99 hundred.txt
+dtb tail -n +95 hundred.txt
+dtb tail -c 6 four.txt
+dtb tail four.txt words.txt
+dtb --stdin hundred.txt tail -n 3
+dtb tail -n 1 nonl.txt
+
+echo "[wc]"
+dt  wc four.txt
+dt  wc -l four.txt
+dt  wc -w words.txt
+dt  wc -c four.txt
+dt  wc -L words.txt
+dt  wc -lw four.txt
+dt  wc four.txt words.txt
+dt  wc -c four.txt words.txt
+dt  --stdin words.txt wc
+dt  wc empty.txt
+dt  wc nonl.txt
+
+echo "[seq]"
+dt  seq 5
+dt  seq 3 7
+dt  seq 2 2 10
+dt  seq 10 -2 2
+dt  seq -s , 1 4
+dt  seq 0
+
+echo "[true/false]"
+dt  true
+dt  false
+
+echo "[pwd/basename/dirname]"
+dt  basename /a/b/c.txt
+dt  basename /a/b/c.txt .txt
+dt  basename /a/b/
+dt  basename c.txt .txt
+dt  dirname /a/b/c.txt
+dt  dirname c.txt
+dt  dirname /
+dt  dirname /a/
+
+echo "[system]"
+dt  uname
+dt  uname -a
+dt  uname -srm
+dt  hostname
+dt  whoami
+dt  id
+dt  id -u
+dt  id -g
+dt  groups
+dt  nproc
+dt  arch
+dt  which sh
+dtg printenv HOME
+
+echo "[printf]"
+dt  printf 'plain\n'
+dt  printf '%s|%s\n' a b
+dt  printf '%d %i %u\n' 42 -7 9
+dt  printf '%x %X %o\n' 255 255 8
+dt  printf '%5d|%-5d|%05d\n' 42 42 42
+dt  printf '%c%c\n' ab cd
+dt  printf '%s\n' one two three
+dt  printf 'tab\there\n'
+dt  printf '%%\n'
+dt  printf '%.2s\n' abcdef
+
+echo "[ls]"
+dt  ls .
+dt  ls -1 .
+dt  ls -a .
+dt  ls -A .
+dt  ls sub
+dt  ls -R .
+dt  ls -F .
+dt  ls -d .
+dt  ls four.txt words.txt
+dt  ls nonexistent-entry
+dt  ls -i four.txt
+dt  ls -s four.txt
+
+echo "[stat]"
+dt  stat four.txt
+dt  stat sub
+dt  stat -c '%n %s %F %a %A %h %u %g' four.txt
+dt  stat -c '%n' nonexistent-entry
+
+echo "[du]"
+dt  du sub
+dt  du -s sub
+dt  du -a sub
+dt  du -k sub
+dt  du -c sub
+
+echo "[find]"
+# find emits in directory order, which is the filesystem's business;
+# nurlbox sorts each directory so a run is reproducible. Compare the two
+# as SETS — the contents are the contract, the order is not.
+dtsort find sub
+dtsort find . -maxdepth 1 -type d
+dtsort find . -name '*.txt'
+dtsort find . -type f -name 'four*'
+dtsort find . -maxdepth 1 ! -type d
+dtsort find . -name 'a*' -o -name 'b*'
+
+echo "[mutating: mkdir/rm/cp/mv/ln/touch]"
+dtfs mkdir newdir
+dtfs mkdir -p a/b/c
+dtfs rmdir empty
+dtfs rm src/a.txt
+dtfs rm -r src
+dtfs rm -f nonexistent
+dtfs cp src/a.txt dst/
+dtfs cp src/a.txt dst/renamed.txt
+dtfs cp -r src dst/copied
+dtfs cp -a src dst/arch
+dtfs mv src/a.txt dst/
+dtfs mv src dst/moved
+dtfs ln -s a.txt src/newlink
+dtfs ln src/a.txt src/hard.txt
+dtfs touch src/brand-new
+dtfs touch -c src/absent
+dtfs chmod 600 src/a.txt
+dtfs chmod u+x,go-r src/b.txt
+dtfs chmod -R 700 src
+dtfs truncate -s 2 src/a.txt
+
+echo "[filters]"
+dtb tac four.txt
+dtb rev four.txt
+dtb nl four.txt
+dtb nl -ba words.txt
+dtg nl -nrz -w4 four.txt
+dtb sort dupes.txt
+dtb sort -r dupes.txt
+dtb sort -u dupes.txt
+dtb sort -n hundred.txt
+dtb sort -f dupes.txt
+dtb uniq dupes.txt
+dtb uniq -c dupes.txt
+dtb uniq -d dupes.txt
+dtb uniq -u dupes.txt
+dtb cut -c1-3 four.txt
+dtb cut -c2- four.txt
+dtb cut -f1 tabs.txt
+dtb cut -f2,3 tabs.txt
+dtb cut -d: -f1 four.txt
+dtb --stdin four.txt tac
+dtb --stdin four.txt rev
+dtb --stdin four.txt sort
+
+echo "[tr]"
+dtb --stdin four.txt tr a-z A-Z
+dtb --stdin four.txt tr -d aeiou
+dtb --stdin words.txt tr -s ' '
+dtb --stdin four.txt tr '[:lower:]' '[:upper:]'
+dtb --stdin four.txt tr -c 'a-z\n' .
+
+echo "[hashes]"
+dt  md5sum four.txt
+dt  sha1sum four.txt
+dt  sha256sum four.txt
+dt  sha512sum four.txt
+dt  md5sum four.txt words.txt
+dt  md5sum binary.bin
+dt  crc32 four.txt
+dtg cksum four.txt
+dt  --stdin four.txt md5sum
+dtb base64 four.txt
+dtb base64 binary.bin
+dt  base64 -d /dev/null
+
+echo "[grep]"
+dt  grep alpha four.txt
+dt  grep -i ALPHA four.txt
+dt  grep -v alpha four.txt
+dt  grep -n a four.txt
+dt  grep -c a four.txt
+dt  grep -l a four.txt words.txt
+dt  grep -w one words.txt
+dt  grep -x alpha four.txt
+dt  grep -o 'a.*a' four.txt
+dt  grep -E 'al(pha|ph)' four.txt
+dt  grep 'al\(pha\|ph\)' four.txt
+dt  grep -F 'a.*a' four.txt
+dt  grep '^b' four.txt
+dt  grep 'a$' four.txt
+dt  grep nomatch four.txt
+dt  grep -e alpha -e bravo four.txt
+dt  grep -r alpha sub
+dt  --stdin four.txt grep alpha
+
+echo "[test]"
+dt  test 1 -eq 1
+dt  test 1 -eq 2
+dt  test 1 -ne 2
+dt  test 3 -lt 4
+dt  test 4 -le 4
+dt  test 5 -gt 4
+dt  test 5 -ge 6
+dt  test -f four.txt
+dt  test -f sub
+dt  test -d sub
+dt  test -e four.txt
+dt  test -s four.txt
+dt  test -s empty.txt
+dt  test -z ""
+dt  test -n abc
+dt  test abc = abc
+dt  test abc != def
+dt  test ! -f nope
+dt  test 1 -eq 1 -a 2 -eq 2
+dt  test 1 -eq 2 -o 2 -eq 2
+dt  test -r four.txt
+dt  test -w four.txt
+
+echo "[expr]"
+dt  expr 1 + 2
+dt  expr 7 - 9
+dt  expr 6 '*' 7
+dt  expr 10 / 3
+dt  expr 10 % 3
+dt  expr 10 '>' 9
+dt  expr 2 '<' 10
+dt  expr abc = abc
+dt  expr abc = def
+dt  expr length abcdef
+dt  expr substr abcdef 2 3
+dt  expr index abcdef d
+dt  expr 1 '|' 0
+dt  expr 0 '&' 1
+
+echo "[xargs]"
+dtb --stdin four.txt xargs echo
+dtb --stdin four.txt xargs -n1 echo
+dtb --stdin four.txt xargs -n2 echo
+
+echo "[sed]"
+dtb sed 's/a/A/' four.txt
+dtb sed 's/a/A/g' four.txt
+dtb sed 's/a/A/2' words.txt
+dtb sed -n '2p' four.txt
+dtb sed -n '2,3p' four.txt
+dtb sed '2d' four.txt
+dtb sed '$d' four.txt
+dtb sed -n '/bravo/p' four.txt
+dtb sed '/bravo/d' four.txt
+dtb sed -n '/alpha/,/charlie/p' four.txt
+dtb sed 's/\(al\)\(pha\)/\2\1/' four.txt
+dtb sed -E 's/(al)(pha)/\2\1/' four.txt
+dtb sed 's/alpha/[&]/' four.txt
+dtb sed 'y/abc/xyz/' four.txt
+dtb sed -n '$=' four.txt
+dtb sed '2q' four.txt
+dtb sed -n '2{p;p}' four.txt
+dtb sed '1!d' four.txt
+dtb sed -e 's/a/A/' -e 's/b/B/' four.txt
+dtb sed 'G' four.txt
+dtb sed -n '1h;2,$H;${g;p}' four.txt
+dtb sed '2i\INSERTED' four.txt
+dtb sed '2a\APPENDED' four.txt
+dtb sed '2c\CHANGED' four.txt
+dtb --stdin four.txt sed 's/a/A/'
+dtb sed 's/x/y/' nonl.txt

--- a/packages/nurlbox/tests/nurlbox_test.sh
+++ b/packages/nurlbox/tests/nurlbox_test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/nurlbox_test.sh — differential test suite.
+#
+#  nurlbox is a clone, so the specification is the original: every case
+#  below runs the same command line through `nurlbox` and through the
+#  system `busybox`, and the two must agree on stdout and on the exit
+#  status. Where busybox is absent the case is skipped rather than
+#  guessed at, and the cases with an explicit expectation still run.
+#
+#  Run from the package dir:  ./tests/nurlbox_test.sh
+#  Env: NURL    build driver (defaults to ../../nurl.sh in a checkout)
+#       NURLBOX pre-built binary to test instead of building one
+#       BUSYBOX  reference binary (default: busybox on $PATH)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+PKG="$(pwd)"
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+BUSYBOX="${BUSYBOX:-busybox}"
+command -v "$BUSYBOX" >/dev/null 2>&1 && HAVE_BB=1 || HAVE_BB=0
+
+WORK="$(mktemp -d -t nurlbox-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+if [ -n "${NURLBOX:-}" ]; then
+    NB="$NURLBOX"
+else
+    echo "[build] src/main.nu"
+    if ! (cd "$REPO_ROOT" && $NURL "$PKG/src/main.nu" "$WORK/nurlbox") >"$WORK/build.log" 2>&1; then
+        echo "FAIL: build failed"; tail -30 "$WORK/build.log"; exit 1
+    fi
+    NB="$WORK/nurlbox"
+fi
+
+PASS=0; FAIL=0; SKIP=0
+ok()   { PASS=$((PASS+1)); }
+bad()  { echo "  FAIL $*"; FAIL=$((FAIL+1)); }
+
+# ── fixtures ────────────────────────────────────────────────────────
+FX="$WORK/fx"
+mkdir -p "$FX/sub/deep" "$FX/empty"
+printf 'alpha\nbravo\ncharlie\ndelta\n'            > "$FX/four.txt"
+printf 'one two three\nfour  five\n\n\nsix\n'      > "$FX/words.txt"
+printf 'no-final-newline'                          > "$FX/nonl.txt"
+printf 'crlf one\r\ncrlf two\r\n'                  > "$FX/crlf.txt"
+printf ''                                          > "$FX/empty.txt"
+printf 'b\na\nc\na\n'                              > "$FX/dupes.txt"
+seq 1 100                                          > "$FX/hundred.txt"
+printf 'x\ty\tz\n1\t2\t3\n'                        > "$FX/tabs.txt"
+printf 'sub file\n'                                > "$FX/sub/inner.txt"
+printf 'deep file\n'                               > "$FX/sub/deep/leaf.txt"
+head -c 4096 /dev/urandom                          > "$FX/binary.bin"
+
+# ── the differential driver ─────────────────────────────────────────
+#   dt [--stdin FILE] <applet> [args...]
+dt() {
+    local infile=""
+    if [ "$1" = "--stdin" ]; then infile="$2"; shift 2; fi
+    local desc="$*"
+    if [ "$HAVE_BB" = 0 ]; then SKIP=$((SKIP+1)); return; fi
+    local go bo gs bs
+    if [ -n "$infile" ]; then
+        go="$(cd "$FX" && "$NB" "$@" < "$infile" 2>/dev/null)"; gs=$?
+        bo="$(cd "$FX" && "$BUSYBOX" "$@" < "$infile" 2>/dev/null)"; bs=$?
+    else
+        go="$(cd "$FX" && "$NB" "$@" 2>/dev/null)"; gs=$?
+        bo="$(cd "$FX" && "$BUSYBOX" "$@" 2>/dev/null)"; bs=$?
+    fi
+    if [ "$go" = "$bo" ] && [ "$gs" = "$bs" ]; then
+        ok
+    else
+        bad "$desc"
+        if [ "$gs" != "$bs" ]; then echo "    exit: got $gs want $bs"; fi
+        if [ "$go" != "$bo" ]; then
+            diff <(printf '%s' "$bo" | cat -A) <(printf '%s' "$go" | cat -A) \
+                 | head -8 | sed 's/^/    /'
+        fi
+    fi
+}
+
+# Byte-exact variant: compares raw bytes, so a trailing newline or a NUL
+# is part of the comparison. `$(...)` strips trailing newlines, which is
+# exactly what a `cat` test must not do.
+dtb() {
+    local infile=""
+    if [ "$1" = "--stdin" ]; then infile="$2"; shift 2; fi
+    local desc="$*"
+    if [ "$HAVE_BB" = 0 ]; then SKIP=$((SKIP+1)); return; fi
+    if [ -n "$infile" ]; then
+        (cd "$FX" && "$NB" "$@" < "$infile" >"$WORK/g.out" 2>/dev/null); local gs=$?
+        (cd "$FX" && "$BUSYBOX" "$@" < "$infile" >"$WORK/b.out" 2>/dev/null); local bs=$?
+    else
+        (cd "$FX" && "$NB" "$@" >"$WORK/g.out" 2>/dev/null); local gs=$?
+        (cd "$FX" && "$BUSYBOX" "$@" >"$WORK/b.out" 2>/dev/null); local bs=$?
+    fi
+    if cmp -s "$WORK/g.out" "$WORK/b.out" && [ "$gs" = "$bs" ]; then
+        ok
+    else
+        bad "$desc (bytes)"
+        [ "$gs" != "$bs" ] && echo "    exit: got $gs want $bs"
+        cmp "$WORK/b.out" "$WORK/g.out" 2>&1 | head -3 | sed 's/^/    /'
+    fi
+}
+
+# Differential against GNU coreutils instead of busybox. Used where
+# busybox simply does not implement the option (`cat -E`, `cat -s`) or
+# where it takes a documented shortcut nurlbox declines to copy —
+# busybox's `cat -n` appends a newline to a file that did not end in one,
+# which rewrites the input. The reference is whichever tool implements
+# the behaviour, not always the same tool.
+dtg() {
+    local infile=""
+    if [ "$1" = "--stdin" ]; then infile="$2"; shift 2; fi
+    local desc="$*" ref="$1"; shift
+    command -v "$ref" >/dev/null 2>&1 || { SKIP=$((SKIP+1)); return; }
+    if [ -n "$infile" ]; then
+        (cd "$FX" && "$NB" "$ref" "$@" < "$infile" >"$WORK/g.out" 2>/dev/null); local gs=$?
+        (cd "$FX" && "$ref" "$@" < "$infile" >"$WORK/b.out" 2>/dev/null); local bs=$?
+    else
+        (cd "$FX" && "$NB" "$ref" "$@" >"$WORK/g.out" 2>/dev/null); local gs=$?
+        (cd "$FX" && "$ref" "$@" >"$WORK/b.out" 2>/dev/null); local bs=$?
+    fi
+    if cmp -s "$WORK/g.out" "$WORK/b.out" && [ "$gs" = "$bs" ]; then
+        ok
+    else
+        bad "$desc (vs GNU)"
+        [ "$gs" != "$bs" ] && echo "    exit: got $gs want $bs"
+        cmp "$WORK/b.out" "$WORK/g.out" 2>&1 | head -3 | sed 's/^/    /'
+    fi
+}
+
+# Compare as a set: both sides sorted before diffing. For output whose
+# order is the filesystem's, not the tool's.
+dtsort() {
+    local desc="$*"
+    if [ "$HAVE_BB" = 0 ]; then SKIP=$((SKIP+1)); return; fi
+    local go bo gs bs
+    go="$(cd "$FX" && "$NB" "$@" 2>/dev/null | sort)"; gs=$?
+    bo="$(cd "$FX" && "$BUSYBOX" "$@" 2>/dev/null | sort)"; bs=$?
+    if [ "$go" = "$bo" ]; then ok; else
+        bad "$desc (set)"
+        diff <(printf '%s' "$bo") <(printf '%s' "$go") | head -8 | sed 's/^/    /'
+    fi
+}
+
+# Differential over a MUTATED tree. The command runs twice, each in its
+# own pristine copy of the seed tree, and the two resulting trees are
+# compared — names, contents and permission bits. That is the only
+# honest way to test `cp` / `mv` / `rm` / `mkdir`: their output is the
+# filesystem, not stdout.
+seed_tree() {
+    local d="$1"
+    rm -rf "$d"; mkdir -p "$d/src/sub" "$d/dst" "$d/empty"
+    printf 'alpha\n'  > "$d/src/a.txt"
+    printf 'bravo\n'  > "$d/src/b.txt"
+    printf 'deep\n'   > "$d/src/sub/c.txt"
+    ln -s a.txt "$d/src/link"
+    chmod 640 "$d/src/b.txt"
+}
+
+tree_digest() {
+    (cd "$1" && find . | sort && find . -type f | sort | xargs -r md5sum | sed "s| .*/| |" \
+     && find . -printf '%m %y %p\n' 2>/dev/null | sort)
+}
+
+dtfs() {
+    local desc="$*"
+    if [ "$HAVE_BB" = 0 ]; then SKIP=$((SKIP+1)); return; fi
+    seed_tree "$WORK/ta"; seed_tree "$WORK/tb"
+    local go bo gs bs
+    go="$(cd "$WORK/ta" && "$NB" "$@" 2>&1)"; gs=$?
+    bo="$(cd "$WORK/tb" && "$BUSYBOX" "$@" 2>&1)"; bs=$?
+    local gd bd
+    gd="$(tree_digest "$WORK/ta")"
+    bd="$(tree_digest "$WORK/tb")"
+    if [ "$gd" = "$bd" ] && [ "$gs" = "$bs" ]; then
+        ok
+    else
+        bad "$desc (tree)"
+        [ "$gs" != "$bs" ] && echo "    exit: got $gs want $bs  (stderr: $go)"
+        diff <(printf '%s' "$bd") <(printf '%s' "$gd") | head -8 | sed 's/^/    /'
+    fi
+}
+
+# Explicit expectation, for behaviour busybox does not have or where the
+# reference is unavailable.
+expect() {
+    local desc="$1" want="$2"; shift 2
+    local got; got="$(cd "$FX" && "$NB" "$@" 2>&1)"
+    [ "$got" = "$want" ] && ok || bad "$desc (got '$got', want '$want')"
+}
+
+. "$PKG/tests/cases.sh"
+
+echo
+echo "== nurlbox: PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
+[ "$FAIL" = 0 ]

--- a/stdlib/ext/env.nu
+++ b/stdlib/ext/env.nu
@@ -71,6 +71,43 @@ $ `stdlib/core/posix.nu`  // posix_const + nurl_errno_get
     ^ out
 }
 
+// ── Enumerating the environment ─────────────────────────────────────
+//
+// `env_get` answers about a name you already know. Listing what is
+// actually set — which `env` / `printenv` / a shell's `export -p` needs,
+// and which a program logging its own configuration wants — needs the
+// vector itself, and that is a C *variable* (`environ`, `_environ` on
+// Windows), not something NURL can bind through FFI. The runtime
+// enumerates it: `nurl_env_count` / `nurl_env_at`.
+
+& `c` @ nurl_env_count → i
+
+& `c` @ nurl_env_at i idx → s
+
+@ env_count → i { ^ ( nurl_env_count ) }
+
+// The `NAME=value` entry at `idx`, as an owned String; the empty string
+// past the end.
+@ env_entry i idx → String {
+    : s raw ( nurl_env_at idx )
+    ? == # i raw 0 { ^ ( string_new ) } {}
+    ^ ( string_from raw )
+}
+
+// Every `NAME=value` currently set, in the process's own order. The
+// caller owns the Vec and every String in it (vec_free_with).
+@ env_list → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    : i n ( nurl_env_count )
+    : ~ i i 0
+    ~ < i n {
+        : s raw ( nurl_env_at i )
+        ? != # i raw 0 { ( vec_push [String] out ( string_from raw ) ) } {}
+        = i + i 1
+    }
+    ^ out
+}
+
 @ env_get s name → ?String {
     ? == # i name 0 { ^ @ ?String { F # String 0 } } {}
     // getenv returns a libc-owned pointer; do not free. `string_from`

--- a/stdlib/ext/regex.nu
+++ b/stdlib/ext/regex.nu
@@ -22,7 +22,9 @@
 //
 // `.` matches any byte except `\n`. Anchors `^` and `$` are zero-width
 // and match only at text start / end (no multiline mode). All
-// quantifiers are greedy; submatch capture is not supported.
+// quantifiers are greedy. Capture groups ARE supported: `(` … `)` both
+// groups for precedence and records the span, readable through
+// `regex_find_caps` and substitutable through `regex_expand`.
 //
 // ── API ─────────────────────────────────────────────────────────────
 //
@@ -30,6 +32,9 @@
 //   ( regex_test    r text )        → b              any match anywhere
 //   ( regex_match   r text )        → b              entire text matches
 //   ( regex_find    r text )        → ? Match        leftmost match
+//   ( regex_find_caps r text slots ) → ? Match       …with capture groups
+//   ( regex_ngroups r )             → i              capture groups in it
+//   ( regex_expand  text slots tmpl ) → String       expand `&` / `\1`
 //   ( regex_find_all r text )       → ( Vec Match )  non-overlapping
 //   ( regex_replace  r text repl )  → String         non-overlapping replace
 //   ( regex_split    r text )       → ( Vec String ) split on matches
@@ -58,6 +63,9 @@ $ `stdlib/core/vec.nu`
 // 4 = Anchor (a = 0 for '^', 1 for '$'; out1 = next, zero-width)
 // 5 = Split  (out1, out2 are both ε-successors)
 // 6 = Eps    (out1 = next, zero-width)
+// 7 = Save   (a = capture slot; out1 = next, zero-width) — records the
+//            current position into the thread's slot array, which is how
+//            a group's span survives to the end of the match
 
 // ── Public types ────────────────────────────────────────────────────
 
@@ -71,6 +79,7 @@ $ `stdlib/core/vec.nu`
     ( Vec i ) classes  // class store, packed
     ( Vec i ) class_starts  // class_idx → offset in classes
     i start
+    i ngroups  // capture groups, numbered by opening paren
 }
 
 : Regex { s ctl }
@@ -83,6 +92,7 @@ $ `stdlib/core/vec.nu`
     ( Vec i ) states
     ( Vec i ) classes
     ( Vec i ) class_starts
+    i ngroups
 }
 
 // ── State table helpers ─────────────────────────────────────────────
@@ -466,11 +476,20 @@ $ `stdlib/core/vec.nu`
             } {
                 ? == c 40 {  // '('
                     = . p pos + . p pos 1
+                    // Number the group at its OPENING paren, before the
+                    // body is parsed, so nested groups number the way
+                    // every regex dialect promises: `((a)(b))` is 1, 2, 3.
+                    = . p ngroups + . p ngroups 1
+                    : i g . p ngroups
                     : i inner ( __parse_alt p )
                     ? < inner 0 { ^ -1 } {}
                     ? != ( __rx_peek p ) 41 { ^ -1 } {}
                     = . p pos + . p pos 1
-                    = frag inner
+                    : i s_open ( __rx_add_state p 7 * 2 g -1 -1 )
+                    : i s_close ( __rx_add_state p 7 + * 2 g 1 -1 -1 )
+                    : i f_open ( __frag s_open s_open )
+                    : i f_close ( __frag s_close s_close )
+                    = frag ( __emit_concat p ( __emit_concat p f_open inner ) f_close )
                 } {
                     ? == c 91 {  // '['
                         = . p pos + . p pos 1
@@ -564,6 +583,7 @@ $ `stdlib/core/vec.nu`
     = . p states ( vec_new [i] )
     = . p classes ( vec_new [i] )
     = . p class_starts ( vec_new [i] )
+    = . p ngroups 0
     : i frag ( __parse_alt p )
     ? < frag 0 {
         ( vec_free [i] . p states )
@@ -589,6 +609,7 @@ $ `stdlib/core/vec.nu`
     = . impl classes . p classes
     = . impl class_starts . p class_starts
     = . impl start start_idx
+    = . impl ngroups . p ngroups
     : Regex r @ Regex { # s impl }
     ( nurl_free # s p )
     ^ @ !Regex ParseErr { T r }
@@ -613,36 +634,65 @@ $ `stdlib/core/vec.nu`
 // land on the active list; Eps/Split/Anchor are zero-width and walked
 // transitively.
 
-@ __rx_add_active_v ( Vec i ) states ( Vec i ) active ( Vec i ) marked i s_idx i text_pos i text_len → v {
-    ? >= s_idx 0 {
-        : i was ( __vi_get marked s_idx )
-        ? == was 0 {
-            ( __vi_set marked s_idx 1 )
-            : i kind ( __rx_state_kind states s_idx )
-            ? == kind 6 {
-                : i o1 ( __rx_state_out1 states s_idx )
-                ( __rx_add_active_v states active marked o1 text_pos text_len )
-            } {
-                ? == kind 5 {
-                    : i o1 ( __rx_state_out1 states s_idx )
-                    : i o2 ( __rx_state_out2 states s_idx )
-                    ( __rx_add_active_v states active marked o1 text_pos text_len )
-                    ( __rx_add_active_v states active marked o2 text_pos text_len )
-                } {
-                    ? == kind 4 {
-                        : i a ( __rx_state_a states s_idx )
-                        : b matches ? == a 0 == text_pos 0 == text_pos text_len
-                        ? matches {
-                            : i o1 ( __rx_state_out1 states s_idx )
-                            ( __rx_add_active_v states active marked o1 text_pos text_len )
-                        } {}
-                    } {
-                        ( vec_push [i] active s_idx )
-                    }
-                }
-            }
-        } {}
+@ __vi_fill ( Vec i ) v i n i val → v {
+    : ~ i k 0
+    ~ < k n { ( __vi_set v k val ) = k + k 1 }
+}
+
+// Copy one thread's slot array out of the flat list, and back in.
+@ __rx_caps_load ( Vec i ) caps ( Vec i ) work i base i nslots → v {
+    : ~ i k 0
+    ~ < k nslots { ( __vi_set work k ( __vi_get caps + base k ) ) = k + k 1 }
+}
+
+// ε-closure with capture slots — a Pike VM's `addthread`.
+//
+// `work` is the caller's slot array for the thread being added; a Save
+// state writes into it, recurses, and writes the old value back, so one
+// array serves the whole depth-first walk instead of a copy per branch.
+// The copy happens once, at the leaf, when the thread is appended.
+//
+// Dedup is still by state, and the FIRST thread to reach a state keeps
+// it. Since Split's out1 is walked before out2 and out1 is the greedy
+// branch, that ordering is what makes `(a*)(a*)` put everything in the
+// first group rather than splitting arbitrarily.
+@ __rx_add_thread ( Vec i ) states ( Vec i ) active ( Vec i ) marked ( Vec i ) caps ( Vec i ) work i nslots i s_idx i text_pos i text_len → v {
+    ? < s_idx 0 { ^ } {}
+    ? != 0 ( __vi_get marked s_idx ) { ^ } {}
+    ( __vi_set marked s_idx 1 )
+    : i kind ( __rx_state_kind states s_idx )
+    ? == kind 6 {
+        ( __rx_add_thread states active marked caps work nslots ( __rx_state_out1 states s_idx ) text_pos text_len )
+        ^
     } {}
+    ? == kind 5 {
+        ( __rx_add_thread states active marked caps work nslots ( __rx_state_out1 states s_idx ) text_pos text_len )
+        ( __rx_add_thread states active marked caps work nslots ( __rx_state_out2 states s_idx ) text_pos text_len )
+        ^
+    } {}
+    ? == kind 4 {
+        : i a ( __rx_state_a states s_idx )
+        : b matches ? == a 0 == text_pos 0 == text_pos text_len
+        ? matches {
+            ( __rx_add_thread states active marked caps work nslots ( __rx_state_out1 states s_idx ) text_pos text_len )
+        } {}
+        ^
+    } {}
+    ? == kind 7 {
+        : i slot ( __rx_state_a states s_idx )
+        ? < slot nslots {
+            : i old ( __vi_get work slot )
+            ( __vi_set work slot text_pos )
+            ( __rx_add_thread states active marked caps work nslots ( __rx_state_out1 states s_idx ) text_pos text_len )
+            ( __vi_set work slot old )
+        } {
+            ( __rx_add_thread states active marked caps work nslots ( __rx_state_out1 states s_idx ) text_pos text_len )
+        }
+        ^
+    } {}
+    ( vec_push [i] active s_idx )
+    : ~ i k 0
+    ~ < k nslots { ( vec_push [i] caps ( __vi_get work k ) ) = k + k 1 }
 }
 
 @ __rx_clear_marked ( Vec i ) marked i n → v {
@@ -653,26 +703,40 @@ $ `stdlib/core/vec.nu`
     }
 }
 
-// Per-search scratch: the four Vec[i] the NFA simulation needs. These
-// used to be allocated (and freed) inside __rx_run_at, i.e. once per
-// START POSITION — 8005 allocations for a 2 KB subject in
-// `regex_replace`. They carry no state between runs, so every public
-// entry point now builds one scratch up front and reuses it across the
-// whole scan. Passing it explicitly (rather than caching it in the
-// Regex) keeps a compiled Regex reentrant: two searches can run over
-// the same Regex at once, each with its own scratch.
+// Per-search scratch: the Vec[i] the NFA simulation needs. These used to
+// be allocated (and freed) inside __rx_run_at, i.e. once per START
+// POSITION — 8005 allocations for a 2 KB subject in `regex_replace`.
+// They carry no state between runs, so every public entry point builds
+// one scratch up front and reuses it across the whole scan. Passing it
+// explicitly (rather than caching it in the Regex) keeps a compiled
+// Regex reentrant: two searches can run over the same Regex at once,
+// each with its own scratch.
 : RxScratch {
     ( Vec i ) cur
     ( Vec i ) nxt
     ( Vec i ) marked_cur
     ( Vec i ) marked_nxt
+    ( Vec i ) caps_cur  // flat: thread k owns [k*nslots, (k+1)*nslots)
+    ( Vec i ) caps_nxt
+    ( Vec i ) work  // one thread's slots, during the ε-closure
+    ( Vec i ) best  // the winning thread's slots
     i nstates
+    i nslots
 }
 
 @ __rx_nstates Regex r → i {
     : *RegexImpl impl # *RegexImpl . r ctl
     ^ / ( vec_len [i] . impl states ) 4
 }
+
+// Capture groups in the pattern. Group `k` occupies slots 2k and 2k+1;
+// slots 0 and 1 are the whole match, filled in by the caller.
+@ regex_ngroups Regex r → i {
+    : *RegexImpl impl # *RegexImpl . r ctl
+    ^ . impl ngroups
+}
+
+@ __rx_nslots Regex r → i { ^ * 2 + ( regex_ngroups r ) 1 }
 
 // A Vec[i] of `n` zeros — the marked-set shape __vi_set writes into.
 @ __rx_zeros i n → ( Vec i ) {
@@ -684,12 +748,18 @@ $ `stdlib/core/vec.nu`
 
 @ __rx_scratch_new Regex r → RxScratch {
     : i ns ( __rx_nstates r )
+    : i nsl ( __rx_nslots r )
     ^ @ RxScratch {
         ( vec_with_cap [i] ns )
         ( vec_with_cap [i] ns )
         ( __rx_zeros ns )
         ( __rx_zeros ns )
+        ( vec_with_cap [i] * ns nsl )
+        ( vec_with_cap [i] * ns nsl )
+        ( __rx_zeros nsl )
+        ( __rx_zeros nsl )
         ns
+        nsl
     }
 }
 
@@ -698,12 +768,18 @@ $ `stdlib/core/vec.nu`
     ( vec_free [i] . sc nxt )
     ( vec_free [i] . sc marked_cur )
     ( vec_free [i] . sc marked_nxt )
+    ( vec_free [i] . sc caps_cur )
+    ( vec_free [i] . sc caps_nxt )
+    ( vec_free [i] . sc work )
+    ( vec_free [i] . sc best )
 }
 
 // Try to match starting at text_pos. Returns the longest match length
 // found at this start (≥0), or -1 if no match. `sc` is scratch owned by
 // the caller; its contents are reset here, so the same scratch can be
-// handed to every start position of a scan.
+// handed to every start position of a scan. On success `sc.best` holds
+// the winning thread's capture slots (absolute offsets, -1 for a group
+// that did not take part).
 @ __rx_run_at Regex r s text i text_len i text_pos RxScratch sc → i {
     : *RegexImpl impl # *RegexImpl . r ctl
     : ( Vec i ) states . impl states
@@ -711,22 +787,34 @@ $ `stdlib/core/vec.nu`
     : ( Vec i ) class_starts . impl class_starts
     : i start . impl start
     : i nstates . sc nstates
+    : i nslots . sc nslots
     : ~ ( Vec i ) cur . sc cur
     : ~ ( Vec i ) nxt . sc nxt
     : ~ ( Vec i ) marked_cur . sc marked_cur
     : ~ ( Vec i ) marked_nxt . sc marked_nxt
+    : ~ ( Vec i ) caps_cur . sc caps_cur
+    : ~ ( Vec i ) caps_nxt . sc caps_nxt
+    : ( Vec i ) work . sc work
+    : ( Vec i ) best_caps . sc best
     ( vec_clear [i] cur )
     ( vec_clear [i] nxt )
+    ( vec_clear [i] caps_cur )
+    ( vec_clear [i] caps_nxt )
     ( __rx_clear_marked marked_cur nstates )
     ( __rx_clear_marked marked_nxt nstates )
-    ( __rx_add_active_v states cur marked_cur start text_pos text_len )
+    ( __vi_fill work nslots -1 )
+    ( __vi_fill best_caps nslots -1 )
+    ( __rx_add_thread states cur marked_cur caps_cur work nslots start text_pos text_len )
 
     : ~ i best -1
-    // Check if start state itself is the match (zero-length match).
+    // The start state may itself be the match (a zero-length match).
     : ~ i k2 0
     ~ < k2 ( vec_len [i] cur ) {
         : i sx ( __vi_get cur k2 )
-        ? == ( __rx_state_kind states sx ) 0 { = best 0 } {}
+        ? & == ( __rx_state_kind states sx ) 0 < best 0 {
+            = best 0
+            ( __rx_caps_load caps_cur best_caps * k2 nslots nslots )
+        } {}
         = k2 + k2 1
     }
 
@@ -737,6 +825,7 @@ $ `stdlib/core/vec.nu`
             : i ch ( nurl_str_at text text_len pos )
             ( __rx_clear_marked marked_nxt nstates )
             ( vec_clear [i] nxt )
+            ( vec_clear [i] caps_nxt )
             : ~ i ki 0
             ~ < ki ( vec_len [i] cur ) {
                 : i si ( __vi_get cur ki )
@@ -756,24 +845,31 @@ $ `stdlib/core/vec.nu`
                 }
                 ? consumes {
                     : i nxt_state ( __rx_state_out1 states si )
-                    ( __rx_add_active_v states nxt marked_nxt nxt_state + pos 1 text_len )
+                    ( __rx_caps_load caps_cur work * ki nslots nslots )
+                    ( __rx_add_thread states nxt marked_nxt caps_nxt work nslots nxt_state + pos 1 text_len )
                 } {}
                 = ki + ki 1
             }
             = pos + pos 1
-            // Swap cur/nxt and their marked sets.
+            // Swap cur/nxt, their marked sets and their capture stores.
             : ( Vec i ) tmp cur
             = cur nxt
             = nxt tmp
             : ( Vec i ) tmpm marked_cur
             = marked_cur marked_nxt
             = marked_nxt tmpm
-            // After consuming a byte, check if any state in the new cur is
-            // a Match — record longest.
+            : ( Vec i ) tmpc caps_cur
+            = caps_cur caps_nxt
+            = caps_nxt tmpc
+            // After consuming a byte, check whether any state in the new
+            // cur is a Match — record the longest.
             : ~ i kj 0
             ~ < kj ( vec_len [i] cur ) {
                 : i sk ( __vi_get cur kj )
-                ? == ( __rx_state_kind states sk ) 0 { = best - pos text_pos } {}
+                ? & == ( __rx_state_kind states sk ) 0 > - pos text_pos best {
+                    = best - pos text_pos
+                    ( __rx_caps_load caps_cur best_caps * kj nslots nslots )
+                } {}
                 = kj + kj 1
             }
             ? == ( vec_len [i] cur ) 0 { = done T } {}
@@ -819,6 +915,107 @@ $ `stdlib/core/vec.nu`
     ( __rx_scratch_free sc )
     ? >= hit_at 0 { ^ @ ?Match { T @ Match { hit_at hit_len } } } {}
     ^ @ ?Match { F @ Match { 0 0 } }
+}
+
+// The leftmost match, WITH its capture groups.
+//
+// `slots` is cleared and refilled with `2 * (ngroups + 1)` entries of
+// absolute byte offsets into `text`: slots 0 and 1 are the whole match's
+// start and end, and group k occupies 2k and 2k+1. A group that did not
+// take part in the match (the untaken side of an alternation, a `?` that
+// matched nothing) reads -1 in BOTH of its slots — the caller must test
+// for it rather than assume a span.
+//
+//     : ( Vec i ) slots ( vec_new [i] )
+//     ?? ( regex_find_caps r line slots ) {
+//       T m → { : i g1s ( __vi_get slots 2 ) … }
+//       F _ → { }
+//     }
+@ regex_find_caps Regex r s text ( Vec i ) slots → ?Match {
+    : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
+    : i nslots . sc nslots
+    ( vec_clear [i] slots )
+    : ~ i k 0
+    ~ < k nslots { ( vec_push [i] slots -1 ) = k + k 1 }
+    : ~ i pos 0
+    : ~ i hit_at -1
+    : ~ i hit_len 0
+    ~ & < hit_at 0 <= pos n {
+        : i m ( __rx_run_at r text n pos sc )
+        ? >= m 0 {
+            = hit_at pos
+            = hit_len m
+            : ~ i j 0
+            ~ < j nslots { ( __vi_set slots j ( __vi_get . sc best j ) ) = j + j 1 }
+            ( __vi_set slots 0 pos )
+            ( __vi_set slots 1 + pos m )
+        } { = pos + pos 1 }
+    }
+    ( __rx_scratch_free sc )
+    ? >= hit_at 0 { ^ @ ?Match { T @ Match { hit_at hit_len } } } {}
+    ^ @ ?Match { F @ Match { 0 0 } }
+}
+
+// Expand a replacement template against a match's capture slots — the
+// `s///` right-hand side every editor and every sed writes:
+//
+//   &        the whole match          \1 … \9   capture group 1 … 9
+//   \&       a literal ampersand      \\        a literal backslash
+//   \n \t \r the usual escapes        \0        the whole match
+//
+// A reference to a group that did not participate expands to nothing,
+// which is what makes `s/(a)|(b)/[\1\2]/` produce `[a]` and `[b]`
+// rather than one of them failing.
+//
+// `regex_replace` deliberately does NOT do this — it inserts its
+// replacement verbatim, which is what a caller substituting arbitrary
+// user text needs. Use this when the template is a pattern language.
+@ regex_expand s text ( Vec i ) slots s tmpl → String {
+    : String out ( string_new )
+    : i tn ( nurl_str_len tmpl )
+    : i nslots ( vec_len [i] slots )
+    : ~ i i 0
+    ~ < i tn {
+        : i c ( nurl_str_at tmpl tn i )
+        ? == c 38 {
+            ( __rx_push_slot out text slots 0 nslots )
+            = i + i 1
+        } {
+            ? & == c 92 < + i 1 tn {
+                : i e ( nurl_str_at tmpl tn + i 1 )
+                = i + i 2
+                ? & >= e 48 <= e 57 {
+                    ( __rx_push_slot out text slots - e 48 nslots )
+                } {
+                    ? == e 110 { ( string_push_char out 10 ) } {
+                        ? == e 116 { ( string_push_char out 9 ) } {
+                            ? == e 114 { ( string_push_char out 13 ) } {
+                                ( string_push_char out e )
+                            } } }
+                }
+            } {
+                ( string_push_char out c )
+                = i + i 1
+            }
+        }
+    }
+    ^ out
+}
+
+@ __rx_push_slot String out s text ( Vec i ) slots i group i nslots → v {
+    : i a * 2 group
+    : i b + a 1
+    ? >= b nslots { ^ } {}
+    : i from ( __vi_get slots a )
+    : i to ( __vi_get slots b )
+    ? | < from 0 < to from { ^ } {}
+    : i n ( nurl_str_len text )
+    : ~ i k from
+    ~ & < k to < k n {
+        ( string_push_char out ( nurl_str_at text n k ) )
+        = k + k 1
+    }
 }
 
 @ regex_find_all Regex r s text → ( Vec Match ) {

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1619,6 +1619,18 @@ const char* nurl_read_file(const char *path) {
 #  include <fcntl.h>
 #  include <unistd.h>
 #  include <sys/ioctl.h>
+/* The user database and the timestamp setter, for nurl_user_name /
+ * nurl_group_name / nurl_utimes_set below. The freestanding target has
+ * neither a passwd file nor a utimensat: unikernel/nolibc/misc.c answers
+ * both, saying "no such user" and ENOSYS out loud rather than letting
+ * the link fail. */
+#  include <pwd.h>
+#  include <grp.h>
+#  include <sys/time.h>
+#  include <sys/utsname.h>
+#endif
+#ifdef _WIN32
+#  include <sys/utime.h>
 #endif
 
 /* Classify entry at `path` WITHOUT following a final symlink (lstat).
@@ -1670,6 +1682,317 @@ long long nurl_path_type_follow(const char *path) {
     if (S_ISDIR(st.st_mode)) return 2;
     if (S_ISREG(st.st_mode)) return 1;
     return 4;
+}
+
+/* ── stat(2), as a fixed-layout answer ──────────────────────────────
+ *
+ * `struct stat` is the least portable struct in POSIX: the field order,
+ * the widths and the timestamp spelling differ per platform, and on
+ * Windows it is a different struct under a different name. Reading it
+ * from NURL through `nurl_native_sizeof`/offset arithmetic would bake a
+ * per-platform offset table into the stdlib, which is exactly the kind
+ * of thing that compiles everywhere and is wrong somewhere.
+ *
+ * So the runtime does the reading, and hands back ONE layout the whole
+ * toolchain agrees on: sixteen int64 slots, documented here and mirrored
+ * by `FileStat` in stdlib/std/fs.nu.
+ *
+ *    0  mode        11  blksize
+ *    1  size        12  atime (seconds)
+ *    2  mtime       13  atime nanoseconds
+ *    3  mtime ns    14  ctime (seconds)
+ *    4  uid         15  ctime nanoseconds
+ *    5  gid
+ *    6  nlink
+ *    7  ino
+ *    8  dev
+ *    9  rdev
+ *   10  blocks (512-byte units)
+ *
+ * A field the platform does not have reads 0 — never a fabricated value.
+ * Returns 0 on success and -1 with errno set on failure, the same
+ * contract stat(2) itself has.
+ *
+ * `mode` carries the raw st_mode: the permission bits AND the file-type
+ * bits. The type bits are NOT portable constants either, so the classify
+ * helpers below answer the question rather than exporting S_IFMT. */
+#define NURL_STAT_SLOTS 16
+
+static void nurl__stat_fill(const struct stat *st, long long *out) {
+    int i;
+    for (i = 0; i < NURL_STAT_SLOTS; i++) out[i] = 0;
+    out[0]  = (long long)st->st_mode;
+    out[1]  = (long long)st->st_size;
+    out[2]  = (long long)st->st_mtime;
+    out[4]  = (long long)st->st_uid;
+    out[5]  = (long long)st->st_gid;
+    out[6]  = (long long)st->st_nlink;
+    out[7]  = (long long)st->st_ino;
+    out[8]  = (long long)st->st_dev;
+    out[9]  = (long long)st->st_rdev;
+    out[12] = (long long)st->st_atime;
+    out[14] = (long long)st->st_ctime;
+#if !defined(_WIN32)
+    out[10] = (long long)st->st_blocks;
+    out[11] = (long long)st->st_blksize;
+#endif
+#if defined(__linux__) || defined(__unix__)
+#  if defined(st_mtime) || defined(__USE_XOPEN2K8) || defined(_BSD_SOURCE) || defined(__linux__)
+    out[3]  = (long long)st->st_mtim.tv_nsec;
+    out[13] = (long long)st->st_atim.tv_nsec;
+    out[15] = (long long)st->st_ctim.tv_nsec;
+#  endif
+#elif defined(__APPLE__)
+    out[3]  = (long long)st->st_mtimespec.tv_nsec;
+    out[13] = (long long)st->st_atimespec.tv_nsec;
+    out[15] = (long long)st->st_ctimespec.tv_nsec;
+#endif
+}
+
+long long nurl_stat_into(const char *path, long long *out) {
+    struct stat st;
+    if (!path || !out) return -1;
+    if (stat(path, &st) != 0) return -1;
+    nurl__stat_fill(&st, out);
+    return 0;
+}
+
+/* The link itself, never what it points at. On Windows there is no
+ * lstat(2) and this is stat(2) — the same degradation nurl_path_type
+ * already documents. */
+long long nurl_lstat_into(const char *path, long long *out) {
+    struct stat st;
+    if (!path || !out) return -1;
+#ifdef _WIN32
+    if (stat(path, &st) != 0) return -1;
+#else
+    if (lstat(path, &st) != 0) return -1;
+#endif
+    nurl__stat_fill(&st, out);
+    return 0;
+}
+
+long long nurl_fstat_into(long long fd, long long *out) {
+    struct stat st;
+    if (!out) return -1;
+    if (fstat((int)fd, &st) != 0) return -1;
+    nurl__stat_fill(&st, out);
+    return 0;
+}
+
+/* Classify a raw st_mode. The S_IF* constants are not values NURL can
+ * portably name, so the question is asked here instead of the bits being
+ * exported: 1 file / 2 dir / 3 symlink / 4 chardev / 5 blockdev /
+ * 6 fifo / 7 socket / 0 unknown. */
+long long nurl_stat_kind(long long mode) {
+    unsigned m = (unsigned)mode;
+    if (S_ISREG(m))  return 1;
+    if (S_ISDIR(m))  return 2;
+#ifdef S_ISLNK
+    if (S_ISLNK(m))  return 3;
+#endif
+#ifdef S_ISCHR
+    if (S_ISCHR(m))  return 4;
+#endif
+#ifdef S_ISBLK
+    if (S_ISBLK(m))  return 5;
+#endif
+#ifdef S_ISFIFO
+    if (S_ISFIFO(m)) return 6;
+#endif
+#ifdef S_ISSOCK
+    if (S_ISSOCK(m)) return 7;
+#endif
+    return 0;
+}
+
+/* Set a file's access + modification times. Nanoseconds are honoured
+ * where the platform has utimensat(2) and rounded to microseconds where
+ * only utimes(2) exists. `follow` = 0 acts on a symlink itself.
+ * Returns 0 / -1 with errno, like the syscall. */
+long long nurl_utimes_set(const char *path, long long atime, long long ansec,
+                          long long mtime, long long mnsec, long long follow) {
+    if (!path) return -1;
+#if defined(__linux__) || (defined(__unix__) && defined(AT_FDCWD))
+    {
+        struct timespec ts[2];
+        ts[0].tv_sec = (time_t)atime; ts[0].tv_nsec = (long)ansec;
+        ts[1].tv_sec = (time_t)mtime; ts[1].tv_nsec = (long)mnsec;
+        return utimensat(AT_FDCWD, path, ts, follow ? 0 : AT_SYMLINK_NOFOLLOW) == 0 ? 0 : -1;
+    }
+#elif defined(_WIN32)
+    {
+        struct _utimbuf tb;
+        tb.actime  = (time_t)atime;
+        tb.modtime = (time_t)mtime;
+        (void)ansec; (void)mnsec; (void)follow;
+        return _utime(path, &tb) == 0 ? 0 : -1;
+    }
+#else
+    (void)atime; (void)ansec; (void)mtime; (void)mnsec; (void)follow;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+/* The name behind a uid / gid, or NULL when the platform has no user
+ * database (Windows, the unikernel) or the id is unknown. The caller
+ * owns the returned string. `ls -l` is the reason this exists: printing
+ * a bare number where every other `ls` prints a name is a difference
+ * people notice immediately. */
+char *nurl_user_name(long long uid) {
+#if defined(__unix__) || defined(__APPLE__)
+    struct passwd *pw = getpwuid((uid_t)uid);
+    if (pw && pw->pw_name) return strdup(pw->pw_name);
+#else
+    (void)uid;
+#endif
+    return NULL;
+}
+
+char *nurl_group_name(long long gid) {
+#if defined(__unix__) || defined(__APPLE__)
+    struct group *gr = getgrgid((gid_t)gid);
+    if (gr && gr->gr_name) return strdup(gr->gr_name);
+#else
+    (void)gid;
+#endif
+    return NULL;
+}
+
+/* ── the machine, and the environment it handed us ──────────────────
+ *
+ * Three things every `env` / `uname` / `nproc` needs and NURL cannot
+ * spell portably: the environment VECTOR (a variable, not a function,
+ * and named `_environ` on Windows), utsname (a struct whose field width
+ * is a per-kernel constant), and the processor count (a sysconf key on
+ * POSIX, a struct field on Windows).
+ *
+ * Each answers with a heap copy the caller frees, or NULL / 0 when the
+ * platform genuinely cannot say — never an invented value. */
+#if defined(_WIN32)
+extern char **_environ;
+#  define NURL_ENVIRON _environ
+#elif defined(__APPLE__)
+#  include <crt_externs.h>
+#  define NURL_ENVIRON (*_NSGetEnviron())
+#else
+extern char **environ;
+#  define NURL_ENVIRON environ
+#endif
+
+long long nurl_env_count(void) {
+    char **e = NURL_ENVIRON;
+    long long n = 0;
+    if (!e) return 0;
+    while (e[n]) n++;
+    return n;
+}
+
+/* Borrowed `NAME=value` at index `i`, or NULL past the end. Borrowed
+ * because the vector is live for the process's whole life and a copy at
+ * every step would make listing the environment allocate once per
+ * entry for nothing. */
+const char *nurl_env_at(long long i) {
+    char **e = NURL_ENVIRON;
+    long long n = 0;
+    if (!e || i < 0) return NULL;
+    while (e[n]) n++;
+    if (i >= n) return NULL;
+    return e[i];
+}
+
+/* One field of utsname, as a heap copy the caller frees:
+ * 0 sysname, 1 nodename, 2 release, 3 version, 4 machine.
+ * NULL where the platform has no answer. */
+char *nurl_uname_field(long long which) {
+#if defined(__unix__) || defined(__APPLE__)
+    struct utsname u;
+    const char *p = NULL;
+    if (uname(&u) != 0) return NULL;
+    switch (which) {
+        case 0: p = u.sysname;  break;
+        case 1: p = u.nodename; break;
+        case 2: p = u.release;  break;
+        case 3: p = u.version;  break;
+        case 4: p = u.machine;  break;
+        default: return NULL;
+    }
+    return p ? strdup(p) : NULL;
+#else
+    (void)which;
+    return NULL;
+#endif
+}
+
+/* ── local time ─────────────────────────────────────────────────────
+ *
+ * stdlib/std/time.nu does its own calendar arithmetic and is therefore
+ * pure and deterministic — but the offset between UTC and the machine's
+ * local time is not arithmetic, it is a database ($TZ, /etc/localtime)
+ * that changes twice a year per zone. Reimplementing tzdata in NURL
+ * would be a large, quietly-wrong thing to own; asking the platform for
+ * the offset at one instant is exact and costs a call.
+ *
+ * Returns seconds EAST of UTC at `secs` (so CET is 3600, CEST 7200,
+ * and a machine with no zone database answers 0 — which is UTC, the
+ * truthful answer for a unikernel rather than a guess). */
+long long nurl_tz_offset(long long secs) {
+#if defined(_WIN32)
+    {
+        long bias = 0;
+        (void)secs;
+        _get_timezone(&bias);        /* seconds WEST of UTC */
+        return -(long long)bias;
+    }
+#elif defined(__unix__) || defined(__APPLE__)
+    {
+        time_t t = (time_t)secs;
+        struct tm lt;
+        if (!localtime_r(&t, &lt)) return 0;
+#  if defined(__USE_MISC) || defined(__APPLE__) || defined(BSD) || defined(__linux__)
+        return (long long)lt.tm_gmtoff;
+#  else
+        return 0;
+#  endif
+    }
+#else
+    (void)secs;
+    return 0;
+#endif
+}
+
+/* The zone's abbreviation at `secs` (`CET`, `EEST`, `UTC`), as a heap
+ * copy the caller frees, or NULL where there is no zone database. */
+char *nurl_tz_name(long long secs) {
+#if defined(__unix__) || defined(__APPLE__)
+    {
+        time_t t = (time_t)secs;
+        struct tm lt;
+        if (!localtime_r(&t, &lt)) return NULL;
+#  if defined(__USE_MISC) || defined(__APPLE__) || defined(BSD) || defined(__linux__)
+        return lt.tm_zone ? strdup(lt.tm_zone) : NULL;
+#  else
+        return NULL;
+#  endif
+    }
+#else
+    (void)secs;
+    return NULL;
+#endif
+}
+
+long long nurl_cpu_count(void) {
+#if defined(_SC_NPROCESSORS_ONLN)
+    long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return n > 0 ? (long long)n : 1;
+#elif defined(_WIN32)
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return si.dwNumberOfProcessors > 0 ? (long long)si.dwNumberOfProcessors : 1;
+#else
+    return 1;
+#endif
 }
 
 /* Force a file's bytes out of the kernel's page cache onto the storage

--- a/stdlib/std/bufio.nu
+++ b/stdlib/std/bufio.nu
@@ -31,6 +31,19 @@
 //                                                     Reuse one `dst`
 //                                                     across the loop for
 //                                                     zero-allocation ETL.
+//   ( bufreader_read_line_raw br dst )  → b         the same, but VERBATIM:
+//                                                     the line's own
+//                                                     terminator is kept
+//                                                     ('\n', '\r\n', or
+//                                                     none at a final
+//                                                     unterminated line),
+//                                                     so writing every
+//                                                     `dst` back out
+//                                                     reproduces the input
+//                                                     byte for byte. What a
+//                                                     filter that must not
+//                                                     rewrite line endings
+//                                                     needs.
 //   ( bufreader_eof br )               → b          T once fully drained
 //   ( bufreader_close br )             → v          free buffer + handle
 //
@@ -240,6 +253,30 @@ $ `stdlib/std/fs.nu`  // nurl_file_open / nurl_file_close
     : *u buf # *u ( nurl_peek ctl 1 )
     : i off ( nurl_peek ctl 7 )
     ( string_push_bytes dst # *u + # i buf off len )
+    ^ T
+}
+
+// Byte-exact twin of `bufreader_read_line_into`: `dst` receives the line
+// AND the terminator the input actually carried — `\n`, `\r\n`, or
+// nothing at all for a final unterminated line. Concatenating every
+// `dst` reproduces the stream exactly, which is the difference between a
+// filter (`head`, `grep`, `sed`) that preserves a CRLF file and one that
+// silently rewrites it to LF and drops or adds a trailing newline.
+//
+// The stripped form is the right default for parsing; this one is the
+// right default for copying. Same zero-allocation loop shape — reuse one
+// `dst`.
+@ bufreader_read_line_raw BufReader br String dst → b {
+    : s ctl . br ctl
+    : i len ( __bufreader_next_line ctl )
+    ( string_clear dst )
+    ? < len 0 { ^ F } {}
+    : *u buf # *u ( nurl_peek ctl 1 )
+    : i off ( nurl_peek ctl 7 )
+    // word 3 is the next unconsumed byte, so the span [off, start) is
+    // the line plus whatever terminated it.
+    : i raw - ( nurl_peek ctl 3 ) off
+    ( string_push_bytes dst # *u + # i buf off raw )
     ^ T
 }
 

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -312,12 +312,18 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
 // Best-effort delete. `nurl_file_del` (libc `remove`) doesn't surface
 // errno reliably across platforms, so callers wanting to distinguish
 // "did not exist" from "still there" should call `file_exists` first.
+// Delete a directory entry.
+//
+// It does NOT pre-check with `file_exists`, and that is the point: that
+// check is `access(2)`, which FOLLOWS a symlink, so a link whose target
+// is gone answered "not there" and was never unlinked. Every `rm -r`
+// over a tree containing a broken symlink then failed at the directory
+// itself, with ENOTEMPTY, having reported the wrong reason twice. The
+// syscall's own return value knows better than a probe before it.
 @ file_delete s path → !v IoErr {
-    ? == ( nurl_file_exists path ) 0 {
-        ^ @ !v IoErr { F @ IoErr { NotFound } }
-    } {}
-    ( nurl_file_del path )
-    ^ @ !v IoErr { T 0 }
+    ? == ( nurl_file_del_rc path ) 0 { ^ @ !v IoErr { T 0 } } {}
+    : IoErr e ( _io_err_of_kind ( errno_kind ) )
+    ^ @ !v IoErr { F e }
 }
 
 @ dir_create s path → !v IoErr {
@@ -353,6 +359,202 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     } {}
     : IoErr e ( _io_err_of_kind ( errno_kind ) )
     ^ @ !v IoErr { F e }
+}
+
+// ── stat(2) ─────────────────────────────────────────────────────────
+//
+// Everything a listing, a copy that preserves metadata, or a `find`
+// predicate needs to know about an entry, in one call.
+//
+// `struct stat` is not a portable layout, so the runtime reads it and
+// hands back sixteen int64 slots in an order the whole toolchain agrees
+// on (`nurl_stat_into`, stdlib/runtime_core.c). This module mirrors
+// those slots as `FileStat` and never touches the C struct itself.
+//
+//   ( fs_stat path )    → !FileStat IoErr   follows symlinks
+//   ( fs_lstat path )   → !FileStat IoErr   the link itself
+//   ( fs_fstat fd )     → !FileStat IoErr   an already-open descriptor
+//
+// A field the platform does not carry reads 0 rather than a made-up
+// value: Windows has no st_blocks and no user database, and the
+// unikernel has neither plus no nanosecond timestamps.
+
+& `c` @ nurl_stat_into s path s out → i
+
+& `c` @ nurl_lstat_into s path s out → i
+
+& `c` @ nurl_fstat_into i fd s out → i
+
+& `c` @ nurl_stat_kind i mode → i
+
+& `c` @ nurl_utimes_set s path i atime i ansec i mtime i mnsec i follow → i
+
+& `c` @ nurl_user_name i uid → s
+
+& `c` @ nurl_group_name i gid → s
+
+: FileStat {
+    i mode  // raw st_mode: permission bits AND type bits
+    i size
+    i mtime  // seconds since the epoch
+    i mtime_ns
+    i uid
+    i gid
+    i nlink
+    i ino
+    i dev
+    i rdev
+    i blocks  // 512-byte units, 0 where unsupported
+    i blksize
+    i atime
+    i atime_ns
+    i ctime
+    i ctime_ns
+}
+
+// What `stat_kind` answers. The S_IF* bits are not portable values, so
+// the runtime classifies and these name the answer.
+: i FS_KIND_UNKNOWN 0
+: i FS_KIND_FILE 1
+: i FS_KIND_DIR 2
+: i FS_KIND_SYMLINK 3
+: i FS_KIND_CHARDEV 4
+: i FS_KIND_BLOCKDEV 5
+: i FS_KIND_FIFO 6
+: i FS_KIND_SOCKET 7
+
+@ __fs_stat_decode s buf → FileStat {
+    ^ @ FileStat {
+        ( nurl_peek buf 0 )
+        ( nurl_peek buf 1 )
+        ( nurl_peek buf 2 )
+        ( nurl_peek buf 3 )
+        ( nurl_peek buf 4 )
+        ( nurl_peek buf 5 )
+        ( nurl_peek buf 6 )
+        ( nurl_peek buf 7 )
+        ( nurl_peek buf 8 )
+        ( nurl_peek buf 9 )
+        ( nurl_peek buf 10 )
+        ( nurl_peek buf 11 )
+        ( nurl_peek buf 12 )
+        ( nurl_peek buf 13 )
+        ( nurl_peek buf 14 )
+        ( nurl_peek buf 15 )
+    }
+}
+
+@ __fs_stat_at s path i follow → !FileStat IoErr {
+    ? == # i path 0 { ^ @ !FileStat IoErr { F @ IoErr { NotFound } } } {}
+    : s buf ( nurl_zalloc 128 )
+    : i rc ? != follow 0 ( nurl_stat_into path buf ) ( nurl_lstat_into path buf )
+    ? != rc 0 {
+        : IoErr e ( _io_err_of_kind ( errno_kind ) )
+        ( nurl_free buf )
+        ^ @ !FileStat IoErr { F e }
+    } {}
+    : FileStat st ( __fs_stat_decode buf )
+    ( nurl_free buf )
+    ^ @ !FileStat IoErr { T st }
+}
+
+// Metadata for `path`, following a final symlink.
+@ fs_stat s path → !FileStat IoErr { ^ ( __fs_stat_at path 1 ) }
+
+// Metadata for the symlink itself. This is the one to use when walking
+// a tree: `fs_stat` on a dangling link is an error, and on a link to a
+// directory it says "directory", which is how a recursive delete follows
+// a link out of the tree it was given.
+@ fs_lstat s path → !FileStat IoErr { ^ ( __fs_stat_at path 0 ) }
+
+@ fs_fstat i fd → !FileStat IoErr {
+    : s buf ( nurl_zalloc 128 )
+    : i rc ( nurl_fstat_into fd buf )
+    ? != rc 0 {
+        : IoErr e ( _io_err_of_kind ( errno_kind ) )
+        ( nurl_free buf )
+        ^ @ !FileStat IoErr { F e }
+    } {}
+    : FileStat st ( __fs_stat_decode buf )
+    ( nurl_free buf )
+    ^ @ !FileStat IoErr { T st }
+}
+
+// ── Interpreting a FileStat ─────────────────────────────────────────
+
+@ stat_kind FileStat st → i { ^ ( nurl_stat_kind . st mode ) }
+
+@ stat_is_file FileStat st → b { ^ == ( stat_kind st ) FS_KIND_FILE }
+
+@ stat_is_dir FileStat st → b { ^ == ( stat_kind st ) FS_KIND_DIR }
+
+@ stat_is_symlink FileStat st → b { ^ == ( stat_kind st ) FS_KIND_SYMLINK }
+
+// The permission bits alone — 0777 plus setuid / setgid / sticky (07777).
+@ stat_mode_bits FileStat st → i { ^ & . st mode 4095 }
+
+@ __fs_rwx String out i bits i setid i setid_char → v {
+    ( string_push_char out ? != 0 & bits 4 114 45 )
+    ( string_push_char out ? != 0 & bits 2 119 45 )
+    ? != setid 0 {
+        ( string_push_char out ? != 0 & bits 1 setid_char - setid_char 32 )
+    } {
+        ( string_push_char out ? != 0 & bits 1 120 45 )
+    }
+}
+
+// The ten-character listing form: `drwxr-xr-x`, `-rw-r--r--`,
+// `lrwxrwxrwx`. setuid / setgid / sticky replace the matching execute
+// character with `s` / `s` / `t`, upper-cased when the execute bit
+// itself is clear — the convention every `ls` follows.
+@ stat_mode_string FileStat st → String {
+    : String out ( string_with_cap 12 )
+    : i k ( stat_kind st )
+    ( string_push_char out ? == k FS_KIND_DIR 100
+    ? == k FS_KIND_SYMLINK 108
+    ? == k FS_KIND_CHARDEV 99
+    ? == k FS_KIND_BLOCKDEV 98
+    ? == k FS_KIND_FIFO 112
+    ? == k FS_KIND_SOCKET 115 45 )
+    : i m ( stat_mode_bits st )
+    ( __fs_rwx out & >> m 6 7 & m 2048 115 )
+    ( __fs_rwx out & >> m 3 7 & m 1024 115 )
+    ( __fs_rwx out & m 7 & m 512 116 )
+    ^ out
+}
+
+// ── Timestamps ──────────────────────────────────────────────────────
+
+// Set access + modification times. Nanoseconds are honoured where the
+// platform has utimensat(2). `follow` = F acts on a symlink itself.
+@ fs_set_times s path i atime i atime_ns i mtime i mtime_ns b follow → !v IoErr {
+    : i rc ( nurl_utimes_set path atime atime_ns mtime mtime_ns ? follow 1 0 )
+    ? == rc 0 { ^ @ !v IoErr { T 0 } } {}
+    : IoErr e ( _io_err_of_kind ( errno_kind ) )
+    ^ @ !v IoErr { F e }
+}
+
+// ── The user database ───────────────────────────────────────────────
+//
+// The name behind a uid / gid, or None where the platform has no user
+// database (Windows, the unikernel) or the id is unknown. A caller that
+// gets None prints the number, which is what `ls -l` does on an NFS
+// mount whose ids do not resolve.
+
+@ fs_user_name i uid → ?String {
+    : s raw ( nurl_user_name uid )
+    ? == # i raw 0 { ^ @ ?String { F # String 0 } } {}
+    : String out ( string_from raw )
+    ( nurl_free raw )
+    ^ @ ?String { T out }
+}
+
+@ fs_group_name i gid → ?String {
+    : s raw ( nurl_group_name gid )
+    ? == # i raw 0 { ^ @ ?String { F # String 0 } } {}
+    : String out ( string_from raw )
+    ( nurl_free raw )
+    ^ @ ?String { T out }
 }
 
 // POSIX symlink(2) — `target` is what the link points TO (stored
@@ -652,9 +854,24 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ? != 0 # i path { : i32 _ ( remove path ) } {}
 }
 
+// remove(2)'s own answer: 0 on success, -1 with errno set. The `v`
+// spelling above predates the C-runtime purge and is kept because the
+// compiler's preamble still declares that symbol; new code wants the
+// status, so `file_delete` can report WHY a delete failed instead of
+// guessing.
+@ nurl_file_del_rc s path → i {
+    ? == 0 # i path { ^ -1 } {}
+    : i32 rc ( remove path )
+    ^ ? == # i rc 0 0 -1
+}
+
+// 0777, not 0755: mkdir(2) subtracts the process umask, and that is
+// where the answer belongs. Hard-coding 0755 silently overrode a umask
+// of 002 — the group-writable setup every shared build directory uses —
+// and produced directories a colleague could not write into.
 @ nurl_dir_create s path → i {
     ? == # i path 0 { ^ -1 } {}
-    : i32 rc ( mkdir path # i32 493 )
+    : i32 rc ( mkdir path # i32 511 )
     ^ ? == # i rc 0 0 -1
 }
 
@@ -1106,6 +1323,35 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
         ? & > pn 0 != ( nurl_str_at pat pn 0 ) 46 { ^ F } {}
     } {}
     ^ ( __fnmatch_at pat 0 pn name 0 nn )
+}
+
+// ── Matching a name against a pattern ───────────────────────────────
+//
+// The matcher `fs_glob` drives, on its own — because the question "does
+// this name match `*.log`?" comes up without a directory to walk, and
+// re-implementing `*` / `?` / `[a-z]` per caller is how two of them end
+// up disagreeing about `[!x]`.
+//
+// Two rules, and the difference matters:
+//
+//   ( fs_match `*.log` name )       fnmatch(3): `*` matches ANY name,
+//                                   including one starting with a dot.
+//                                   This is `find -name`'s rule.
+//   ( fs_match_glob `*.log` name )  the shell's rule: `*`, `?` and `[`
+//                                   never match a leading `.`, so a
+//                                   pattern must spell the dot to see a
+//                                   hidden file. This is what `fs_glob`
+//                                   uses per path segment.
+//
+// Neither treats `/` specially — they match one NAME, not a path. A
+// pattern with no metacharacter is a plain equality test.
+
+@ fs_match s pattern s name → b {
+    ^ ( __fnmatch_at pattern 0 ( nurl_str_len pattern ) name 0 ( nurl_str_len name ) )
+}
+
+@ fs_match_glob s pattern s name → b {
+    ^ ( __fnmatch_seg pattern name )
 }
 
 // Recursive matcher over pat[pi..pn) vs name[ni..nn).

--- a/stdlib/std/path.nu
+++ b/stdlib/std/path.nu
@@ -11,7 +11,7 @@
 //
 //   ( path_join a b )       → String  drops a trailing sep on `a`, leading sep on `b`
 //   ( path_basename p )     → String  segment after the last separator
-//   ( path_dirname p )      → String  everything before the last separator (no trailing sep)
+//   ( path_dirname p )      → String  everything before the last component (POSIX: `.` when there is none)
 //   ( path_extension p )    → String  text after the last '.' in the basename, "" if none
 //   ( path_is_absolute p )  → b       starts with '/' / '\\' or matches X: drive prefix
 //   ( path_normalize p )    → String  collapses '.', '..', and duplicate separators
@@ -113,50 +113,81 @@ $ `stdlib/core/vec.nu`
     ^ out
 }
 
+// Index of the last byte of `p` that is not a trailing separator, or 0
+// when `p` is empty or made of separators only. POSIX basename and
+// dirname both begin here: `/a/b/` names `b`, not the empty string
+// after the final slash.
+@ __trimmed_end s p → i {
+    : i n ( nurl_str_len p )
+    : ~ i e n
+    ~ & > e 0 ( __is_sep ( nurl_str_at p n - e 1 ) ) { = e - e 1 }
+    ^ e
+}
+
+// Last separator strictly before `end`, or -1.
+@ __sep_before s p i end → i {
+    : i n ( nurl_str_len p )
+    : ~ i i - end 1
+    : ~ i out -1
+    ~ >= i 0 {
+        ? ( __is_sep ( nurl_str_at p n i ) ) {
+            = out i
+            = i -1
+        } { = i - i 1 }
+    }
+    ^ out
+}
+
+@ __one_slash → String {
+    : String r ( string_with_cap 1 )
+    ( string_push_char r 47 )
+    ^ r
+}
+
+// POSIX basename(3): the final component, with trailing separators
+// ignored. `/a/b/` → `b`, `/` → `/`, `foo` → `foo`. The empty path
+// stays empty (POSIX says `.`; every shell's `basename ""` prints an
+// empty line, and that is what callers here expect).
 @ path_basename s p → String {
     : i n ( nurl_str_len p )
     ? == n 0 { ^ ( string_new ) } {}
-    : i idx ( __last_sep_idx p )
+    : i end ( __trimmed_end p )
+    // All separators: the path names the root, and the root's name is
+    // the root.
+    ? == end 0 { ^ ( __one_slash ) } {}
+    : i idx ( __sep_before p end )
     ? < idx 0 {
-        ? ( __has_drive p ) {
-            ^ ( __substr_to_string p 2 - n 2 )
-        } {}
-        ^ ( __substr_to_string p 0 n )
+        ? ( __has_drive p ) { ^ ( __substr_to_string p 2 - end 2 ) } {}
+        ^ ( __substr_to_string p 0 end )
     } {}
     : i start + idx 1
-    ^ ( __substr_to_string p start - n start )
+    ^ ( __substr_to_string p start - end start )
 }
 
+// POSIX dirname(3): everything before the final component, with
+// trailing separators ignored and no trailing separator on the result.
+// `/a/b/c` → `/a/b`, `/a/b/` → `/a`, `foo` → `.`, `/foo` → `/`.
+//
+// A path with no separator answers `.`, not the empty string: the
+// result is meant to be usable as a path, and `""` is not one — a
+// caller that joined it back on would address the filesystem root.
 @ path_dirname s p → String {
     : i n ( nurl_str_len p )
-    ? == n 0 { ^ ( string_new ) } {}
-    : i idx ( __last_sep_idx p )
+    ? == n 0 { ^ ( string_from `.` ) } {}
+    : i end ( __trimmed_end p )
+    ? == end 0 { ^ ( __one_slash ) } {}
+    : i idx ( __sep_before p end )
     ? < idx 0 {
-        ? ( __has_drive p ) {
-            ^ ( __substr_to_string p 0 2 )
-        } {}
-        ^ ( string_new )
+        ? ( __has_drive p ) { ^ ( __substr_to_string p 0 2 ) } {}
+        ^ ( string_from `.` )
     } {}
-    ? == idx 0 {
-        : String r ( string_with_cap 1 )
-        ( string_push_char r 47 )
-        ^ r
-    } {}
-    // Strip trailing separators ("a//b" → "a") but keep "C:/" → "C:/".
-    : ~ i end idx
-    : ~ b going T
-    ~ going {
-        ? <= end 0 { = going F } {
-            : i c ( nurl_str_at p n - end 1 )
-            ? ( __is_sep c ) {
-                = end - end 1
-            } { = going F }
-        }
-    }
-    ? & == end 2 ( __has_drive p ) {
-        ^ ( __substr_to_string p 0 3 )
-    } {}
-    ^ ( __substr_to_string p 0 end )
+    ? == idx 0 { ^ ( __one_slash ) } {}
+    // Collapse the run of separators before the last component.
+    : ~ i cut idx
+    ~ & > cut 0 ( __is_sep ( nurl_str_at p n - cut 1 ) ) { = cut - cut 1 }
+    ? == cut 0 { ^ ( __one_slash ) } {}
+    ? & == cut 2 ( __has_drive p ) { ^ ( __substr_to_string p 0 3 ) } {}
+    ^ ( __substr_to_string p 0 cut )
 }
 
 @ path_extension s p → String {

--- a/stdlib/std/sysinfo.nu
+++ b/stdlib/std/sysinfo.nu
@@ -1,0 +1,55 @@
+// stdlib/std/sysinfo.nu — what machine is this, and how big?
+//
+// The three questions a program asks about its host that are not files
+// and not the environment: the kernel and machine identity (`uname`),
+// the host's name, and how many processors are online.
+//
+// Each of them is unportable in a different way — utsname is a struct
+// whose field width is a kernel constant, the host name is a syscall on
+// POSIX and a Win32 API elsewhere, and the processor count is a sysconf
+// key — so the runtime answers and this module presents.
+//
+//   ( sys_uname_field SYS_SYSNAME )  → ?String   `Linux`
+//   ( sys_hostname )                 → ?String   the node name
+//   ( sys_cpu_count )                → i         online processors, >= 1
+//
+// A `None` means the platform genuinely cannot say (Windows has no
+// utsname; a unikernel has no name to give), never a placeholder.
+// Callers print what they got or fall back visibly — `uname -s` on a
+// machine that will not say prints `unknown`, it does not print `Linux`.
+
+$ `stdlib/core/string.nu`
+
+& `c` @ nurl_uname_field i which → s
+
+& `c` @ nurl_cpu_count → i
+
+: i SYS_SYSNAME 0
+: i SYS_NODENAME 1
+: i SYS_RELEASE 2
+: i SYS_VERSION 3
+: i SYS_MACHINE 4
+
+// One utsname field as an owned String, or None where there is no
+// utsname. `which` is one of the SYS_* constants above.
+@ sys_uname_field i which → ?String {
+    : s raw ( nurl_uname_field which )
+    ? == # i raw 0 { ^ @ ?String { F # String 0 } } {}
+    : String out ( string_from raw )
+    ( nurl_free raw )
+    ^ @ ?String { T out }
+}
+
+// The host's name — utsname's nodename, which is what `hostname` prints
+// and what `uname -n` reports.
+@ sys_hostname → ?String {
+    ^ ( sys_uname_field SYS_NODENAME )
+}
+
+// Processors online. At least 1 on every target, including a machine
+// that cannot count them, because a caller sizing a thread pool needs a
+// number it can divide by.
+@ sys_cpu_count → i {
+    : i n ( nurl_cpu_count )
+    ^ ? < n 1 1 n
+}

--- a/stdlib/std/time.nu
+++ b/stdlib/std/time.nu
@@ -481,6 +481,19 @@ $ `stdlib/std/async_ffi.nu`
 // a recognised directive, F otherwise (the caller then emits the `%`
 // and the byte verbatim). Supported: %Y %y %m %d %H %M %S %j %a %A
 // %b %B %%.
+// Space-padded 2-digit — `%e` and `%k` pad with a space where `%d` and
+// `%H` pad with a zero.
+@ __push_2space String out i n → v {
+    ? < n 10 { ( string_push_char out 32 ) } {}
+    ( string_push_int out n )
+}
+
+// 12-hour clock: midnight and noon are both 12, not 0.
+@ __hour12 i h → i {
+    : i r ( __i_mod h 12 )
+    ^ ? == r 0 12 r
+}
+
 @ __time_emit_directive String out Time t i d → b {
     ? == d 37 { ( string_push_char out 37 ) ^ T } {}
     ? == d 89 { ( __push_4digit out . t year ) ^ T } {}
@@ -494,15 +507,72 @@ $ `stdlib/std/async_ffi.nu`
     ? == d 97 { ( string_push_str out ( __wday_name . t wday ) ) ^ T } {}
     ? == d 65 { ( string_push_str out ( __wday_full . t wday ) ) ^ T } {}
     ? == d 98 { ( string_push_str out ( __month_name . t month ) ) ^ T } {}
+    ? == d 104 { ( string_push_str out ( __month_name . t month ) ) ^ T } {}
     ? == d 66 { ( string_push_str out ( __month_full . t month ) ) ^ T } {}
+    ? == d 101 { ( __push_2space out . t day ) ^ T } {}
+    ? == d 107 { ( __push_2space out . t hour ) ^ T } {}
+    ? == d 73 { ( __push_2digit out ( __hour12 . t hour ) ) ^ T } {}
+    ? == d 108 { ( __push_2space out ( __hour12 . t hour ) ) ^ T } {}
+    ? == d 112 { ( string_push_str out ? < . t hour 12 `AM` `PM` ) ^ T } {}
+    ? == d 80 { ( string_push_str out ? < . t hour 12 `am` `pm` ) ^ T } {}
+    ? == d 67 { ( __push_2digit out ( __i_floor_div . t year 100 ) ) ^ T } {}
+    ? == d 119 { ( string_push_int out . t wday ) ^ T } {}
+    ? == d 117 { ( string_push_int out ? == . t wday 0 7 . t wday ) ^ T } {}
+    ? == d 110 { ( string_push_char out 10 ) ^ T } {}
+    ? == d 116 { ( string_push_char out 9 ) ^ T } {}
+    ? == d 70 {
+        ( __push_4digit out . t year )
+        ( string_push_char out 45 )
+        ( __push_2digit out . t month )
+        ( string_push_char out 45 )
+        ( __push_2digit out . t day )
+        ^ T
+    } {}
+    ? == d 68 {
+        ( __push_2digit out . t month )
+        ( string_push_char out 47 )
+        ( __push_2digit out . t day )
+        ( string_push_char out 47 )
+        ( __push_2digit out ( __i_mod . t year 100 ) )
+        ^ T
+    } {}
+    ? == d 84 {
+        ( __push_2digit out . t hour )
+        ( string_push_char out 58 )
+        ( __push_2digit out . t min )
+        ( string_push_char out 58 )
+        ( __push_2digit out . t sec )
+        ^ T
+    } {}
+    ? == d 82 {
+        ( __push_2digit out . t hour )
+        ( string_push_char out 58 )
+        ( __push_2digit out . t min )
+        ^ T
+    } {}
     ^ F
 }
 
 // strftime-style formatter. `fmt` is a borrowed raw `s`; the result is
-// a fresh owned String. Directives: %Y (4-digit year), %y (2-digit
-// year), %m %d %H %M %S (zero-padded 2-digit), %j (3-digit day of
-// year), %a/%A (abbreviated/full weekday), %b/%B (abbreviated/full
-// month), %% (literal percent). An unrecognised %X is copied verbatim.
+// a fresh owned String. Directives:
+//
+//   %Y %y %C   year (4-digit, 2-digit, century)
+//   %m %d %e   month, day (zero-padded), day (space-padded)
+//   %H %k      hour 00-23, hour  0-23 space-padded
+//   %I %l %p %P  hour 01-12, space-padded, AM/PM, am/pm
+//   %M %S      minute, second
+//   %j         day of year, 3 digits
+//   %a %A      weekday, abbreviated / full
+//   %b %h %B   month name, abbreviated / abbreviated / full
+//   %w %u      weekday number (0-6 from Sunday / 1-7 from Monday)
+//   %F %D      %Y-%m-%d  /  %m/%d/%y
+//   %T %R      %H:%M:%S  /  %H:%M
+//   %n %t %%   newline, tab, literal percent
+//
+// The zone directives (%Z, %z) are deliberately absent: a `Time` carries
+// a calendar, not an offset, so it cannot answer them — see `tz_offset`
+// and `tz_name`, which take the epoch second the zone question needs.
+// An unrecognised %X is copied verbatim.
 // For the two common fixed shapes prefer `time_format_iso` /
 // `time_format_http` — they skip the directive scan.
 @ time_format Time t s fmt → String {
@@ -524,6 +594,51 @@ $ `stdlib/std/async_ffi.nu`
         }
     }
     ^ out
+}
+
+// ── Local time ────────────────────────────────────────────────────────
+//
+// Everything above is UTC and pure — the calendar is arithmetic, so it
+// is the same on every machine. Local time is not: the offset from UTC
+// at a given instant comes from a zone database ($TZ, /etc/localtime)
+// that changes twice a year per zone, and owning a copy of tzdata in
+// NURL would be a large thing that is quietly wrong the season after it
+// ships. The platform is asked instead, once per conversion.
+//
+//   ( tz_offset secs )   → i        seconds EAST of UTC at that instant
+//   ( tz_name secs )     → ?String  `CET` / `EEST` / None
+//   ( time_local secs )  → Time     the local calendar at that instant
+//   ( time_now_local )   → Time
+//
+// A platform with no zone database (Windows without a set zone, the
+// unikernel) answers 0 / None, which is UTC — the truthful answer, not
+// a guess. A caller that must distinguish "UTC" from "unknown" reads
+// `tz_name`.
+
+& `c` @ nurl_tz_offset i secs → i
+
+& `c` @ nurl_tz_name i secs → s
+
+@ tz_offset i secs → i { ^ ( nurl_tz_offset secs ) }
+
+@ tz_name i secs → ?String {
+    : s raw ( nurl_tz_name secs )
+    ? == # i raw 0 { ^ @ ?String { F # String 0 } } {}
+    : String out ( string_from raw )
+    ( nurl_free raw )
+    ^ @ ?String { T out }
+}
+
+// The local calendar at a Unix instant. The returned `Time` carries
+// local wall-clock fields; `time_to_unix` on it would give the WRONG
+// instant back (it reads its fields as UTC), so keep the epoch second
+// if you need to convert again.
+@ time_local i secs → Time {
+    ^ ( time_from_unix + secs ( nurl_tz_offset secs ) )
+}
+
+@ time_now_local → Time {
+    ^ ( time_local ( now_seconds ) )
 }
 
 // ── Parsing ───────────────────────────────────────────────────────────

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -51,17 +51,24 @@ from a baked-in image) and the second (the boot shim enters at
 with a different bottom edge, which is what makes testing it on Linux
 worth anything.
 
-## State (2026-08-21)
+## State (2026-08-27)
 
 ```
-  PASS         505    corpus tests that build and run with no libc at all
+  PASS         516    corpus tests that build and run with no libc at all
   FAIL           0
   NEEDS-BARE    23    processes and signals — a unikernel has neither
   NEEDS-LIBM     0
-  NEEDS-NOLIBC   9    realpath, inotify, execvp, unix sockets
+  NEEDS-NOLIBC   5    inotify, execvp, unix sockets
   NEEDS-LIB      3    libsqlite3 — third-party C libraries
-  SKIP         344    compile-fail tests and tests with no standalone build
+  SKIP         355    compile-fail tests and tests with no standalone build
 ```
+
+`realpath` left that column when `packages/nurlbox` — a busybox-shaped
+userland — was built for this target and found the holes: nolibc gained
+`realpath`, `fdopen`, `link`/`symlink`/`readlink`, `chmod`, `getcwd`, the
+uid/gid quartet, `getgroups`, `uname`, `sysconf` and `utimensat`, and the
+guest's VFS gained `stat` and directory listing over the baked-in
+archive. `ls -l`, `find`, `du` and `test -d` answer in the guest now.
 
 The guest suite (`unikernel/run_qemu_tests.sh`) is **29/29**.
 

--- a/unikernel/boot/initfs.c
+++ b/unikernel/boot/initfs.c
@@ -83,11 +83,17 @@ static const char *fs_norm(const char *p) {
     return p;
 }
 
+static int fs_norm_dir(const char *path, char *out, int cap);
+
 /* Find `name` in the archive. Returns its bytes and size, or 0. */
 static const unsigned char *fs_lookup(const char *name, fs_size_t *size_out) {
     const unsigned char *p = nurl_initfs_start;
     const unsigned char *end = nurl_initfs_end;
-    const char *want = fs_norm(name);
+    /* Fold `.` / `..` here as well: a program that opens `etc/../etc/x`
+     * gets the same file it would on any other machine. */
+    static char folded[256];
+    const char *want = name;
+    if (fs_norm_dir(name, folded, (int)sizeof folded) >= 0) want = folded;
 
     while (p + 512 <= end) {
         const char *hdr = (const char *)p;
@@ -217,6 +223,195 @@ const unsigned char *ifs_map(int fd, fs_size_t off) {
     FsFile *f = fs_file(fd);
     if (!f || off > f->size) return 0;
     return f->data + off;
+}
+
+/* ── the archive as a DIRECTORY TREE ─────────────────────────────
+ *
+ * A tar is a flat list of paths, but the paths spell a tree, and a
+ * userland needs that tree: `ls`, `find`, `du`, `test -d` and every
+ * `stat` on a directory are otherwise answered "I/O error" on a machine
+ * whose image demonstrably contains the files.
+ *
+ * Nothing is indexed up front — the archive is small, in memory, and
+ * walking it is a few hundred instructions. Directories are derived
+ * from the paths rather than requiring `tar` to have written explicit
+ * '5' entries, because `tar cf` does not always emit them and a
+ * directory that exists only as a prefix of its children is still a
+ * directory.
+ */
+
+/* Copy the header's name field into `out` (bounded, NUL-terminated),
+ * normalised the same way a lookup normalises the caller's path.
+ * Returns the length. */
+static int fs_hdr_name(const char *hdr, char *out, int cap) {
+    const char *n = fs_norm(hdr);
+    int room = 100 - (int)(n - hdr);
+    int i = 0;
+    while (i < room && i < cap - 1 && n[i]) { out[i] = n[i]; i++; }
+    out[i] = 0;
+    return i;
+}
+
+/* Does `name` sit inside directory `dir`, and if so where does its next
+ * component end? `dir` is normalised and may be "" for the root.
+ * Returns the component's length, or -1 when `name` is not under `dir`.
+ * `*is_dir` says whether the component has anything after it. */
+static int fs_child_of(const char *dir, int dirlen, const char *name, int *is_dir) {
+    int i = 0;
+    if (dirlen > 0) {
+        for (i = 0; i < dirlen; i++) if (name[i] != dir[i]) return -1;
+        if (name[dirlen] != '/') return -1;
+        i = dirlen + 1;
+    }
+    if (name[i] == 0) return -1;                 /* the directory itself */
+    {
+        int start = i;
+        while (name[i] && name[i] != '/') i++;
+        *is_dir = (name[i] == '/');
+        return i - start;
+    }
+}
+
+/* Normalise a caller's directory path into `out`: drop the leading
+ * "./" or "/", fold every "." and ".." component, and drop trailing
+ * slashes. Returns the length.
+ *
+ * The folding is not cosmetic. On a hosted system the KERNEL resolves
+ * `etc/.` and `etc/..`; here nothing does, so `ls -a` — which stats
+ * exactly those two names — asked the archive about paths it could
+ * never contain and was told they did not exist. A listing whose first
+ * two entries are reported as neither file nor directory is the shape
+ * of that bug. */
+static int fs_norm_dir(const char *path, char *out, int cap) {
+    const char *p = fs_norm(path);
+    int i = 0, n = 0;
+    for (;;) {
+        int start, seglen;
+        while (p[i] == '/') i++;
+        if (!p[i]) break;
+        start = i;
+        while (p[i] && p[i] != '/') i++;
+        seglen = i - start;
+        if (seglen == 1 && p[start] == '.') continue;
+        if (seglen == 2 && p[start] == '.' && p[start + 1] == '.') {
+            while (n > 0 && out[n - 1] != '/') n--;
+            if (n > 0) n--;                       /* the separator too */
+            out[n] = 0;
+            continue;
+        }
+        if (n > 0) { if (n < cap - 1) out[n++] = '/'; }
+        {
+            int k = 0;
+            while (k < seglen && n < cap - 1) out[n++] = p[start + k++];
+        }
+        out[n] = 0;
+    }
+    return n;
+}
+
+/* 0 = missing, 1 = regular file, 2 = directory. Sets *size for a file. */
+int ifs_kind(const char *path, fs_size_t *size_out) {
+    char dir[256];
+    char name[256];
+    int dirlen = fs_norm_dir(path, dir, sizeof dir);
+    const unsigned char *p = nurl_initfs_start;
+    const unsigned char *end = nurl_initfs_end;
+
+    if (dirlen == 0) return 2;                   /* the archive's root */
+
+    while (p + 512 <= end) {
+        const char *hdr = (const char *)p;
+        fs_size_t size, stride;
+        char type;
+        int nlen, is_dir;
+        if (hdr[0] == 0) break;
+        size = tar_octal(hdr + 124, 12);
+        type = hdr[156];
+        if (size > (fs_size_t)(end - (p + 512))) break;
+        stride = 512 + ((size + 511) & ~(fs_size_t)511);
+        nlen = fs_hdr_name(hdr, name, sizeof name);
+        /* Trailing slash on a '5' entry: `etc/` names `etc`. */
+        while (nlen > 0 && name[nlen - 1] == '/') name[--nlen] = 0;
+        if (nlen == dirlen) {
+            int i = 0;
+            while (i < nlen && name[i] == dir[i]) i++;
+            if (i == nlen) {
+                if (type == '5') return 2;
+                if (size_out) *size_out = size;
+                return 1;
+            }
+        }
+        /* Anything under it makes it a directory, explicit entry or not. */
+        if (fs_child_of(dir, dirlen, name, &is_dir) > 0) return 2;
+        p += stride;
+    }
+    return 0;
+}
+
+/* The `index`-th immediate child of `path`, deduplicated. Returns 1 and
+ * fills `out` / `*is_dir`, or 0 past the end. O(entries) per call, which
+ * an archive of a few dozen files does not notice. */
+int ifs_dirent(const char *path, int index, char *out, int cap, int *is_dir) {
+    char dir[256];
+    char name[256];
+    char seen[256];
+    int dirlen = fs_norm_dir(path, dir, sizeof dir);
+    const unsigned char *p = nurl_initfs_start;
+    const unsigned char *end = nurl_initfs_end;
+    int found = 0;
+
+    while (p + 512 <= end) {
+        const char *hdr = (const char *)p;
+        fs_size_t size, stride;
+        int nlen, child_is_dir = 0, clen;
+        if (hdr[0] == 0) break;
+        size = tar_octal(hdr + 124, 12);
+        if (size > (fs_size_t)(end - (p + 512))) break;
+        stride = 512 + ((size + 511) & ~(fs_size_t)511);
+        nlen = fs_hdr_name(hdr, name, sizeof name);
+        while (nlen > 0 && name[nlen - 1] == '/') name[--nlen] = 0;
+        clen = fs_child_of(dir, dirlen, name, &child_is_dir);
+        if (clen > 0 && clen < (int)sizeof seen) {
+            int start = dirlen == 0 ? 0 : dirlen + 1;
+            int dup = 0;
+            const unsigned char *q = nurl_initfs_start;
+            int i;
+            for (i = 0; i < clen; i++) seen[i] = name[start + i];
+            seen[clen] = 0;
+            /* Emitted already? A directory appears once per file under
+             * it, and a listing must name it once. */
+            while (q < p && q + 512 <= end) {
+                const char *h2 = (const char *)q;
+                char n2[256];
+                fs_size_t s2, st2;
+                int l2, d2 = 0, c2;
+                if (h2[0] == 0) break;
+                s2 = tar_octal(h2 + 124, 12);
+                if (s2 > (fs_size_t)(end - (q + 512))) break;
+                st2 = 512 + ((s2 + 511) & ~(fs_size_t)511);
+                l2 = fs_hdr_name(h2, n2, sizeof n2);
+                while (l2 > 0 && n2[l2 - 1] == '/') n2[--l2] = 0;
+                c2 = fs_child_of(dir, dirlen, n2, &d2);
+                if (c2 == clen) {
+                    int j = 0;
+                    while (j < clen && n2[start + j] == seen[j]) j++;
+                    if (j == clen) { dup = 1; break; }
+                }
+                q += st2;
+            }
+            if (!dup) {
+                if (found == index) {
+                    for (i = 0; i < clen && i < cap - 1; i++) out[i] = seen[i];
+                    out[i] = 0;
+                    if (is_dir) *is_dir = child_is_dir;
+                    return 1;
+                }
+                found++;
+            }
+        }
+        p += stride;
+    }
+    return 0;
 }
 
 /* Is this path a file in the image? `access(2)` is how a program asks —

--- a/unikernel/boot/nosys.c
+++ b/unikernel/boot/nosys.c
@@ -45,6 +45,8 @@
  * genuinely does not have either — into 21 failures.
  */
 
+#include "../../stdlib/nurl_version_gen.h"
+
 typedef unsigned long ns_size_t;
 
 extern int nl_errno_slot;
@@ -53,6 +55,85 @@ extern int nl_errno_slot;
 #define NS_EROFS  30
 
 static int ns_refuse(int err) { nl_errno_slot = err; return -1; }
+
+/* ── the filesystem calls this machine does not have ─────────────
+ *
+ * The image's filesystem is a tar in the text segment plus, when there
+ * is one, a FAT volume on a virtio disk. Neither carries POSIX
+ * permission bits or symlinks, so `chmod` and the link calls refuse
+ * rather than pretend: a script that believes it just made a key file
+ * unreadable, on a machine where it did nothing of the sort, is the
+ * failure this whole file exists to prevent. */
+int chmod(const char *p, int mode)   { (void)p; (void)mode; return ns_refuse(NS_EROFS); }
+int link(const char *a, const char *b) { (void)a; (void)b; return ns_refuse(NS_ENOSYS); }
+int symlink(const char *t, const char *l) { (void)t; (void)l; return ns_refuse(NS_ENOSYS); }
+long readlink(const char *p, char *b, unsigned long n) {
+    (void)p; (void)b; (void)n;
+    /* EINVAL, not ENOSYS: "that is not a symlink" is the true answer on
+     * a filesystem that has none, and it is the answer `readlink` and
+     * `ls -l` already know how to handle. */
+    return ns_refuse(22);
+}
+
+/* ── the working directory ───────────────────────────────────────
+ * There is exactly one namespace and the program starts at its root, so
+ * `/` is not a placeholder here — it is the answer. */
+char *getcwd(char *buf, unsigned long size) {
+    if (!buf || size < 2) { nl_errno_slot = 34 /* ERANGE */; return 0; }
+    buf[0] = '/';
+    buf[1] = 0;
+    return buf;
+}
+
+/* ── credentials ─────────────────────────────────────────────────
+ * One program, one address space, nothing above it: it is uid 0 in the
+ * only sense the word can have here. There is no user database to give
+ * that number a name — nurl_user_name answers NULL and every caller
+ * prints the number, which is what `ls -l` on an unmapped NFS id does
+ * on any machine. */
+int getuid(void)  { return 0; }
+int getgid(void)  { return 0; }
+int geteuid(void) { return 0; }
+int getegid(void) { return 0; }
+
+int getgroups(int size, unsigned int *list) {
+    (void)size; (void)list;
+    return 0;                       /* no supplementary groups, truthfully */
+}
+
+/* ── uname(2) ────────────────────────────────────────────────────
+ * A guest CAN answer this, and should: `uname -a` is the first thing
+ * anyone types to find out where they are, and "unknown" would be a
+ * worse answer than the true one. `struct utsname` is six fixed 65-byte
+ * fields on Linux, which is the layout runtime_core.c was compiled
+ * against. */
+static void ns_field(char *base, int idx, const char *text) {
+    char *p = base + idx * 65;
+    int i = 0;
+    while (text[i] && i < 64) { p[i] = text[i]; i++; }
+    p[i] = 0;
+}
+
+int uname(void *buf) {
+    char *b = (char *)buf;
+    if (!b) return ns_refuse(14 /* EFAULT */);
+    ns_field(b, 0, "NURL");
+    ns_field(b, 1, "unikernel");
+    ns_field(b, 2, NURL_VERSION);
+    ns_field(b, 3, "#1 NURL unikernel");
+#if defined(__aarch64__)
+    ns_field(b, 4, "aarch64");
+#elif defined(__riscv)
+    ns_field(b, 4, "riscv64");
+#else
+    ns_field(b, 4, "x86_64");
+#endif
+    ns_field(b, 5, "");
+    return 0;
+}
+
+/* sysconf(3) — one vCPU, which is the machine v1 is. */
+long sysconf(int name) { return name == 84 ? 1 : -1; }
 
 /* ── processes ───────────────────────────────────────────────── */
 

--- a/unikernel/boot/platform_arm64.c
+++ b/unikernel/boot/platform_arm64.c
@@ -649,7 +649,7 @@ void _exit(int code) { pf_shutdown(code); for (;;) { } }
 
 /* ── entry ───────────────────────────────────────────────────────── */
 
-extern char **nl_environ;
+extern char **environ;          /* nolibc/misc.c owns the storage */
 extern void nl_tls_init_guest(void);
 extern int main(int argc, char **argv);
 
@@ -722,7 +722,7 @@ void kmain(unsigned long x0) {
         extern int nl_env_from_cmdline(const char *, char *,
                                        unsigned long, char **, int);
         nl_env_from_cmdline(cmdline, env_buf, sizeof env_buf, envv, 32);
-        nl_environ = envv;
+        environ = envv;
         (void)no_argv;
     }
 

--- a/unikernel/boot/platform_riscv64.c
+++ b/unikernel/boot/platform_riscv64.c
@@ -610,7 +610,7 @@ void _exit(int code) { pf_shutdown(code); for (;;) { } }
 
 /* ── entry ───────────────────────────────────────────────────────── */
 
-extern char **nl_environ;
+extern char **environ;          /* nolibc/misc.c owns the storage */
 extern void nl_tls_init_guest(void);
 extern int main(int argc, char **argv);
 
@@ -698,7 +698,7 @@ void kmain(unsigned long dtb) {
         extern int nl_env_from_cmdline(const char *, char *,
                                        unsigned long, char **, int);
         nl_env_from_cmdline(cmdline, env_buf, sizeof env_buf, envv, 32);
-        nl_environ = envv;
+        environ = envv;
         (void)no_argv;
     }
 

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -1132,7 +1132,7 @@ static void pf_shutdown(int code) {
     for (;;) __asm__ __volatile__("cli; hlt");
 }
 
-/* `exit`, `abort` and `nl_environ` belong to nolibc/misc.c, which this
+/* `exit`, `abort` and `environ` belong to nolibc/misc.c, which this
  * target keeps verbatim: exit runs the atexit chain and flushes stdio
  * before calling `nl_exit_group`, and abort prints its line first.
  * Defining them here would duplicate the symbols AND skip both. The
@@ -1211,7 +1211,7 @@ const char *nurl_console_kind(void) { return console_kind_name(); }
 
 /* ── entry ───────────────────────────────────────────────────────── */
 
-extern char **nl_environ;          /* nolibc/misc.c owns the storage */
+extern char **environ;          /* nolibc/misc.c owns the storage */          /* nolibc/misc.c owns the storage */
 extern void nl_tls_init_guest(void);
 extern int main(int argc, char **argv);
 
@@ -1358,7 +1358,7 @@ void kmain(unsigned long start_info_paddr) {
         extern int nl_env_from_cmdline(const char *, char *,
                                        unsigned long, char **, int);
         nl_env_from_cmdline(cmdline, env_buf, sizeof env_buf, envv, 32);
-        nl_environ = envv;
+        environ = envv;
         (void)no_argv;
     }
 

--- a/unikernel/boot/vfs.c
+++ b/unikernel/boot/vfs.c
@@ -45,6 +45,7 @@ typedef unsigned long vfs_size_t;
 typedef long          vfs_ssize_t;
 
 extern int nl_errno_slot;
+long long nurl_initfs_size(void);
 
 /* ── the archive, one layer down ─────────────────────────────────── */
 
@@ -55,6 +56,8 @@ long long            ifs_lseek(int fd, long long off, int whence);
 int                  ifs_close(int fd);
 const unsigned char *ifs_map(int fd, vfs_size_t off);
 int                  ifs_exists(const char *path);
+int                  ifs_kind(const char *path, vfs_size_t *size_out);
+int                  ifs_dirent(const char *path, int index, char *out, int cap, int *is_dir);
 
 /* ── the disk, when one is linked ────────────────────────────────── */
 
@@ -97,6 +100,57 @@ static int disk_live(void) {
 
 static int disk_is_fd(int fd) { return fd >= VFS_DISK_FD_BASE && fd < VFS_DISK_FD_MAX; }
 
+/* Archive directories get their own range above the disk's: an
+ * `opendir` on the image is a cursor over tar headers, not a file. */
+#define VFS_IFSDIR_FD_BASE 256
+#define VFS_IFSDIR_MAX     8
+
+/* A directory handle over the UNION of the two filesystems: the
+ * archive's entries first, then the disk's, with a name the archive
+ * already supplied skipped so a file that exists in both is listed
+ * once. Reads resolve archive-first (see nl_open), and a listing that
+ * disagreed with that would show a name whose `open` returns different
+ * bytes. */
+typedef struct {
+    char      path[256];
+    int       cursor;      /* next archive entry to emit */
+    int       archive_done;
+    long long disk_h;      /* the disk's own handle, or -1 */
+    int       used;
+} VfsIfsDir;
+
+static VfsIfsDir vfs_ifsdirs[VFS_IFSDIR_MAX];
+
+static int ifsdir_is_fd(int fd) {
+    int i = fd - VFS_IFSDIR_FD_BASE;
+    return i >= 0 && i < VFS_IFSDIR_MAX && vfs_ifsdirs[i].used;
+}
+
+static int ifsdir_open(const char *path, int have_archive) {
+    int i, n;
+    long long h = -1;
+    if (disk_live() && nurl_disk_opendir) {
+        h = nurl_disk_opendir(path);
+        if (h < 0) h = -1;
+    }
+    /* Neither side has it: that is ENOENT, not an empty directory. */
+    if (!have_archive && h < 0) return -1;
+    for (i = 0; i < VFS_IFSDIR_MAX; i++) {
+        if (vfs_ifsdirs[i].used) continue;
+        for (n = 0; path[n] && n < (int)sizeof vfs_ifsdirs[i].path - 1; n++)
+            vfs_ifsdirs[i].path[n] = path[n];
+        vfs_ifsdirs[i].path[n] = 0;
+        vfs_ifsdirs[i].cursor = 0;
+        vfs_ifsdirs[i].archive_done = !have_archive;
+        vfs_ifsdirs[i].disk_h = h;
+        vfs_ifsdirs[i].used = 1;
+        return VFS_IFSDIR_FD_BASE + i;
+    }
+    if (h >= 0 && nurl_disk_closedir) (void)nurl_disk_closedir(h);
+    nl_errno_slot = 24 /* EMFILE */;
+    return -1;
+}
+
 /* A negative errno from NURL becomes -1 plus `errno`, which is the
  * shape every caller of these POSIX names already handles. */
 static int posix_ret(long long rc) {
@@ -128,6 +182,20 @@ int nl_open(const char *path, int flags, int mode) {
     if (!wants_write && !(flags & VFS_O_DIRECTORY)) {
         int fd = ifs_open(path, flags, mode);
         if (fd >= 0) return fd;
+    }
+
+    /* A directory the IMAGE holds is a directory: the archive's paths
+     * spell a tree, and refusing to open it would make `ls` and every
+     * "is this a directory?" predicate wrong about files that are
+     * plainly there. Checked before the disk, for the same reason a
+     * file read is. */
+    if (flags & VFS_O_DIRECTORY) {
+        /* An EMPTY archive has no root to speak of — it must not
+         * shadow the disk's. */
+        int have_arch = ifs_kind(path, 0) == 2 && nurl_initfs_size() > 0;
+        int fd = ifsdir_open(path, have_arch);
+        if (fd >= 0) return fd;
+        if (!disk_live()) { nl_errno_slot = 2 /* ENOENT */; return -1; }
     }
 
     if (disk_live()) {
@@ -178,6 +246,13 @@ long long fs_lseek_fd(int fd, long long off, int whence) {
 }
 
 int fs_close_fd(int fd) {
+    if (ifsdir_is_fd(fd)) {
+        VfsIfsDir *d = &vfs_ifsdirs[fd - VFS_IFSDIR_FD_BASE];
+        if (d->disk_h >= 0 && nurl_disk_closedir) (void)nurl_disk_closedir(d->disk_h);
+        d->disk_h = -1;
+        d->used = 0;
+        return 0;
+    }
     if (ifs_is_fd(fd)) return ifs_close(fd);
     if (disk_is_fd(fd) && nurl_disk_close)
         return posix_ret(nurl_disk_close(fd - VFS_DISK_FD_BASE));
@@ -236,6 +311,10 @@ void *vfs_map_file(int fd, unsigned long len, long off) {
 
 int fs_exists(const char *path) {
     if (!path) return 0;
+    /* A directory exists as surely as a file does; `ifs_exists` only
+     * answers about regular entries, which made `access` say no about
+     * every directory in the image. */
+    if (ifs_kind(path, 0) != 0) return 1;
     if (ifs_exists(path)) return 1;
     if (disk_live() && nurl_disk_exists) return nurl_disk_exists(path) == 1;
     return 0;
@@ -471,10 +550,182 @@ int mkstemp(char *tmpl) {
     return -1;
 }
 
-/* The one syscall this machine answers. Everything else is -ENOSYS,
- * which is what a Linux kernel says about a syscall it does not
- * implement, so every caller already knows the shape. */
+/* ── stat(2) ─────────────────────────────────────────────────────
+ *
+ * `struct stat` on x86_64 is a fixed layout, and runtime_core.c was
+ * compiled against exactly that header — so this fills it by offset
+ * rather than by declaring a struct nobody here can see.
+ *
+ *   0 st_dev   8 st_ino  16 st_nlink  24 st_mode(u32)  28 st_uid(u32)
+ *  32 st_gid   40 st_rdev 48 st_size   56 st_blksize    64 st_blocks
+ *  72 atime    88 mtime  104 ctime                     (144 bytes)
+ *
+ * The timestamps are ZERO, deliberately: the archive is baked at link
+ * time and the FAT layer does not surface a modification time, so `ls
+ * -l` shows the epoch. That is the machine saying "I do not know",
+ * which is a thing a reader can act on; a boot-time value would be a
+ * plausible-looking number that means nothing.
+ */
+#define VFS_S_IFREG 0100000
+#define VFS_S_IFDIR 0040000
+
+static void vfs_put_u32(char *p, unsigned int v) {
+    p[0] = (char)(v & 0xff); p[1] = (char)((v >> 8) & 0xff);
+    p[2] = (char)((v >> 16) & 0xff); p[3] = (char)((v >> 24) & 0xff);
+}
+
+static void vfs_fill_stat(void *st, int is_dir, long long size) {
+    char *p = (char *)st;
+    unsigned long i;
+    for (i = 0; i < 144; i++) p[i] = 0;
+    vfs_put_u64(p, 1);                                   /* st_dev  */
+    vfs_put_u64(p + 8, 1);                               /* st_ino  */
+    vfs_put_u64(p + 16, 1);                              /* st_nlink */
+    /* Read-only for the archive; the disk's FAT has no permission bits
+     * either, so 0555 / 0444 is the truth about both. */
+    vfs_put_u32(p + 24, (unsigned int)(is_dir ? (VFS_S_IFDIR | 0555)
+                                              : (VFS_S_IFREG | 0444)));
+    vfs_put_u64(p + 48, (unsigned long long)size);       /* st_size */
+    vfs_put_u64(p + 56, 512);                            /* st_blksize */
+    vfs_put_u64(p + 64, (unsigned long long)((size + 511) / 512)); /* st_blocks */
+}
+
+static long vfs_stat_path(const char *path, void *st) {
+    vfs_size_t size = 0;
+    int kind;
+    if (!path || !st) return -14 /* EFAULT */;
+    kind = ifs_kind(path, &size);
+    /* The archive's ROOT is a directory only when the archive has
+     * something in it; an empty image must not shadow the disk's `/`. */
+    if (kind == 2 && nurl_initfs_size() == 0) kind = 0;
+    if (kind != 0) {
+        vfs_fill_stat(st, kind == 2, (long long)size);
+        return 0;
+    }
+    if (disk_live() && nurl_disk_exists && nurl_disk_exists(path) == 1) {
+        int is_dir = nurl_disk_is_dir && nurl_disk_is_dir(path) == 1;
+        long long sz = (!is_dir && nurl_disk_stat_size) ? nurl_disk_stat_size(path) : 0;
+        vfs_fill_stat(st, is_dir, sz < 0 ? 0 : sz);
+        return 0;
+    }
+    return -2 /* ENOENT */;
+}
+
+static long vfs_fstat_fd(int fd, void *st) {
+    if (!st) return -14;
+    if (ifsdir_is_fd(fd)) { vfs_fill_stat(st, 1, 0); return 0; }
+    if (ifs_is_fd(fd)) {
+        /* The archive's own size, via the seek the handle already
+         * supports — no second index to keep in step. */
+        long long cur = ifs_lseek(fd, 0, 1);
+        long long end = ifs_lseek(fd, 0, 2);
+        (void)ifs_lseek(fd, cur, 0);
+        vfs_fill_stat(st, 0, end < 0 ? 0 : end);
+        return 0;
+    }
+    if (disk_is_fd(fd) && nurl_disk_size) {
+        long long sz = nurl_disk_size(fd - VFS_DISK_FD_BASE);
+        vfs_fill_stat(st, 0, sz < 0 ? 0 : sz);
+        return 0;
+    }
+    /* stdin/stdout/stderr: a character device, which is what they are. */
+    if (fd >= 0 && fd <= 2) {
+        char *p = (char *)st;
+        unsigned long i;
+        for (i = 0; i < 144; i++) p[i] = 0;
+        vfs_put_u32(p + 24, 020000 | 0620);              /* S_IFCHR */
+        vfs_put_u64(p + 56, 1024);
+        return 0;
+    }
+    return -9 /* EBADF */;
+}
+
+/* getdents64 over the union directory — the same record layout the
+ * disk-only path emits, so nolibc's readdir cannot tell them apart. */
+static int vfs_ifs_has(const char *dir, const char *name) {
+    char probe[256];
+    int i = 0, is_dir = 0;
+    while (ifs_dirent(dir, i, probe, (int)sizeof probe, &is_dir)) {
+        int k = 0;
+        while (probe[k] && probe[k] == name[k]) k++;
+        if (!probe[k] && !name[k]) return 1;
+        i++;
+    }
+    return 0;
+}
+
+static long vfs_ifs_getdents(int fd, void *buf, unsigned long len) {
+    VfsIfsDir *d = &vfs_ifsdirs[fd - VFS_IFSDIR_FD_BASE];
+    char *out = (char *)buf;
+    unsigned long used = 0;
+    char name[256];
+
+    for (;;) {
+        int is_dir = 0;
+        unsigned long reclen, n = 0;
+        int from_disk = 0;
+        if (used + 19 + 1 + 8 > len) break;
+
+        if (!d->archive_done) {
+            if (!ifs_dirent(d->path, d->cursor, name, (int)sizeof name, &is_dir)) {
+                d->archive_done = 1;
+                continue;
+            }
+            d->cursor++;
+        } else if (d->disk_h >= 0 && nurl_disk_readdir_name) {
+            unsigned long room = len - used - 19 - 1;
+            long long got;
+            if (room > sizeof name - 1) room = sizeof name - 1;
+            got = nurl_disk_readdir_name(d->disk_h, name, (long long)room + 1);
+            if (got == 0) break;
+            if (got < 0) {
+                if (used == 0) { nl_errno_slot = 22; return -22; }
+                break;
+            }
+            name[got] = 0;
+            is_dir = nurl_disk_dirent_is_dir && nurl_disk_dirent_is_dir();
+            from_disk = 1;
+            /* Already listed from the archive: read resolution is
+             * archive-first, so the listing must be too. */
+            if (vfs_ifs_has(d->path, name)) continue;
+        } else {
+            break;
+        }
+        (void)from_disk;
+
+        while (name[n]) n++;
+        reclen = (19 + n + 1 + 7) & ~7UL;
+        if (used + reclen > len) break;
+        {
+            char *rec = out + used;
+            unsigned long i;
+            vfs_put_u64(rec, (unsigned long long)(used + 1));
+            vfs_put_u64(rec + 8, (unsigned long long)(used + reclen));
+            vfs_put_u16(rec + 16, (unsigned short)reclen);
+            rec[18] = (char)(is_dir ? VFS_DT_DIR : VFS_DT_REG);
+            for (i = 0; i < n; i++) rec[19 + i] = name[i];
+            for (i = 19 + n; i < reclen; i++) rec[i] = 0;
+        }
+        used += reclen;
+    }
+    return (long)used;
+}
+
+/* The syscalls this machine answers. Everything else is -ENOSYS, which
+ * is what a Linux kernel says about a syscall it does not implement, so
+ * every caller already knows the shape. */
+#define VFS_SYS_STAT   4
+#define VFS_SYS_FSTAT  5
+#define VFS_SYS_LSTAT  6
+
 long vfs_syscall(long n, long a, long b, long c) {
-    if (n == VFS_SYS_GETDENTS64) return vfs_getdents64((int)a, (void *)b, (unsigned long)c);
+    if (n == VFS_SYS_GETDENTS64) {
+        if (ifsdir_is_fd((int)a)) return vfs_ifs_getdents((int)a, (void *)b, (unsigned long)c);
+        return vfs_getdents64((int)a, (void *)b, (unsigned long)c);
+    }
+    /* lstat is stat here: neither the archive nor a FAT volume has
+     * symlinks, so there is nothing for the two to disagree about. */
+    if (n == VFS_SYS_STAT || n == VFS_SYS_LSTAT) return vfs_stat_path((const char *)a, (void *)b);
+    if (n == VFS_SYS_FSTAT) return vfs_fstat_fd((int)a, (void *)b);
     return -38;
 }

--- a/unikernel/nolibc/misc.c
+++ b/unikernel/nolibc/misc.c
@@ -24,7 +24,7 @@ extern int  nl_open(const char *path, int flags, int mode);
 extern int  nl_close(int fd);
 extern long nl_ret(long r);
 
-char **nl_environ;
+char **environ;                     /* nl_environ is a macro for this */
 
 void exit(int code) {
     fflush(stdout);
@@ -179,6 +179,170 @@ int stat(const char *path, void *st) {
 int fstat(int fd, void *st) {
     return (int)nl_ret(nl_syscall6(NL_SYS_fstat, fd, (long)st, 0, 0, 0, 0));
 }
+
+/* utimensat(2) — what `touch` needs to set a timestamp. The syscall is
+ * there on Linux; on the guest, nl_syscall6 answers -ENOSYS and the
+ * caller reports it, which is the truth about a machine whose filesystem
+ * may be a read-only image in its own text segment. */
+#define NL_SYS_utimensat 280
+
+int utimensat(int dirfd, const char *path, const void *times, int flags) {
+    return (int)nl_ret(nl_syscall6(NL_SYS_utimensat, dirfd, (long)path,
+                                   (long)times, flags, 0, 0));
+}
+
+extern char *getcwd(char *buf, unsigned long size);
+extern long  readlink(const char *path, char *buf, unsigned long size);
+extern int   access(const char *path, int mode);
+
+/* The filesystem and credential calls this file BUILDS ON — chmod,
+ * link, symlink, readlink, getcwd, the uid/gid quartet, getgroups,
+ * uname and sysconf — are the bottom edge, and the bottom edge is
+ * per-target: `syscall_linux.c` makes them syscalls, and the guest's
+ * `boot/nosys.c` answers them for a machine with one address space and
+ * no user database. Everything below is written against those and is
+ * the same code on both.
+ */
+
+/* realpath(3) — libc's, not a syscall, so it is written out here.
+ *
+ * Absolutise against the working directory, then consume the path one
+ * component at a time: `.` is dropped, `..` pops the resolved prefix,
+ * and anything that turns out to be a symlink is replaced by its target
+ * followed by whatever of the path is still unconsumed. The link budget
+ * is 40, matching Linux's own ELOOP threshold, because a symlink cycle
+ * must terminate as an error rather than as a hang.
+ *
+ * On the guest there are no symlinks, so this reduces to the lexical
+ * normalisation — which is the right answer there, not an approximation
+ * of one.
+ */
+#define NL_PATH_MAX 4096
+
+static int nl_rp_push(char *out, int *len, const char *seg, int seglen) {
+    if (*len + seglen + 2 >= NL_PATH_MAX) return -1;
+    out[(*len)++] = '/';
+    memcpy(out + *len, seg, (nl_size_t)seglen);
+    *len += seglen;
+    out[*len] = 0;
+    return 0;
+}
+
+char *realpath(const char *path, char *resolved) {
+    static char left[2][NL_PATH_MAX];   /* the path still to consume */
+    static char out[NL_PATH_MAX];       /* the resolved prefix */
+    static char link_buf[NL_PATH_MAX];
+    int which = 0, li = 0, llen = 0, olen = 0, links = 0;
+
+    if (!path || !*path) { errno = 2 /* ENOENT */; return 0; }
+
+    if (path[0] == '/') {
+        nl_size_t n = strlen(path);
+        if (n >= NL_PATH_MAX) { errno = 36 /* ENAMETOOLONG */; return 0; }
+        memcpy(left[0], path, n + 1);
+        llen = (int)n;
+    } else {
+        nl_size_t n;
+        if (!getcwd(left[0], NL_PATH_MAX)) return 0;
+        llen = (int)strlen(left[0]);
+        if (llen == 1 && left[0][0] == '/') llen = 0;
+        n = strlen(path);
+        if (llen + 1 + (int)n >= NL_PATH_MAX) { errno = 36; return 0; }
+        left[0][llen++] = '/';
+        memcpy(left[0] + llen, path, n + 1);
+        llen += (int)n;
+    }
+
+    out[0] = 0;
+    for (;;) {
+        char *cur = left[which];
+        int start, seglen;
+        while (li < llen && cur[li] == '/') li++;
+        if (li >= llen) break;
+        start = li;
+        while (li < llen && cur[li] != '/') li++;
+        seglen = li - start;
+
+        if (seglen == 1 && cur[start] == '.') continue;
+        if (seglen == 2 && cur[start] == '.' && cur[start + 1] == '.') {
+            while (olen > 0 && out[olen - 1] != '/') olen--;
+            if (olen > 0) olen--;               /* drop the '/' as well */
+            out[olen] = 0;
+            continue;
+        }
+        if (nl_rp_push(out, &olen, cur + start, seglen) != 0) {
+            errno = 36;
+            return 0;
+        }
+        {
+            long n = readlink(out, link_buf, NL_PATH_MAX - 1);
+            if (n > 0) {
+                char *next = left[which ^ 1];
+                int rest = llen - li;
+                int nlen = 0;
+                if (++links > 40) { errno = 40 /* ELOOP */; return 0; }
+                link_buf[n] = 0;
+                if ((int)n + rest + 2 >= NL_PATH_MAX) { errno = 36; return 0; }
+                /* The link's target, then whatever of the path we have
+                 * not walked yet, becomes the new work list. */
+                memcpy(next, link_buf, (nl_size_t)n);
+                nlen = (int)n;
+                if (rest > 0) {
+                    next[nlen++] = '/';
+                    memcpy(next + nlen, cur + li, (nl_size_t)rest);
+                    nlen += rest;
+                }
+                next[nlen] = 0;
+                /* An absolute target restarts from the root; a relative
+                 * one is resolved against the link's own directory, so
+                 * the last component pops off first. */
+                while (olen > 0 && out[olen - 1] != '/') olen--;
+                if (olen > 0) olen--;
+                out[olen] = 0;
+                if (link_buf[0] == '/') { olen = 0; out[0] = 0; }
+                which ^= 1;
+                llen = nlen;
+                li = 0;
+            }
+        }
+    }
+    if (olen == 0) { out[olen++] = '/'; out[olen] = 0; }
+    /* POSIX: every component must exist, and a caller distinguishes
+     * "this is where that path would be" from "this is where it IS" by
+     * whether realpath answered at all. The lexical result of a missing
+     * path is a plausible string, which is worse than no answer —
+     * `path_canonical` is specified to say None. */
+    if (access(out, 0 /* F_OK */) != 0) {
+        errno = 2 /* ENOENT */;
+        return 0;
+    }
+    if (resolved) {
+        memcpy(resolved, out, (nl_size_t)olen + 1);
+        return resolved;
+    }
+    {
+        char *heap = (char *)malloc((nl_size_t)olen + 1);
+        if (!heap) return 0;
+        memcpy(heap, out, (nl_size_t)olen + 1);
+        return heap;
+    }
+}
+
+/* localtime_r(3) — there is no zone database on a machine whose whole
+ * filesystem may be its own text segment, and a -nostdlib Linux build
+ * has no /etc/localtime reader either. The honest answer is "no local
+ * time", and runtime_core.c's nurl_tz_offset turns that into 0, i.e.
+ * UTC. Reporting a fabricated offset would put every timestamp an hour
+ * off, twice a year, silently. */
+void *localtime_r(const void *t, void *tm) { (void)t; (void)tm; return 0; }
+
+/* ── the user database ──────────────────────────────────────────
+ * There isn't one. A machine with no /etc/passwd has no name for a uid,
+ * and saying so is what makes `ls -l` print the number instead of
+ * inventing `root`. runtime_core.c's nurl_user_name / nurl_group_name
+ * treat NULL exactly that way. */
+void *getpwuid(unsigned int uid) { (void)uid; return 0; }
+void *getgrgid(unsigned int gid) { (void)gid; return 0; }
 
 /* ── backtrace ──────────────────────────────────────────────────── */
 /* glibc's backtrace walks .eh_frame; a -nostdlib link has no unwinder,

--- a/unikernel/nolibc/nolibc.h
+++ b/unikernel/nolibc/nolibc.h
@@ -87,6 +87,7 @@ int   fgetc(FILE *f);
 int   getc(FILE *f);
 int   ungetc(int c, FILE *f);
 FILE *fopen(const char *path, const char *mode);
+FILE *fdopen(int fd, const char *mode);
 int   fclose(FILE *f);
 nl_size_t fread(void *p, nl_size_t sz, nl_size_t n, FILE *f);
 nl_size_t fwrite(const void *p, nl_size_t sz, nl_size_t n, FILE *f);
@@ -102,7 +103,13 @@ int  *__errno_location(void);
 
 /* Set by _start from the process stack; getenv reads it and the runtime
  * never sees it. */
-extern char **nl_environ;
+/* libc's spelling of the environment vector. It is ONE variable under
+ * two names: runtime_core.c enumerates `environ` (nurl_env_at, so `env`
+ * and `printenv` can list it), while everything in nolibc was written
+ * against `nl_environ`. Two variables would drift the moment setenv
+ * reallocated one of them. */
+extern char **environ;
+#define nl_environ environ
 
 /* ── the pieces with no portable form ───────────────────────────── */
 long nl_syscall6(long n, long a, long b, long c, long d, long e, long f);

--- a/unikernel/nolibc/stdio.c
+++ b/unikernel/nolibc/stdio.c
@@ -387,6 +387,29 @@ FILE *fopen(const char *path, const char *mode) {
     return f;
 }
 
+/* fdopen(3) — wrap an already-open descriptor in a stream. stdlib's
+ * bufio uses it for stdin, so a guest that could not do this had no
+ * buffered line reader at all. The stream OWNS the fd afterwards, the
+ * same contract fopen's does, so fclose closes it. */
+FILE *fdopen(int fd, const char *mode) {
+    int sflags, plus = 0, i;
+    FILE *f;
+    if (fd < 0) return 0;
+    for (i = 1; mode && mode[i]; i++) if (mode[i] == '+') plus = 1;
+    switch (mode ? mode[0] : 'r') {
+    case 'w':
+    case 'a': sflags = plus ? (NL_F_READ | NL_F_WRITE) : NL_F_WRITE; break;
+    default:  sflags = plus ? (NL_F_READ | NL_F_WRITE) : NL_F_READ; break;
+    }
+    f = (FILE *)malloc(sizeof(FILE));
+    if (!f) return 0;
+    memset(f, 0, sizeof(FILE));
+    f->fd = fd;
+    f->ungot = -1;
+    f->flags = sflags | NL_F_ALLOC;
+    return f;
+}
+
 int fclose(FILE *f) {
     int r;
     if (!f) return -1;

--- a/unikernel/nolibc/syscall_linux.c
+++ b/unikernel/nolibc/syscall_linux.c
@@ -162,6 +162,60 @@ int   rename(const char *a, const char *b)          { return (int)nl_ret(nl_sysc
 int   chdir(const char *p)                          { return (int)nl_ret(nl_syscall6(SYS_chdir_, (long)p, 0, 0, 0, 0, 0)); }
 int   chmod(const char *p, int mode)                { return (int)nl_ret(nl_syscall6(SYS_chmod_, (long)p, mode, 0, 0, 0, 0)); }
 int   madvise(void *p, unsigned long len, int adv)  { return (int)nl_ret(nl_syscall6(SYS_madvise_, (long)p, (long)len, adv, 0, 0, 0)); }
+
+/* ── the calls a userland needs, at x86_64's numbers ─────────────
+ * The guest answers these differently (boot/nosys.c): it has one
+ * address space, one program and no user database, so `getcwd` is `/`
+ * and `getuid` is 0 there. Here they are the kernel's. */
+#define SYS_link_        86
+#define SYS_symlink_     88
+#define SYS_readlink_    89
+#define SYS_getcwd_      79
+#define SYS_getuid_     102
+#define SYS_getgid_     104
+#define SYS_geteuid_    107
+#define SYS_getegid_    108
+#define SYS_getgroups_  115
+#define SYS_uname_       63
+#define SYS_sched_getaffinity_ 204
+
+int   link(const char *a, const char *b)            { return (int)nl_ret(nl_syscall6(SYS_link_, (long)a, (long)b, 0, 0, 0, 0)); }
+int   symlink(const char *t, const char *l)         { return (int)nl_ret(nl_syscall6(SYS_symlink_, (long)t, (long)l, 0, 0, 0, 0)); }
+long  readlink(const char *p, char *b, unsigned long n) { return nl_ret(nl_syscall6(SYS_readlink_, (long)p, (long)b, (long)n, 0, 0, 0)); }
+int   uname(void *buf)                              { return (int)nl_ret(nl_syscall6(SYS_uname_, (long)buf, 0, 0, 0, 0, 0)); }
+int   getuid(void)                                  { return (int)nl_syscall6(SYS_getuid_, 0, 0, 0, 0, 0, 0); }
+int   getgid(void)                                  { return (int)nl_syscall6(SYS_getgid_, 0, 0, 0, 0, 0, 0); }
+int   geteuid(void)                                 { return (int)nl_syscall6(SYS_geteuid_, 0, 0, 0, 0, 0, 0); }
+int   getegid(void)                                 { return (int)nl_syscall6(SYS_getegid_, 0, 0, 0, 0, 0, 0); }
+int   getgroups(int size, unsigned int *list)       { return (int)nl_ret(nl_syscall6(SYS_getgroups_, size, (long)list, 0, 0, 0, 0)); }
+
+/* getcwd(3) returns the BUFFER; the syscall returns the length. Callers
+ * test the pointer, so the two must not be confused. */
+char *getcwd(char *buf, unsigned long size) {
+    long r = nl_ret(nl_syscall6(SYS_getcwd_, (long)buf, (long)size, 0, 0, 0, 0));
+    return r < 0 ? 0 : buf;
+}
+
+/* sysconf(3) — only _SC_NPROCESSORS_ONLN (84 on glibc), which is what
+ * the runtime asks for. Counted from the affinity mask rather than
+ * guessed: that is the number of CPUs this process may actually run on,
+ * which is the number a thread pool should be sized against, and it is
+ * right inside a container where /proc/cpuinfo is not. */
+long sysconf(int name) {
+    if (name != 84) return -1;
+    {
+        unsigned long mask[16];
+        long r = nl_ret(nl_syscall6(SYS_sched_getaffinity_, 0, (long)sizeof mask, (long)mask, 0, 0, 0));
+        long n = 0;
+        unsigned long i;
+        if (r <= 0) return 1;
+        for (i = 0; i < (unsigned long)r / sizeof mask[0]; i++) {
+            unsigned long w = mask[i];
+            while (w) { n += (long)(w & 1UL); w >>= 1; }
+        }
+        return n > 0 ? n : 1;
+    }
+}
 /* The two durability primitives. A freestanding target cannot borrow
  * them from a host, and they are exactly one syscall each: fsync(2) is
  * the barrier a write-ahead log needs before it may acknowledge a write,


### PR DESCRIPTION
Adds **`packages/nurlbox`** — one multi-call binary carrying 69 of the
everyday UNIX utilities, dispatching on `argv[0]` exactly as busybox
does, written in pure NURL over the shipped stdlib. No shelling out, no
`coreutils` underneath, nothing to link beyond libc — which is also why
the same source builds for Linux, macOS, Windows and wasm32-wasi, and
**boots as its own kernel** on the unikernel target.

```
[, arch, base64, basename, cat, chmod, cksum, clear, cp, crc32, cut,
date, dirname, du, echo, egrep, env, expr, false, fgrep, find, grep,
groups, head, hostname, id, ln, logname, ls, md5sum, mkdir, mktemp, mv,
nl, nproc, printenv, printf, pwd, readlink, realpath, rev, rm, rmdir,
sed, seq, sha1sum, sha256sum, sha512sum, sleep, sort, stat, sync, tac,
tail, tee, test, touch, tr, true, truncate, tty, uname, uniq, usleep,
wc, which, whoami, xargs, yes
```

## The specification is the original

`tests/nurlbox_test.sh` runs **262 differential cases**: the same command
line through `nurlbox` and through the system `busybox`, required to
agree on stdout, on the *bytes*, and on the exit status. The mutating
applets are compared by the resulting **tree** — names, contents and
permission bits — because that is what a `cp` actually outputs, not what
it printed. Where busybox does not implement an option at all (`cat -E`,
`cat -s`, `nl -n`, `cksum`) the reference is GNU coreutils instead.

Leak-clean under AddressSanitizer with `detect_leaks=1` on every path,
including the error paths.

Three deliberate divergences, each because the original takes a shortcut
a modern tool should not: a file whose last line has no newline never
grows one; CRLF survives every filter; and `ls -lh` prints `total 12K`
rather than `total 12K····`.

## Writing a userland is how you find out what is missing

Each of these was fixed **where it actually was**, not worked around in
the package:

| | |
|---|---|
| `stat(2)` did not exist at all | `FileStat` + `fs_stat` / `fs_lstat` / `fs_fstat` over a new fixed-layout runtime thunk, `stat_mode_string`, `fs_set_times`, `fs_user_name` / `fs_group_name` |
| regular expressions had **no capture groups** | the engine is now a Pike VM with capture slots — `regex_find_caps`, `regex_ngroups`, `regex_expand` (`&`, `\1`..`\9`). `sed`'s back references forced it; every caller gets them |
| `path_dirname "foo"` answered `""`, `path_basename "/a/b/"` answered `""` | POSIX semantics — neither is what a caller then joins back on |
| time was UTC-only | `tz_offset` / `tz_name` / `time_local`, and `time_format` grew `%e %F %T %D %R %I %p %C %u %w %k %l %h %n %t` |
| `bufio` could not read a line verbatim | `bufreader_read_line_raw`, which keeps the terminator |
| the environment could not be enumerated | `env_count` / `env_entry` / `env_list` |
| no `uname`, host name or processor count | new `stdlib/std/sysinfo.nu` |
| the wildcard matcher was private to `fs_glob` | `fs_match` / `fs_match_glob` |
| `file_delete` probed with `access(2)` first — which **follows** a symlink | a dangling link was "not found" and never unlinked, so every `rm -r` over a tree containing one failed at the directory with ENOTEMPTY |
| `nurl_dir_create` hard-coded 0755 | 0777, and `mkdir(2)` subtracts the umask, as it is supposed to |

## The unikernel needed the same treatment

`nolibc` gained `realpath`, `fdopen`, `link` / `symlink` / `readlink`,
`chmod`, `getcwd`, the uid/gid quartet, `getgroups`, `uname`, `sysconf`,
`utimensat` and `localtime_r` — each real where the target can be real,
and refusing out loud where it cannot. The guest's VFS gained **`stat(2)`
and directory listing** over the baked-in archive, as a **union** with
the disk, and folds `.` / `..` the way a kernel would.

```
$ NURL_APPEND='args="ls -l etc"' unikernel/run_qemu.sh nurlbox.elf
total 0
-r--r--r--    1 0        0               18 Jan  1  1970 greeting.txt
-r--r--r--    1 0        0               20 Jan  1  1970 lines.txt

$ NURL_APPEND='args="uname -a"' unikernel/run_qemu.sh nurlbox.elf
NURL unikernel v0.53.0 #1 NURL unikernel x86_64
```

The timestamps are the epoch on purpose: the archive is baked at link
time and the FAT layer surfaces no mtime, so the machine says "I do not
know" rather than printing a plausible number that means nothing.

## Gates

| | |
|---|---|
| hosted corpus | green, including the new `regex_captures` golden |
| unikernel guest | 29/29 |
| nolibc corpus | **516 PASS / 0 FAIL** (was 505); NEEDS-NOLIBC 9 → 5 |
| `nurlbox` suite | 262 PASS / 0 FAIL |
| ASan + LSan | clean across every applet |
| `tools/check_*` | package imports, version strings, stdlib symbols, builtins doc, nolibc symbols, strict arity — all green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyDDy4qzKJRsJd91x9e57P