### PR TITLE
nurlbox: a shell, and the machine it has to run on

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4714,7 +4714,7 @@
 // real: released compilers freed the temp handed to vec_push [s].
 @ mem_consumer_copy_safe s fname → b {
     ( str_contains_word
-    `nurl_sym_def nurl_sym_set nurl_sym_append nurl_sym_get nurl_sym_get2 nurl_sym_len nurl_sym_len2 nurl_set_last_type nurl_print nurl_println nurl_eprintln puts nurl_str_len nurl_str_to_int nurl_str_to_float nurl_str_find nurl_str_starts nurl_str_ends seq str_contains_word str_word_index count_words nurl_str_cat nurl_str_cat3 nurl_str_cat4 nurl_str_slice nurl_str_int nurl_read_file nurl_lex_new nurl_file_exists emit die die_stmt warn bck_esc_warn bck_emit_error nurl_str_eq nurl_str_get int_width ty_is_unsigned mem_is_slice_ty is_int_ty nurl_llty llvm_type ty_to_unsigned mangle_type demangle_type str_first_word str_skip_word compound_field_type convert_closure_arg`
+    `nurl_sym_def nurl_sym_set nurl_sym_append nurl_sym_get nurl_sym_get2 nurl_sym_len nurl_sym_len2 nurl_set_last_type nurl_print nurl_println nurl_eprint nurl_eprintln nurl_print_str nurl_print_bytes puts nurl_str_len nurl_str_to_int nurl_str_to_float nurl_str_find nurl_str_starts nurl_str_ends seq str_contains_word str_word_index count_words nurl_str_cat nurl_str_cat3 nurl_str_cat4 nurl_str_slice nurl_str_int nurl_read_file nurl_lex_new nurl_file_exists emit die die_stmt warn bck_esc_warn bck_emit_error nurl_str_eq nurl_str_get int_width ty_is_unsigned mem_is_slice_ty is_int_ty nurl_llty llvm_type ty_to_unsigned mangle_type demangle_type str_first_word str_skip_word compound_field_type convert_closure_arg string_from string_push_str string_starts_with string_ends_with string_contains string_index_of path_new path_join path_basename path_dirname path_extension path_normalize path_is_absolute fs_match fs_match_glob`
     fname )
 }
 
@@ -8625,11 +8625,20 @@
         //     for THIS argument position), or
         //   - a hand-audited copy/read-only consumer
         //     (mem_consumer_copy_safe) — the diagnostic printers (they
-        //     only read the message) and the type/string INSPECTORS,
-        //     which either answer with a scalar or build a fresh string
-        //     and so can neither retain the pointer nor hand back an
-        //     alias of it. Both families are defined below their call
-        //     sites, so they have no body summary to trust.
+        //     only read the message), the type/string INSPECTORS, which
+        //     either answer with a scalar or build a fresh string, and
+        //     the stdlib's COPYING constructors (`string_from`,
+        //     `path_join`, …), which memcpy their argument's bytes into
+        //     a buffer of their own. None of them can retain the pointer
+        //     or hand back an alias of it. Both families are defined
+        //     below their call sites, so they have no body summary to
+        //     trust.
+        //
+        //     `string_from_take` is deliberately NOT on that list, and
+        //     is the reason the list is hand-audited rather than derived
+        //     from the signature: it has `string_from`'s shape exactly
+        //     and ADOPTS the buffer instead of copying it. The two
+        //     cannot be told apart from outside their bodies.
         // Everything else keeps the temp alive: into a storing callee
         // (vec_push) the temp's ownership has MOVED — freeing it left
         // the container holding freed memory in released compilers —

--- a/compiler/tests/outputs-windows/path_basic.txt
+++ b/compiler/tests/outputs-windows/path_basic.txt
@@ -27,6 +27,8 @@ join a b: a/b
 join a/ /b: /b
 join . b: ./b
 join a /abs: /abs
+join / d: /d
+join /a/ b: /a/b
 normalize a/./b: a/b
 normalize a/b/../c: a/c
 normalize /a/../../b: /b

--- a/compiler/tests/outputs/path_basic.txt
+++ b/compiler/tests/outputs/path_basic.txt
@@ -27,6 +27,8 @@ join a b: a/b
 join a/ /b: /b
 join . b: ./b
 join a /abs: /abs
+join / d: /d
+join /a/ b: /a/b
 normalize a/./b: a/b
 normalize a/b/../c: a/c
 normalize /a/../../b: /b

--- a/compiler/tests/path_basic.nu
+++ b/compiler/tests/path_basic.nu
@@ -105,6 +105,8 @@ $ `stdlib/core/string.nu`
     ( test_join `a/` `/b` )
     ( test_join `.` `b` )
     ( test_join `a` `/abs` )
+    ( test_join `/` `d` )
+    ( test_join `/a/` `b` )
 
     ( test_normalize `a/./b` `a/b` )
     ( test_normalize `a/b/../c` `a/c` )

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1152,6 +1152,16 @@ yours to release. This is the complete list; nothing else leaks.
     (and, in a loop body, each iteration) unless it escapes — covering
     the `: f \ …` then `( hof f )` callback pattern.
 
+  One seam inside this: the invoke-only set is keyed on the callee's
+  name, and a **generic** callee is instantiated per type argument, so
+  an inline closure that CAPTURES something and is passed straight to
+  one (`( sort_by [T] v \ T a T b → i { … flags … } )`) is not proven
+  invoke-only, and its env is left to the caller. A closure that
+  captures nothing allocates no env at all and is unaffected, which is
+  why the stdlib's own comparators read their configuration from a
+  binding at the call site rather than closing over it — and why
+  `packages/nurlbox`'s `ls` comparator does the same.
+
   An env is left for *you* only when the closure genuinely outlives the
   frame: it is returned (`^ \ …` / `^ f`), stored into a struct field or
   container, captured into another closure, detached onto a thread

--- a/packages/nurlbox/README.md
+++ b/packages/nurlbox/README.md
@@ -20,12 +20,41 @@ wasm32-wasi, and **boots as its own kernel** on the unikernel target.
 
 | Group | Applets |
 |---|---|
-| text | `cat` `echo` `head` `tail` `wc` `seq` `yes` `tac` `rev` `nl` `cut` `tr` `sort` `uniq` `tee` |
-| search & edit | `grep` `egrep` `fgrep` `sed` `find` |
-| files | `ls` `stat` `du` `cp` `mv` `rm` `mkdir` `rmdir` `ln` `touch` `chmod` `readlink` `realpath` `truncate` `mktemp` |
-| digests | `md5sum` `sha1sum` `sha256sum` `sha512sum` `cksum` `crc32` `base64` |
-| shell | `test` `[` `expr` `xargs` `sleep` `usleep` `true` `false` `env` `printenv` `printf` `which` |
+| shell | **`sh`** — quoting, `$VAR` / `${VAR:-…}` / `${VAR#pat}`, `$(…)`, `` `…` ``, `$((…))`, globbing, pipelines, redirections, heredocs, `&&` / `\|\|`, `if` / `while` / `until` / `for` / `case`, functions, and the builtins (`cd export unset shift set read eval . source return break continue local type`) |
+| text | `cat` `echo` `head` `tail` `wc` `seq` `yes` `tac` `rev` `nl` `cut` `tr` `sort` `uniq` `tee` `fold` `expand` `unexpand` `paste` `comm` `shuf` `dos2unix` `unix2dos` |
+| search & edit | `grep` `egrep` `fgrep` `sed` `find` `xargs` |
+| files | `ls` `stat` `du` `df` `cp` `mv` `rm` `mkdir` `rmdir` `ln` `touch` `chmod` `readlink` `realpath` `truncate` `mktemp` `split` |
+| binary | `od` `hexdump` `xxd` `cmp` `dd` `strings` |
+| digests | `md5sum` `sha1sum` `sha256sum` `sha512sum` `cksum` `crc32` `sum` `base64` |
+| archives | `tar` `gzip` `gunzip` `zcat` |
+| processes | `ps` `kill` `killall` `pidof` `free` `uptime` `mount` |
+| shell plumbing | `test` `[` `expr` `sleep` `usleep` `true` `false` `env` `printenv` `printf` `which` `factor` |
 | system | `pwd` `basename` `dirname` `uname` `arch` `hostname` `whoami` `id` `groups` `logname` `nproc` `date` `sync` `clear` `tty` |
+
+`nurlbox --install [-s] DIR` fills a directory with one entry per applet
+— hard links by default, symlinks with `-s` — which is how one file
+becomes a userland.
+
+### The shell
+
+`sh` is the reason the rest of it is useful, and it makes one decision
+worth knowing about: **an applet runs in-process**. When a command names
+one of nurlbox's own, the shell calls it directly instead of exec'ing
+itself. That is busybox's standalone-shell trick, and here it is what
+makes the shell work on a machine with no `fork` at all.
+
+On the unikernel that is not a detail — it is the whole thing:
+
+```sh
+$ NURL_APPEND='args="sh script.sh"' unikernel/run_qemu.sh nurlbox.elf
+```
+
+runs a script with globbing, loops, functions, pipelines, redirections
+and command substitution inside a guest that has exactly one address
+space and no processes. A pipeline there is not concurrent — each stage
+runs to completion into a temporary file and the next reads it — and the
+shell says so rather than pretending, exactly as it says so when a
+machine has nowhere writable to put that file.
 
 ## What "clone" means here
 
@@ -66,15 +95,27 @@ fixed where they actually were, not worked around here:
 | Gap | Fix |
 |---|---|
 | No `stat(2)` at all | `FileStat` + `fs_stat` / `fs_lstat` / `fs_fstat`, mode strings, `fs_set_times`, `fs_user_name` — `stdlib/std/fs.nu` over a new fixed-layout runtime thunk |
+| No filesystem statistics | `FsStat` + `fs_statfs` — what `df` asks |
 | No way to enumerate the environment | `env_count` / `env_entry` / `env_list` — `stdlib/ext/env.nu` |
 | No `uname`, host name or processor count | `stdlib/std/sysinfo.nu` |
 | Time was UTC-only | `tz_offset` / `tz_name` / `time_local` — `stdlib/std/time.nu`, plus a dozen more `strftime` directives |
 | `bufio` could not read a line verbatim | `bufreader_read_line_raw`, which keeps the terminator |
-| Regular expressions had no capture groups | a Pike VM with capture slots in `stdlib/ext/regex.nu`; `regex_find_caps`, `regex_ngroups`, `regex_expand` |
+| Regular expressions had no capture groups | a Pike VM with capture slots in `stdlib/ext/regex.nu`; `regex_find_caps`, `regex_ngroups`, `regex_expand` — `sed`'s `\1` is why |
 | The wildcard matcher was private to `fs_glob` | `fs_match` / `fs_match_glob` |
-| `path_dirname "foo"` answered `""`, `path_basename "/a/b/"` answered `""` | POSIX semantics in `stdlib/std/path.nu` |
+| `path_dirname "foo"` answered `""`, `path_basename "/a/b/"` answered `""`, `path_join "/" "x"` answered `"//x"` | POSIX semantics in `stdlib/std/path.nu` |
 | `file_delete` could not delete a dangling symlink | it stopped probing with `access(2)` first |
 | `mkdir` ignored the umask | `nurl_dir_create` passes 0777 and lets the kernel subtract |
+| `fs_tempfile "/"` produced `//tmp.XXXXXX` | one separator, not two |
+| An owned temporary passed to a copying constructor leaked | `mem_consumer_copy_safe` in the compiler now covers `string_from`, the `path_*` family and `nurl_eprint` — `( string_from ( nurl_str_slice … ) )` no longer leaks its inner buffer, in any program |
+
+And on the freestanding side, so that all of the above works in a guest:
+
+| Gap | Fix |
+|---|---|
+| nolibc had no `realpath`, `fdopen`, `link`, `symlink`, `readlink`, `chmod`, `getcwd`, `getuid`/`getgid`/`geteuid`/`getegid`, `getgroups`, `uname`, `sysconf`, `utimensat`, `localtime_r`, `statvfs` | each one implemented where the target can answer, and refusing out loud where it cannot |
+| The guest VFS had no `stat` and no directory listing | `vfs_stat_path` + a union directory handle over the baked-in archive and the disk, with `.` / `..` folded |
+| The guest had no working directory | one, with every path-taking entry point resolving against it — which is what `cd` is |
+| The guest could not redirect a descriptor | a redirection table for fds 0–2 behind `dup` / `dup2` / `fcntl(F_DUPFD)`, so `>`, `2>&1`, `$(…)` and pipelines work there |
 
 ## Memory
 

--- a/packages/nurlbox/nurl.toml
+++ b/packages/nurlbox/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nurlbox"
-version = "0.1.0"
-description = "The Swiss Army knife of NURL — a single multi-call binary carrying tiny, POSIX-shaped implementations of the everyday UNIX utilities (cat, ls, cp, mv, rm, grep, sed, sort, wc, head, tail, find, tar, gzip, sha256sum, …). One `nurlbox` binary dispatches on argv[0], exactly as busybox does, so a directory of symlinks becomes a complete userland. Pure NURL over the shipped stdlib: no libc utilities, no shell-outs. Builds for Linux, macOS, Windows and wasm32-wasi, and boots as its own kernel on the unikernel target."
+version = "0.2.0"
+description = "The Swiss Army knife of NURL — a single multi-call binary carrying 100 POSIX-shaped UNIX utilities, including a real `sh` (quoting, parameter and command substitution, arithmetic, globbing, pipelines, redirections, heredocs, if/while/until/for/case, functions). cat, ls, cp, mv, rm, grep, sed, find, sort, tar, gzip, xargs, od, xxd, dd, ps, df, sha256sum and the rest. One binary dispatches on argv[0], exactly as busybox does, so a directory of symlinks — `nurlbox --install` makes one — is a complete userland. Pure NURL over the shipped stdlib: no coreutils underneath, no shell-outs, nothing to link beyond libc. Verified against busybox and GNU coreutils by ~350 differential test cases, leak-clean under AddressSanitizer, and it boots as its own kernel on the unikernel target, where applets run in-process because that machine has no fork."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurlbox"
 

--- a/packages/nurlbox/src/archive.nu
+++ b/packages/nurlbox/src/archive.nu
@@ -1,0 +1,337 @@
+// nurlbox/archive.nu — tar, gzip, gunzip, zcat.
+//
+// Both formats are the shipped pure-NURL implementations —
+// `stdlib/ext/tar.nu` and `stdlib/ext/compress.nu` over
+// `stdlib/std/deflate.nu` — so an image carrying these applets links
+// nothing beyond libc: no libz, no libarchive.
+//
+// Whole-archive: an archive is read into memory, transformed and
+// written back. tar's own format is a stream and could be processed as
+// one; this is the honest limit of the current implementation and the
+// reason a multi-gigabyte tarball is not this tool's job yet.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/ext/tar.nu`
+$ `stdlib/ext/compress.nu`
+$ `bx.nu`
+
+// ── gzip / gunzip / zcat ──────────────────────────────────────────
+
+@ __gz_name s path → String {
+    : String out ( string_from path )
+    ( string_push_str out `.gz` )
+    ^ out
+}
+
+// `x.gz` → `x`, `x.tgz` → `x.tar`, anything else keeps its name.
+@ __gz_strip s path → String {
+    : i n ( nurl_str_len path )
+    ? & > n 3 != 0 ( nurl_str_ends path `.gz` ) { ^ ( string_from ( nurl_str_slice path 0 - n 3 ) ) } {}
+    ? & > n 4 != 0 ( nurl_str_ends path `.tgz` ) {
+        : String out ( string_from ( nurl_str_slice path 0 - n 4 ) )
+        ( string_push_str out `.tar` )
+        ^ out
+    } {}
+    ? & > n 2 != 0 ( nurl_str_ends path `.z` ) { ^ ( string_from ( nurl_str_slice path 0 - n 2 ) ) } {}
+    ^ ( string_from path )
+}
+
+@ ap_gzip ( Vec String ) argv → i {
+    : s me ( bx_name )
+    : BxOpts o ( bx_getopt argv 1 `cdfktnq123456789` `stdout=c,decompress=d,force=f,keep=k,test=t,quiet=q` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ b decompress | ( bx_has o `d` ) | ( bx_streq me `gunzip` ) ( bx_streq me `zcat` )
+        : ~ b to_stdout | ( bx_has o `c` ) ( bx_streq me `zcat` )
+        : b keep ( bx_has o `k` )
+        : b test ( bx_has o `t` )
+        ? test { = decompress T = to_stdout T } {}
+        : i nops ( bx_operand_count o )
+        ? == nops 0 { = to_stdout T } {}
+        : ~ i i 0
+        ~ < i ? > nops 0 nops 1 {
+            : s p ? > nops 0 ( bx_operand o i ) `-`
+            ? ( bx_is_stdin p ) { = to_stdout T } {}
+            : ~ b ok T
+            : ( Vec u ) data ( bx_slurp p ok )
+            ? ok {
+                : !( Vec u ) CompressErr r ? decompress ( gzip_decompress data ) ( gzip_compress data )
+                ?? r {
+                    F e → {
+                        ( bx_err_at p ( compress_err_name e ) )
+                        = rc 1
+                    }
+                    T outbytes → {
+                        ? test {} {
+                            ? to_stdout {
+                                ( bx_write_bytes outbytes )
+                            } {
+                                : String target ? decompress ( __gz_strip p ) ( __gz_name p )
+                                ?? ( write_file_bytes ( string_data target ) outbytes ) {
+                                    T _ → {
+                                        // The original goes, unless -k:
+                                        // that is what makes `gzip x`
+                                        // leave only `x.gz`.
+                                        ? ! keep {
+                                            ?? ( file_delete p ) { T _ → {} F _ → {} }
+                                        } {}
+                                    }
+                                    F e2 → {
+                                        ( bx_err_at ( string_data target ) ( bx_ioerr e2 ) )
+                                        = rc 1
+                                    }
+                                }
+                                ( string_free target )
+                            }
+                        }
+                        ( vec_free [u] outbytes )
+                    }
+                }
+            } { = rc 1 }
+            ( vec_free [u] data )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── tar ───────────────────────────────────────────────────────────
+
+// Walk `path` into `entries`, depth first, names relative to the tar's
+// own root. Directories are emitted before their contents so an
+// extractor that creates as it goes never meets a missing parent.
+@ __tar_collect s path ( Vec TarEntry ) entries inout i rc → v {
+    ?? ( fs_lstat path ) {
+        F e → {
+            ( bx_err_at path ( bx_ioerr e ) )
+            = rc 1
+        }
+        T st → {
+            ? ( stat_is_dir st ) {
+                : String dirname ( string_from path )
+                ( string_push_char dirname 47 )
+                ( vec_push [TarEntry] entries @ TarEntry {
+                    dirname ( stat_mode_bits st ) 0 . st mtime 53 ( vec_new [u] )
+                } )
+                ?? ( dir_list path ) {
+                    T names → {
+                        ( sort_by [String] names \ String a String b → i { ^ ( cmp_string a b ) } )
+                        : i n ( vec_len [String] names )
+                        : ~ i k 0
+                        ~ < k n {
+                            : String sub ( path_join path ( bx_at names k ) )
+                            ( __tar_collect ( string_data sub ) entries rc )
+                            ( string_free sub )
+                            = k + k 1
+                        }
+                        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+                    }
+                    F e2 → {
+                        ( bx_err_at path ( bx_ioerr e2 ) )
+                        = rc 1
+                    }
+                }
+            } {
+                ? ( stat_is_symlink st ) {
+                    // A symlink is stored as what it points at, because
+                    // the stdlib's tar writer knows two type flags. Said
+                    // out loud rather than silently storing the target's
+                    // bytes under the link's name.
+                    ( bx_err_at path `symlink stored as a regular file` )
+                    ?? ( read_file_bytes path ) {
+                        T data → {
+                            ( vec_push [TarEntry] entries @ TarEntry {
+                                ( string_from path ) ( stat_mode_bits st ) ( vec_len [u] data ) . st mtime 48 data
+                            } )
+                        }
+                        F _ → {}
+                    }
+                } {
+                    ?? ( read_file_bytes path ) {
+                        T data → {
+                            ( vec_push [TarEntry] entries @ TarEntry {
+                                ( string_from path ) ( stat_mode_bits st ) ( vec_len [u] data ) . st mtime 48 data
+                            } )
+                        }
+                        F e3 → {
+                            ( bx_err_at path ( bx_ioerr e3 ) )
+                            = rc 1
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@ __tar_list ( Vec TarEntry ) entries b verbose → v {
+    : i n ( vec_len [TarEntry] entries )
+    : String out ( string_new )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [TarEntry] entries i ) {
+            T e → {
+                ? verbose {
+                    : FileStat st @ FileStat {
+                        | . e mode ? == . e typeflag 53 16384 32768
+                        . e size . e mtime 0 0 0 1 0 0 0 0 0 0 0 0 0
+                    }
+                    : String modes ( stat_mode_string st )
+                    ( string_push_bytes out # *u ( string_data modes ) ( string_len modes ) )
+                    ( string_free modes )
+                    ( string_push_str out ` 0/0 ` )
+                    ( string_push_int out . e size )
+                    ( string_push_char out 32 )
+                } {}
+                ( string_push_bytes out # *u ( string_data . e path ) ( string_len . e path ) )
+                ( string_push_char out 10 )
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ( bx_write out )
+    ( string_free out )
+}
+
+@ ap_tar ( Vec String ) argv → i {
+    // `tar cf x.tar dir` — the leading bundle with no dash is the
+    // historical spelling and still the common one.
+    : ( Vec String ) av ( vec_new [String] )
+    : i argn ( vec_len [String] argv )
+    ( vec_push [String] av ( string_from ( bx_at argv 0 ) ) )
+    : ~ i ai 1
+    ? & > argn 1 != 45 ( nurl_str_get ( bx_at argv 1 ) 0 ) {
+        : String dashed ( string_from `-` )
+        ( string_push_str dashed ( bx_at argv 1 ) )
+        ( vec_push [String] av dashed )
+        = ai 2
+    } {}
+    ~ < ai argn {
+        ( vec_push [String] av ( string_from ( bx_at argv ai ) ) )
+        = ai + ai 1
+    }
+    : BxOpts o ( bx_getopt av 1 `cxtvf:C:zOkp` `create=c,extract=x,list=t,verbose=v,file=f,directory=C,gzip=z,to-stdout=O,keep-old-files=k` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b create ( bx_has o `c` )
+        : b extract ( bx_has o `x` )
+        : b list ( bx_has o `t` )
+        : b verbose ( bx_has o `v` )
+        : b gz ( bx_has o `z` )
+        : s file ? ( bx_has o `f` ) ( bx_val o `f` ) `-`
+        : s chdir ? ( bx_has o `C` ) ( bx_val o `C` ) ``
+        ? ! | create | extract list {
+            ( bx_err `you must specify one of -c, -x or -t` )
+            = rc 1
+        } {
+            ? create {
+                : ( Vec TarEntry ) entries ( vec_new [TarEntry] )
+                : i nops ( bx_operand_count o )
+                : ~ i i 0
+                ~ < i nops {
+                    ( __tar_collect ( bx_operand o i ) entries rc )
+                    = i + i 1
+                }
+                ? verbose { ( __tar_list entries F ) } {}
+                ?? ( tar_create entries ) {
+                    T raw → {
+                        : ~ b wrote F
+                        ? gz {
+                            ?? ( gzip_compress raw ) {
+                                T z → {
+                                    = wrote ( __tar_emit file z )
+                                    ( vec_free [u] z )
+                                }
+                                F e → {
+                                    ( bx_err ( compress_err_name e ) )
+                                    = rc 1
+                                }
+                            }
+                        } { = wrote ( __tar_emit file raw ) }
+                        ? ! wrote { = rc 1 } {}
+                        ( vec_free [u] raw )
+                    }
+                    F e2 → {
+                        ( bx_err ( tar_err_name e2 ) )
+                        = rc 1
+                    }
+                }
+                ( tar_entries_free entries )
+            } {
+                : ~ b ok T
+                : ( Vec u ) raw ( bx_slurp file ok )
+                ? ! ok { = rc 1 } {
+                    // A gzip member starts 1f 8b; `-z` is then a
+                    // formality rather than a requirement, which is what
+                    // every modern tar does.
+                    : i n ( vec_len [u] raw )
+                    : *u p ( vec_data [u] raw )
+                    : b looks_gz & >= n 2 & == 31 & 255 # i . p 0 == 139 & 255 # i . p 1
+                    : ( Vec u ) plain ( vec_new [u] )
+                    : ~ b have T
+                    ? | gz looks_gz {
+                        ?? ( gzip_decompress raw ) {
+                            T d → { ( vec_extend [u] plain d ) ( vec_free [u] d ) }
+                            F e → {
+                                ( bx_err ( compress_err_name e ) )
+                                = rc 1
+                                = have F
+                            }
+                        }
+                    } { ( vec_extend [u] plain raw ) }
+                    ? have {
+                        ?? ( tar_parse plain ) {
+                            F e2 → {
+                                ( bx_err ( tar_err_name e2 ) )
+                                = rc 1
+                            }
+                            T entries → {
+                                ? list {
+                                    ( __tar_list entries verbose )
+                                } {
+                                    ? verbose { ( __tar_list entries F ) } {}
+                                    : s dest ? > ( nurl_str_len chdir ) 0 chdir `.`
+                                    ?? ( tar_unpack plain dest ) {
+                                        T _ → {}
+                                        F e3 → {
+                                            ( bx_err ( tar_err_name e3 ) )
+                                            = rc 1
+                                        }
+                                    }
+                                }
+                                ( tar_entries_free entries )
+                            }
+                        }
+                    } {}
+                    ( vec_free [u] plain )
+                }
+                ( vec_free [u] raw )
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ( vec_free_with [String] av \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+@ __tar_emit s file ( Vec u ) data → b {
+    ? ( bx_is_stdin file ) {
+        ( bx_write_bytes data )
+        ^ T
+    } {}
+    ?? ( write_file_bytes file data ) {
+        T _ → { ^ T }
+        F e → {
+            ( bx_err_at file ( bx_ioerr e ) )
+            ^ F
+        }
+    }
+}

--- a/packages/nurlbox/src/binio.nu
+++ b/packages/nurlbox/src/binio.nu
@@ -1,0 +1,821 @@
+// nurlbox/binio.nu — the byte-level tools.
+//
+// od / hexdump / xxd / cmp / dd / split / strings.
+//
+// These are the applets people reach for when something is not text
+// after all, so every one of them is byte-exact: no line-ending
+// rewriting, no NUL truncation, and no assumption that the input fits
+// in memory unless the tool's own definition requires it.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `bx.nu`
+
+: s BX_HEX_LOWER `0123456789abcdef`
+: s BX_HEX_UPPER `0123456789ABCDEF`
+
+@ bx_push_hex String out i value i digits b upper → v {
+    : ~ i sh * - digits 1 4
+    ~ >= sh 0 {
+        ( string_push_char out ( nurl_str_get ? upper BX_HEX_UPPER BX_HEX_LOWER & 15 >> value sh ) )
+        = sh - sh 4
+    }
+}
+
+@ bx_push_octal String out i value i digits → v {
+    : ~ i sh * - digits 1 3
+    ~ >= sh 0 {
+        ( string_push_char out + 48 & 7 >> value sh )
+        = sh - sh 3
+    }
+}
+
+@ bx_push_right String out s text i width → v {
+    : ~ i k - width ( nurl_str_len text )
+    ~ > k 0 { ( string_push_char out 32 ) = k - k 1 }
+    ( string_push_str out text )
+}
+
+// ── od ────────────────────────────────────────────────────────────
+
+// Column width for `-t <kind><size>`, matching coreutils so two dumps
+// of different files line up under each other.
+@ __od_width i kind i size → i {
+    ? == kind 120 { ^ * size 2 } {}
+    ? == kind 111 { ^ ? == size 1 3 ? == size 2 6 ? == size 4 11 22 } {}
+    ? == kind 117 { ^ ? == size 1 3 ? == size 2 5 ? == size 4 10 20 } {}
+    ? == kind 100 { ^ ? == size 1 4 ? == size 2 6 ? == size 4 11 20 } {}
+    ^ 3
+}
+
+// `size` bytes at `off`, little-endian, as an unsigned value.
+@ __od_word * u p i n i off i size → i {
+    : ~ i v 0
+    : ~ i k - size 1
+    ~ >= k 0 {
+        : i b ? < + off k n & 255 # i . p + off k 0
+        = v | << v 8 b
+        = k - k 1
+    }
+    ^ v
+}
+
+// The signed reading of the same word, for `-t d`.
+@ __od_signed i v i size → i {
+    ? == size 8 { ^ v } {}
+    : i bits * size 8
+    : i sign << 1 - bits 1
+    ? != 0 & v sign { ^ - v << 1 bits } {}
+    ^ v
+}
+
+@ __od_char String out i c → v {
+    ? == c 0 { ( bx_push_right out `\\0` 3 ) ^ } {}
+    ? == c 7 { ( bx_push_right out `\\a` 3 ) ^ } {}
+    ? == c 8 { ( bx_push_right out `\\b` 3 ) ^ } {}
+    ? == c 9 { ( bx_push_right out `\\t` 3 ) ^ } {}
+    ? == c 10 { ( bx_push_right out `\\n` 3 ) ^ } {}
+    ? == c 11 { ( bx_push_right out `\\v` 3 ) ^ } {}
+    ? == c 12 { ( bx_push_right out `\\f` 3 ) ^ } {}
+    ? == c 13 { ( bx_push_right out `\\r` 3 ) ^ } {}
+    ? & >= c 32 < c 127 {
+        ( string_push_str out `  ` )
+        ( string_push_char out c )
+        ^
+    } {}
+    ( bx_push_octal out c 3 )
+}
+
+@ __od_addr String out i kind i off → v {
+    ? == kind 110 { ^ } {}
+    ? == kind 120 { ( bx_push_hex out off 6 F ) ^ } {}
+    ? == kind 100 {
+        : s d ( nurl_str_int off )
+        : ~ i pad - 7 ( nurl_str_len d )
+        ~ > pad 0 { ( string_push_char out 48 ) = pad - pad 1 }
+        ( string_push_str out d )
+        ^
+    } {}
+    ( bx_push_octal out off 7 )
+}
+
+@ __od_line String out * u p i n i off i take i kind i size i addr_kind → v {
+    ( __od_addr out addr_kind off )
+    : ~ i k 0
+    ~ < k take {
+        ( string_push_char out 32 )
+        ? == kind 99 {
+            ( __od_char out & 255 # i . p + off k )
+            = k + k 1
+        } {
+            : i w ( __od_word p n + off k size )
+            : i width ( __od_width kind size )
+            ? == kind 120 {
+                : ~ i pad - width * size 2
+                ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+                ( bx_push_hex out w * size 2 F )
+            } {
+                ? == kind 111 {
+                    ( bx_push_octal out w width )
+                } {
+                    : i v ? == kind 100 ( __od_signed w size ) w
+                    ( bx_push_right out ( nurl_str_int v ) width )
+                }
+            }
+            = k + k size
+        }
+    }
+    ( string_push_char out 10 )
+}
+
+@ ap_od ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `A:t:N:j:vbcdosxh` `address-radix=A,format=t,read-bytes=N,skip-bytes=j,output-duplicates=v` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ~ i kind 111
+        : ~ i size 2
+        : ~ i addr_kind 111
+        ? ( bx_has o `A` ) { = addr_kind ( nurl_str_get ( bx_val o `A` ) 0 ) } {}
+        // The single-letter shorthands, in the order coreutils lists.
+        ? ( bx_has o `b` ) { = kind 111 = size 1 } {}
+        ? ( bx_has o `c` ) { = kind 99 = size 1 } {}
+        ? ( bx_has o `d` ) { = kind 117 = size 2 } {}
+        ? ( bx_has o `o` ) { = kind 111 = size 2 } {}
+        ? ( bx_has o `x` ) { = kind 120 = size 2 } {}
+        ? ( bx_has o `s` ) { = kind 100 = size 2 } {}
+        ? ( bx_has o `h` ) { = kind 120 = size 2 } {}
+        ? ( bx_has o `t` ) {
+            : s spec ( bx_val o `t` )
+            = kind ( nurl_str_get spec 0 )
+            = size ? > ( nurl_str_len spec ) 1 ( nurl_str_to_int ( nurl_str_slice spec 1 - ( nurl_str_len spec ) 1 ) ) ? == kind 99 1 ? == kind 120 4 4
+            ? <= size 0 { = size 1 } {}
+            ? == kind 99 { = size 1 } {}
+        } {}
+        : i skip ? ( bx_has o `j` ) ( bx_count ( bx_val o `j` ) ) 0
+        : i limit ? ( bx_has o `N` ) ( bx_count ( bx_val o `N` ) ) -1
+        : b verbose ( bx_has o `v` )
+        : s p ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        : ~ b ok T
+        : ( Vec u ) data ( bx_slurp p ok )
+        ? ! ok { = rc 1 } {
+            : i total ( vec_len [u] data )
+            : *u pt ( vec_data [u] data )
+            : i start ? > skip total total skip
+            : i end ? >= limit 0 ? > + start limit total total + start limit total
+            : String out ( string_new )
+            : String prev ( string_new )
+            : ~ b eliding F
+            : ~ i off start
+            ~ < off end {
+                : i take ? < - end off 16 - end off 16
+                : String line ( string_new )
+                ( __od_line line pt total off take kind size addr_kind )
+                // A run of identical lines collapses to `*`, unless -v.
+                : b same & ! verbose & > off start ( __od_same line prev )
+                ? same {
+                    ? ! eliding {
+                        ( string_push_str out `*\n` )
+                        = eliding T
+                    } {}
+                } {
+                    ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+                    = eliding F
+                }
+                ( string_clear prev )
+                ( string_push_bytes prev # *u ( string_data line ) ( string_len line ) )
+                ( string_free line )
+                = off + off take
+            }
+            ? != addr_kind 110 {
+                ( __od_addr out addr_kind end )
+                ( string_push_char out 10 )
+            } {}
+            ( bx_write out )
+            ( string_free out )
+            ( string_free prev )
+        }
+        ( vec_free [u] data )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// Two rendered lines are "the same" when their DATA columns match; the
+// address differs by definition, so it is skipped.
+@ __od_same String a String b → b {
+    : i na ( string_len a )
+    : i nb ( string_len b )
+    ? != na nb { ^ F } {}
+    : ~ i i 0
+    ~ & < i na != ( string_get a i ) 32 { = i + i 1 }
+    : ~ i k i
+    ~ < k na {
+        ? != ( string_get a k ) ( string_get b k ) { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+// ── hexdump ───────────────────────────────────────────────────────
+
+@ ap_hexdump ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `Cn:vs:x` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b canonical ( bx_has o `C` )
+        : i skip ? ( bx_has o `s` ) ( bx_count ( bx_val o `s` ) ) 0
+        : i limit ? ( bx_has o `n` ) ( bx_count ( bx_val o `n` ) ) -1
+        : b verbose ( bx_has o `v` )
+        : s p ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        : ~ b ok T
+        : ( Vec u ) data ( bx_slurp p ok )
+        ? ! ok { = rc 1 } {
+            : i total ( vec_len [u] data )
+            : *u pt ( vec_data [u] data )
+            : i start ? > skip total total skip
+            : i end ? >= limit 0 ? > + start limit total total + start limit total
+            : String out ( string_new )
+            : String prev ( string_new )
+            : ~ b eliding F
+            : ~ i off start
+            ~ < off end {
+                : i take ? < - end off 16 - end off 16
+                : String line ( string_new )
+                ( bx_push_hex line off ? canonical 8 7 F )
+                ? canonical {
+                    ( string_push_str line `  ` )
+                    : ~ i k 0
+                    ~ < k 16 {
+                        ? == k 8 { ( string_push_char line 32 ) } {}
+                        ? < k take {
+                            ( bx_push_hex line & 255 # i . pt + off k 2 F )
+                            ( string_push_char line 32 )
+                        } { ( string_push_str line `   ` ) }
+                        = k + k 1
+                    }
+                    // One more space than the byte columns leave: the
+                    // ASCII gutter is two spaces from the last pair.
+                    ( string_push_char line 32 )
+                    ( string_push_char line 124 )
+                    : ~ i q 0
+                    ~ < q take {
+                        : i c & 255 # i . pt + off q
+                        ( string_push_char line ? & >= c 32 < c 127 c 46 )
+                        = q + q 1
+                    }
+                    ( string_push_char line 124 )
+                } {
+                    // The historical default: 8 little-endian 16-bit
+                    // words, padded out so a short last line still
+                    // occupies the full width.
+                    : ~ i k 0
+                    ~ < k 16 {
+                        ? < k take {
+                            ( string_push_char line 32 )
+                            : i lo & 255 # i . pt + off k
+                            : i hi ? < + k 1 take & 255 # i . pt + off + k 1 0
+                            ( bx_push_hex line | << hi 8 lo 4 F )
+                        } { ( string_push_str line `     ` ) }
+                        = k + k 2
+                    }
+                }
+                ( string_push_char line 10 )
+                : b same & ! verbose & > off start ( __od_same line prev )
+                ? same {
+                    ? ! eliding {
+                        ( string_push_str out `*\n` )
+                        = eliding T
+                    } {}
+                } {
+                    ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+                    = eliding F
+                }
+                ( string_clear prev )
+                ( string_push_bytes prev # *u ( string_data line ) ( string_len line ) )
+                ( string_free line )
+                = off + off take
+            }
+            ( bx_push_hex out end ? canonical 8 7 F )
+            ( string_push_char out 10 )
+            ( bx_write out )
+            ( string_free out )
+            ( string_free prev )
+        }
+        ( vec_free [u] data )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── xxd ───────────────────────────────────────────────────────────
+
+@ __xxd_nibble i c → i {
+    ? ( bx_is_hex c ) { ^ ( bx_hex_val c ) } {}
+    ^ -1
+}
+
+@ ap_xxd ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `pruc:g:l:s:` `plain=p,revert=r,upper=u,cols=c,groupsize=g,len=l,seek=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b plain ( bx_has o `p` )
+        : b revert ( bx_has o `r` )
+        : b upper ( bx_has o `u` )
+        : i cols ? ( bx_has o `c` ) ( nurl_str_to_int ( bx_val o `c` ) ) ? plain 30 16
+        : i group ? ( bx_has o `g` ) ( nurl_str_to_int ( bx_val o `g` ) ) 2
+        : i skip ? ( bx_has o `s` ) ( bx_count ( bx_val o `s` ) ) 0
+        : i limit ? ( bx_has o `l` ) ( bx_count ( bx_val o `l` ) ) -1
+        : s p ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        : ~ b ok T
+        : ( Vec u ) data ( bx_slurp p ok )
+        ? ! ok { = rc 1 } {
+            ? revert {
+                // Read hex back into bytes, ignoring an address prefix
+                // and everything after a `  ` ASCII column.
+                : String out ( string_new )
+                : i n ( vec_len [u] data )
+                : *u pt ( vec_data [u] data )
+                : ~ i i 0
+                : ~ i hi -1
+                ~ < i n {
+                    : i c & 255 # i . pt i
+                    ? == c 10 { = hi -1 = i + i 1 } {
+                        ? & == c 58 T {
+                            // Drop everything up to and including the
+                            // colon: that was the address.
+                            ( string_clear out )
+                            = i + i 1
+                        } {
+                            : i v ( __xxd_nibble c )
+                            ? >= v 0 {
+                                ? < hi 0 { = hi v } {
+                                    ( string_push_char out | << hi 4 v )
+                                    = hi -1
+                                }
+                            } {}
+                            = i + i 1
+                        }
+                    }
+                }
+                ( bx_write out )
+                ( string_free out )
+            } {
+                : i total ( vec_len [u] data )
+                : *u pt ( vec_data [u] data )
+                : i start ? > skip total total skip
+                : i end ? >= limit 0 ? > + start limit total total + start limit total
+                : String out ( string_new )
+                : ~ i off start
+                ~ < off end {
+                    : i take ? < - end off cols - end off cols
+                    ? plain {
+                        : ~ i k 0
+                        ~ < k take {
+                            ( bx_push_hex out & 255 # i . pt + off k 2 upper )
+                            = k + k 1
+                        }
+                        ( string_push_char out 10 )
+                    } {
+                        ( bx_push_hex out off 8 F )
+                        ( string_push_str out `: ` )
+                        : ~ i k 0
+                        ~ < k cols {
+                            ? < k take {
+                                ( bx_push_hex out & 255 # i . pt + off k 2 upper )
+                            } { ( string_push_str out `  ` ) }
+                            ? == 0 - + k 1 * group / + k 1 group { ( string_push_char out 32 ) } {}
+                            = k + k 1
+                        }
+                        ( string_push_char out 32 )
+                        : ~ i q 0
+                        ~ < q take {
+                            : i c & 255 # i . pt + off q
+                            ( string_push_char out ? & >= c 32 < c 127 c 46 )
+                            = q + q 1
+                        }
+                        ( string_push_char out 10 )
+                    }
+                    = off + off take
+                }
+                ( bx_write out )
+                ( string_free out )
+            }
+        }
+        ( vec_free [u] data )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── cmp ───────────────────────────────────────────────────────────
+
+// `cmp -l` right-ALIGNS its octal bytes rather than zero-padding them:
+// ` 40` and `012` are the same byte, and the first is what every cmp
+// has printed.
+@ __cmp_octal String out i v → v {
+    : String tmp ( string_new )
+    : ~ i x v
+    ? == x 0 { ( string_push_char tmp 48 ) } {}
+    ~ != x 0 {
+        ( string_push_char tmp + 48 & 7 x )
+        = x >> x 3
+    }
+    : ~ i pad - 3 ( string_len tmp )
+    ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+    : ~ i k ( string_len tmp )
+    ~ > k 0 {
+        ( string_push_char out ( string_get tmp - k 1 ) )
+        = k - k 1
+    }
+    ( string_free tmp )
+}
+
+@ ap_cmp ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `sln:` `silent=s,verbose=l,bytes=n` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 2 } {
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            ( bx_err `missing operand` )
+            = rc 2
+        } {
+            : s p1 ( bx_operand o 0 )
+            : s p2 ? > nops 1 ( bx_operand o 1 ) `-`
+            : b quiet ( bx_has o `s` )
+            : b listall ( bx_has o `l` )
+            : ~ b ok1 T
+            : ~ b ok2 T
+            : ( Vec u ) a ( bx_slurp p1 ok1 )
+            : ( Vec u ) b ( bx_slurp p2 ok2 )
+            ? & ok1 ok2 {
+                : i na ( vec_len [u] a )
+                : i nb ( vec_len [u] b )
+                : *u pa ( vec_data [u] a )
+                : *u pb ( vec_data [u] b )
+                : i lim ? < na nb na nb
+                : i cap ? ( bx_has o `n` ) ( bx_count ( bx_val o `n` ) ) -1
+                : i scan ? & >= cap 0 < cap lim cap lim
+                : ~ i line 1
+                : ~ b differ F
+                : String out ( string_new )
+                : ~ i i 0
+                ~ < i scan {
+                    : i ca & 255 # i . pa i
+                    : i cb & 255 # i . pb i
+                    ? != ca cb {
+                        = differ T
+                        ? listall {
+                            ( string_push_int out + i 1 )
+                            ( string_push_char out 32 )
+                            ( __cmp_octal out ca )
+                            ( string_push_char out 32 )
+                            ( __cmp_octal out cb )
+                            ( string_push_char out 10 )
+                        } {
+                            ? ! quiet {
+                                ( nurl_print p1 )
+                                ( nurl_print ` ` )
+                                ( nurl_print p2 )
+                                ( nurl_print ` differ: char ` )
+                                ( nurl_print ( nurl_str_int + i 1 ) )
+                                ( nurl_print `, line ` )
+                                ( nurl_print ( nurl_str_int line ) )
+                                ( nurl_print `\n` )
+                            } {}
+                            = i scan
+                        }
+                    } {}
+                    ? == ca 10 { = line + line 1 } {}
+                    = i + i 1
+                }
+                ( bx_write out )
+                ( string_free out )
+                ? & ! differ & != na nb < cap 0 {
+                    = differ T
+                    ? ! quiet {
+                        ( nurl_eprint ( bx_name ) )
+                        ( nurl_eprint `: EOF on ` )
+                        ( nurl_eprint ? < na nb p1 p2 )
+                        ( nurl_eprint `\n` )
+                    } {}
+                } {}
+                = rc ? differ 1 0
+            } { = rc 2 }
+            ( vec_free [u] a )
+            ( vec_free [u] b )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── strings ───────────────────────────────────────────────────────
+
+@ ap_strings ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `n:at:f` `bytes=n,all=a,radix=t,print-file-name=f` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i minlen ? ( bx_has o `n` ) ( nurl_str_to_int ( bx_val o `n` ) ) 4
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        ~ < i ? > nops 0 nops 1 {
+            : s p ? > nops 0 ( bx_operand o i ) `-`
+            : ~ b ok T
+            : ( Vec u ) data ( bx_slurp p ok )
+            ? ok {
+                : i n ( vec_len [u] data )
+                : *u pt ( vec_data [u] data )
+                : String out ( string_new )
+                : String run ( string_new )
+                : ~ i start 0
+                : ~ i k 0
+                ~ <= k n {
+                    : i c ? < k n & 255 # i . pt k 0
+                    // A tab belongs to the run: `strings` on a config
+                    // file that lost its extension should still show the
+                    // indented lines whole.
+                    : b printable & < k n | == c 9 & >= c 32 < c 127
+                    ? printable {
+                        ? == ( string_len run ) 0 { = start k } {}
+                        ( string_push_char run c )
+                    } {
+                        ? >= ( string_len run ) minlen {
+                            ? ( bx_has o `f` ) {
+                                ( string_push_str out p )
+                                ( string_push_str out `: ` )
+                            } {}
+                            ? ( bx_has o `t` ) {
+                                : i radix ( nurl_str_get ( bx_val o `t` ) 0 )
+                                ? == radix 120 { ( bx_push_hex out start 7 F ) } {
+                                    ? == radix 100 { ( bx_push_right out ( nurl_str_int start ) 7 ) } {
+                                        ( bx_push_octal out start 7 )
+                                    }
+                                }
+                                ( string_push_char out 32 )
+                            } {}
+                            ( string_push_bytes out # *u ( string_data run ) ( string_len run ) )
+                            ( string_push_char out 10 )
+                        } {}
+                        ( string_clear run )
+                    }
+                    = k + k 1
+                }
+                ( bx_write out )
+                ( string_free out )
+                ( string_free run )
+            } { = rc 1 }
+            ( vec_free [u] data )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── split ─────────────────────────────────────────────────────────
+
+// `aa`, `ab`, … `zz` for suffix length 2; `00`, `01`, … with -d.
+@ __split_suffix String out i index i width b numeric → v {
+    : i base ? numeric 10 26
+    : ~ i v index
+    : String tmp ( string_new )
+    : ~ i k 0
+    ~ < k width {
+        ( string_push_char tmp + ? numeric 48 97 - v * base / v base )
+        = v / v base
+        = k + k 1
+    }
+    : ~ i q width
+    ~ > q 0 {
+        ( string_push_char out ( string_get tmp - q 1 ) )
+        = q - q 1
+    }
+    ( string_free tmp )
+}
+
+@ __split_write s prefix i index i width b numeric ( Vec u ) data i from i len → i {
+    : String name ( string_from prefix )
+    ( __split_suffix name index width numeric )
+    : ( Vec u ) piece ( vec_new [u] )
+    : *u p ( vec_data [u] data )
+    : ~ i k 0
+    ~ < k len {
+        ( vec_push [u] piece # u & 255 # i . p + from k )
+        = k + k 1
+    }
+    : ~ i rc 0
+    ?? ( write_file_bytes ( string_data name ) piece ) {
+        T _ → {}
+        F e → {
+            ( bx_err_at ( string_data name ) ( bx_ioerr e ) )
+            = rc 1
+        }
+    }
+    ( vec_free [u] piece )
+    ( string_free name )
+    ^ rc
+}
+
+@ ap_split ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `b:l:a:d` `bytes=b,lines=l,suffix-length=a,numeric-suffixes=d` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i width ? ( bx_has o `a` ) ( nurl_str_to_int ( bx_val o `a` ) ) 2
+        : b numeric ( bx_has o `d` )
+        : s input ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+        : s prefix ? > ( bx_operand_count o ) 1 ( bx_operand o 1 ) `x`
+        : ~ b ok T
+        : ( Vec u ) data ( bx_slurp input ok )
+        ? ! ok { = rc 1 } {
+            : i n ( vec_len [u] data )
+            : *u p ( vec_data [u] data )
+            : ~ i index 0
+            ? ( bx_has o `b` ) {
+                : i chunk ( bx_count ( bx_val o `b` ) )
+                ? <= chunk 0 {
+                    ( bx_err_at ( bx_val o `b` ) `invalid number of bytes` )
+                    = rc 1
+                } {
+                    : ~ i off 0
+                    ~ < off n {
+                        : i take ? < - n off chunk - n off chunk
+                        : i one ( __split_write prefix index width numeric data off take )
+                        ? != one 0 { = rc 1 = off n } { = off + off take }
+                        = index + index 1
+                    }
+                }
+            } {
+                : i per ? ( bx_has o `l` ) ( nurl_str_to_int ( bx_val o `l` ) ) 1000
+                ? <= per 0 {
+                    ( bx_err `invalid number of lines` )
+                    = rc 1
+                } {
+                    : ~ i from 0
+                    : ~ i lines 0
+                    : ~ i k 0
+                    ~ < k n {
+                        ? == 10 & 255 # i . p k {
+                            = lines + lines 1
+                            ? >= lines per {
+                                : i one ( __split_write prefix index width numeric data from - + k 1 from )
+                                ? != one 0 { = rc 1 = k n } {}
+                                = index + index 1
+                                = from + k 1
+                                = lines 0
+                            } {}
+                        } {}
+                        = k + k 1
+                    }
+                    ? & < from n == rc 0 {
+                        : i one ( __split_write prefix index width numeric data from - n from )
+                        ? != one 0 { = rc 1 } {}
+                    } {}
+                }
+            }
+        }
+        ( vec_free [u] data )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── dd ────────────────────────────────────────────────────────────
+
+// `key=value` operands, the only applet that spells its options that
+// way. Fills a caller-owned String rather than returning a raw slice:
+// one of the two exits would otherwise hand back a literal and the
+// other a fresh allocation, and no caller could tell which to free.
+@ __dd_arg ( Vec String ) argv s key String out → v {
+    ( string_clear out )
+    : i n ( vec_len [String] argv )
+    : i kl ( nurl_str_len key )
+    : ~ i i 1
+    ~ < i n {
+        : s a ( bx_at argv i )
+        ? & != 0 ( nurl_str_starts a key ) == 61 ( nurl_str_get a kl ) {
+            ( string_push_str out ( nurl_str_slice a + kl 1 - ( nurl_str_len a ) + kl 1 ) )
+            = i n
+        } { = i + i 1 }
+    }
+}
+
+@ ap_dd ( Vec String ) argv → i {
+    : String inf_s ( string_new )
+    : String outf_s ( string_new )
+    : String bs_str ( string_new )
+    : String count_str ( string_new )
+    : String skip_str ( string_new )
+    : String seek_str ( string_new )
+    : String status_s ( string_new )
+    : String conv_s ( string_new )
+    ( __dd_arg argv `if` inf_s )
+    ( __dd_arg argv `of` outf_s )
+    ( __dd_arg argv `bs` bs_str )
+    ( __dd_arg argv `count` count_str )
+    ( __dd_arg argv `skip` skip_str )
+    ( __dd_arg argv `seek` seek_str )
+    ( __dd_arg argv `status` status_s )
+    ( __dd_arg argv `conv` conv_s )
+    : s inf ( string_data inf_s )
+    : s outf ( string_data outf_s )
+    : s bs_s ( string_data bs_str )
+    : s count_s ( string_data count_str )
+    : s skip_s ( string_data skip_str )
+    : s seek_s ( string_data seek_str )
+    : s status ( string_data status_s )
+    : s conv ( string_data conv_s )
+    : i bs ? > ( nurl_str_len bs_s ) 0 ( bx_count bs_s ) 512
+    : i count ? > ( nurl_str_len count_s ) 0 ( bx_count count_s ) -1
+    : i skip ? > ( nurl_str_len skip_s ) 0 ( bx_count skip_s ) 0
+    : i seek ? > ( nurl_str_len seek_s ) 0 ( bx_count seek_s ) 0
+    ? <= bs 0 {
+        ( bx_err `invalid block size` )
+        ( __dd_free inf_s outf_s bs_str count_str skip_str seek_str status_s conv_s )
+        ^ 1
+    } {}
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp ? > ( nurl_str_len inf ) 0 inf `-` ok )
+    ? ! ok {
+        ( vec_free [u] data )
+        ( __dd_free inf_s outf_s bs_str count_str skip_str seek_str status_s conv_s )
+        ^ 1
+    } {}
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : i from ? > * skip bs n n * skip bs
+    : i avail - n from
+    : i want ? >= count 0 * count bs avail
+    : i take ? < want avail want avail
+    // Whole blocks in, a partial one counted separately — that is what
+    // the `N+M records` line means and the only reason dd reports it.
+    : i full / take bs
+    : i partial ? > - take * full bs 0 1 0
+    : ( Vec u ) outbuf ( vec_new [u] )
+    : ~ i k 0
+    ~ < k take {
+        ( vec_push [u] outbuf # u & 255 # i . p + from k )
+        = k + k 1
+    }
+    : ~ i rc 0
+    ? > ( nurl_str_len outf ) 0 {
+        : b notrunc >= ( nurl_str_find conv `notrunc` ) 0
+        : ( Vec u ) final ( vec_new [u] )
+        ? > seek 0 {
+            // seek= writes at an offset: keep what was there when
+            // conv=notrunc says so, otherwise pad with NULs.
+            ? notrunc {
+                : ~ b ok2 T
+                : ( Vec u ) old ( bx_slurp outf ok2 )
+                : i on ( vec_len [u] old )
+                : *u op ( vec_data [u] old )
+                : ~ i q 0
+                ~ < q * seek bs {
+                    ( vec_push [u] final # u ? < q on & 255 # i . op q 0 )
+                    = q + q 1
+                }
+                ( vec_free [u] old )
+            } {
+                : ~ i q 0
+                ~ < q * seek bs { ( vec_push [u] final # u 0 ) = q + q 1 }
+            }
+        } {}
+        ( vec_extend [u] final outbuf )
+        ?? ( write_file_bytes outf final ) {
+            T _ → {}
+            F e → {
+                ( bx_err_at outf ( bx_ioerr e ) )
+                = rc 1
+            }
+        }
+        ( vec_free [u] final )
+    } { ( bx_write_bytes outbuf ) }
+    ? ! ( bx_streq status `none` ) {
+        ( flush )
+        ( nurl_eprint ( nurl_str_int full ) )
+        ( nurl_eprint `+` )
+        ( nurl_eprint ( nurl_str_int partial ) )
+        ( nurl_eprint ` records in\n` )
+        ( nurl_eprint ( nurl_str_int full ) )
+        ( nurl_eprint `+` )
+        ( nurl_eprint ( nurl_str_int partial ) )
+        ( nurl_eprint ` records out\n` )
+    } {}
+    ( vec_free [u] outbuf )
+    ( vec_free [u] data )
+    ( __dd_free inf_s outf_s bs_str count_str skip_str seek_str status_s conv_s )
+    ^ rc
+}
+
+@ __dd_free String a String b String c String d String e String f String g String h → v {
+    ( string_free a )
+    ( string_free b )
+    ( string_free c )
+    ( string_free d )
+    ( string_free e )
+    ( string_free f )
+    ( string_free g )
+    ( string_free h )
+}

--- a/packages/nurlbox/src/fileops.nu
+++ b/packages/nurlbox/src/fileops.nu
@@ -40,19 +40,37 @@ $ `bx.nu`
 
 @ __ent_of s dir s name b follow → BxEnt {
     : String full ? == ( nurl_str_len dir ) 0 ( string_from name ) ( path_join dir name )
-    : ~ BxEnt out @ BxEnt { ( string_from name ) 0 0 0 0 0 0 0 0 F }
+    : ~ i mode 0
+    : ~ i size 0
+    : ~ i mtime 0
+    : ~ i nlink 0
+    : ~ i uid 0
+    : ~ i gid 0
+    : ~ i blocks 0
+    : ~ i ino 0
+    : ~ b ok F
     : !FileStat IoErr r ? follow ( fs_stat ( string_data full ) ) ( fs_lstat ( string_data full ) )
     ?? r {
         T st → {
-            = out @ BxEnt {
-                ( string_from name ) . st mode . st size . st mtime . st nlink
-                . st uid . st gid . st blocks . st ino T
-            }
+            = mode . st mode
+            = size . st size
+            = mtime . st mtime
+            = nlink . st nlink
+            = uid . st uid
+            = gid . st gid
+            = blocks . st blocks
+            = ino . st ino
+            = ok T
         }
         F _ → {}
     }
     ( string_free full )
-    ^ out
+    // ONE struct literal, so exactly one name String is ever allocated.
+    // Building a blank entry first and reassigning it leaked that first
+    // String: auto-drop registers a struct field at the literal that
+    // allocated it, and a reassignment of the binding does not reach
+    // back for the fields of the value it replaced.
+    ^ @ BxEnt { ( string_from name ) mode size mtime nlink uid gid blocks ino ok }
 }
 
 // ── ls ────────────────────────────────────────────────────────────
@@ -362,8 +380,16 @@ $ `bx.nu`
     }
 }
 
+// The comparator's flags ride a global rather than a capture: a
+// capturing closure handed to a GENERIC callee cannot be proven
+// invoke-only, so its heap environment becomes the caller's to free —
+// one 16-byte block per `ls`, which LeakSanitizer duly reported. A
+// capture-free closure allocates nothing at all.
+: ~ i g_ls_sort_flags 0
+
 @ __ls_sort ( Vec BxEnt ) ents i flags → v {
-    ( sort_by [BxEnt] ents \ BxEnt a BxEnt b → i { ^ ( __ls_cmp a b flags ) } )
+    = g_ls_sort_flags flags
+    ( sort_by [BxEnt] ents \ BxEnt a BxEnt b → i { ^ ( __ls_cmp a b g_ls_sort_flags ) } )
 }
 
 @ __ls_dir s dir i flags i now b header b more_after → i {

--- a/packages/nurlbox/src/main.nu
+++ b/packages/nurlbox/src/main.nu
@@ -27,49 +27,74 @@ $ `hash.nu`
 $ `grep.nu`
 $ `shell.nu`
 $ `sed.nu`
+$ `textmisc.nu`
+$ `binio.nu`
+$ `archive.nu`
+$ `proc.nu`
+$ `sh.nu`
 
-: s NURLBOX_VERSION `0.1.0`
+: s NURLBOX_VERSION `0.2.0`
 
 // Every applet, in the order `nurlbox` lists them.
 @ __applet_names → ( Vec String ) {
     : ( Vec String ) v ( vec_new [String] )
     ( vec_push [String] v ( string_from `[` ) )
     ( vec_push [String] v ( string_from `arch` ) )
+    ( vec_push [String] v ( string_from `ash` ) )
     ( vec_push [String] v ( string_from `base64` ) )
     ( vec_push [String] v ( string_from `basename` ) )
     ( vec_push [String] v ( string_from `cat` ) )
     ( vec_push [String] v ( string_from `chmod` ) )
     ( vec_push [String] v ( string_from `cksum` ) )
     ( vec_push [String] v ( string_from `clear` ) )
+    ( vec_push [String] v ( string_from `cmp` ) )
+    ( vec_push [String] v ( string_from `comm` ) )
     ( vec_push [String] v ( string_from `cp` ) )
     ( vec_push [String] v ( string_from `crc32` ) )
     ( vec_push [String] v ( string_from `cut` ) )
     ( vec_push [String] v ( string_from `date` ) )
+    ( vec_push [String] v ( string_from `dd` ) )
+    ( vec_push [String] v ( string_from `df` ) )
     ( vec_push [String] v ( string_from `dirname` ) )
+    ( vec_push [String] v ( string_from `dos2unix` ) )
     ( vec_push [String] v ( string_from `du` ) )
     ( vec_push [String] v ( string_from `echo` ) )
     ( vec_push [String] v ( string_from `egrep` ) )
     ( vec_push [String] v ( string_from `env` ) )
+    ( vec_push [String] v ( string_from `expand` ) )
     ( vec_push [String] v ( string_from `expr` ) )
+    ( vec_push [String] v ( string_from `factor` ) )
     ( vec_push [String] v ( string_from `false` ) )
     ( vec_push [String] v ( string_from `fgrep` ) )
     ( vec_push [String] v ( string_from `find` ) )
+    ( vec_push [String] v ( string_from `fold` ) )
+    ( vec_push [String] v ( string_from `free` ) )
     ( vec_push [String] v ( string_from `grep` ) )
     ( vec_push [String] v ( string_from `groups` ) )
+    ( vec_push [String] v ( string_from `gunzip` ) )
+    ( vec_push [String] v ( string_from `gzip` ) )
     ( vec_push [String] v ( string_from `head` ) )
+    ( vec_push [String] v ( string_from `hexdump` ) )
     ( vec_push [String] v ( string_from `hostname` ) )
     ( vec_push [String] v ( string_from `id` ) )
+    ( vec_push [String] v ( string_from `kill` ) )
+    ( vec_push [String] v ( string_from `killall` ) )
     ( vec_push [String] v ( string_from `ln` ) )
     ( vec_push [String] v ( string_from `logname` ) )
     ( vec_push [String] v ( string_from `ls` ) )
     ( vec_push [String] v ( string_from `md5sum` ) )
     ( vec_push [String] v ( string_from `mkdir` ) )
     ( vec_push [String] v ( string_from `mktemp` ) )
+    ( vec_push [String] v ( string_from `mount` ) )
     ( vec_push [String] v ( string_from `mv` ) )
     ( vec_push [String] v ( string_from `nl` ) )
     ( vec_push [String] v ( string_from `nproc` ) )
+    ( vec_push [String] v ( string_from `od` ) )
+    ( vec_push [String] v ( string_from `paste` ) )
+    ( vec_push [String] v ( string_from `pidof` ) )
     ( vec_push [String] v ( string_from `printenv` ) )
     ( vec_push [String] v ( string_from `printf` ) )
+    ( vec_push [String] v ( string_from `ps` ) )
     ( vec_push [String] v ( string_from `pwd` ) )
     ( vec_push [String] v ( string_from `readlink` ) )
     ( vec_push [String] v ( string_from `realpath` ) )
@@ -78,15 +103,21 @@ $ `sed.nu`
     ( vec_push [String] v ( string_from `rmdir` ) )
     ( vec_push [String] v ( string_from `sed` ) )
     ( vec_push [String] v ( string_from `seq` ) )
+    ( vec_push [String] v ( string_from `sh` ) )
     ( vec_push [String] v ( string_from `sha1sum` ) )
     ( vec_push [String] v ( string_from `sha256sum` ) )
     ( vec_push [String] v ( string_from `sha512sum` ) )
+    ( vec_push [String] v ( string_from `shuf` ) )
     ( vec_push [String] v ( string_from `sleep` ) )
     ( vec_push [String] v ( string_from `sort` ) )
+    ( vec_push [String] v ( string_from `split` ) )
     ( vec_push [String] v ( string_from `stat` ) )
+    ( vec_push [String] v ( string_from `strings` ) )
+    ( vec_push [String] v ( string_from `sum` ) )
     ( vec_push [String] v ( string_from `sync` ) )
     ( vec_push [String] v ( string_from `tac` ) )
     ( vec_push [String] v ( string_from `tail` ) )
+    ( vec_push [String] v ( string_from `tar` ) )
     ( vec_push [String] v ( string_from `tee` ) )
     ( vec_push [String] v ( string_from `test` ) )
     ( vec_push [String] v ( string_from `touch` ) )
@@ -95,13 +126,18 @@ $ `sed.nu`
     ( vec_push [String] v ( string_from `truncate` ) )
     ( vec_push [String] v ( string_from `tty` ) )
     ( vec_push [String] v ( string_from `uname` ) )
+    ( vec_push [String] v ( string_from `unexpand` ) )
     ( vec_push [String] v ( string_from `uniq` ) )
+    ( vec_push [String] v ( string_from `unix2dos` ) )
+    ( vec_push [String] v ( string_from `uptime` ) )
     ( vec_push [String] v ( string_from `usleep` ) )
     ( vec_push [String] v ( string_from `wc` ) )
     ( vec_push [String] v ( string_from `which` ) )
     ( vec_push [String] v ( string_from `whoami` ) )
     ( vec_push [String] v ( string_from `xargs` ) )
+    ( vec_push [String] v ( string_from `xxd` ) )
     ( vec_push [String] v ( string_from `yes` ) )
+    ( vec_push [String] v ( string_from `zcat` ) )
     ^ v
 }
 
@@ -120,45 +156,65 @@ $ `sed.nu`
 
 // The dispatcher. `argv` is the applet's own argument vector: argv[0]
 // is the applet name, exactly as a directly-executed utility sees it.
-@ __run s name ( Vec String ) argv → i {
+@ bx_run_applet s name ( Vec String ) argv → i {
     ( bx_set_name name )
     ? ( bx_streq name `[` ) { ^ ( ap_test argv ) } {}
     ? ( bx_streq name `arch` ) { ^ ( ap_arch argv ) } {}
+    ? ( bx_streq name `ash` ) { ^ ( ap_sh argv ) } {}
     ? ( bx_streq name `base64` ) { ^ ( ap_base64 argv ) } {}
     ? ( bx_streq name `basename` ) { ^ ( ap_basename argv ) } {}
     ? ( bx_streq name `cat` ) { ^ ( ap_cat argv ) } {}
     ? ( bx_streq name `chmod` ) { ^ ( ap_chmod argv ) } {}
     ? ( bx_streq name `cksum` ) { ^ ( ap_cksum argv ) } {}
     ? ( bx_streq name `clear` ) { ^ ( ap_clear argv ) } {}
+    ? ( bx_streq name `cmp` ) { ^ ( ap_cmp argv ) } {}
+    ? ( bx_streq name `comm` ) { ^ ( ap_comm argv ) } {}
     ? ( bx_streq name `cp` ) { ^ ( ap_cp argv ) } {}
     ? ( bx_streq name `crc32` ) { ^ ( ap_crc32 argv ) } {}
     ? ( bx_streq name `cut` ) { ^ ( ap_cut argv ) } {}
     ? ( bx_streq name `date` ) { ^ ( ap_date argv ) } {}
+    ? ( bx_streq name `dd` ) { ^ ( ap_dd argv ) } {}
+    ? ( bx_streq name `df` ) { ^ ( ap_df argv ) } {}
     ? ( bx_streq name `dirname` ) { ^ ( ap_dirname argv ) } {}
+    ? ( bx_streq name `dos2unix` ) { ^ ( ap_dos2unix argv ) } {}
     ? ( bx_streq name `du` ) { ^ ( ap_du argv ) } {}
     ? ( bx_streq name `echo` ) { ^ ( ap_echo argv ) } {}
     ? ( bx_streq name `egrep` ) { ^ ( ap_grep argv ) } {}
     ? ( bx_streq name `env` ) { ^ ( ap_env argv ) } {}
+    ? ( bx_streq name `expand` ) { ^ ( ap_expand argv ) } {}
     ? ( bx_streq name `expr` ) { ^ ( ap_expr argv ) } {}
+    ? ( bx_streq name `factor` ) { ^ ( ap_factor argv ) } {}
     ? ( bx_streq name `false` ) { ^ 1 } {}
     ? ( bx_streq name `fgrep` ) { ^ ( ap_grep argv ) } {}
     ? ( bx_streq name `find` ) { ^ ( ap_find argv ) } {}
+    ? ( bx_streq name `fold` ) { ^ ( ap_fold argv ) } {}
+    ? ( bx_streq name `free` ) { ^ ( ap_free argv ) } {}
     ? ( bx_streq name `grep` ) { ^ ( ap_grep argv ) } {}
     ? ( bx_streq name `groups` ) { ^ ( ap_groups argv ) } {}
+    ? ( bx_streq name `gunzip` ) { ^ ( ap_gzip argv ) } {}
+    ? ( bx_streq name `gzip` ) { ^ ( ap_gzip argv ) } {}
     ? ( bx_streq name `head` ) { ^ ( ap_head argv ) } {}
+    ? ( bx_streq name `hexdump` ) { ^ ( ap_hexdump argv ) } {}
     ? ( bx_streq name `hostname` ) { ^ ( ap_hostname argv ) } {}
     ? ( bx_streq name `id` ) { ^ ( ap_id argv ) } {}
+    ? ( bx_streq name `kill` ) { ^ ( ap_kill argv ) } {}
+    ? ( bx_streq name `killall` ) { ^ ( ap_killall argv ) } {}
     ? ( bx_streq name `ln` ) { ^ ( ap_ln argv ) } {}
     ? ( bx_streq name `logname` ) { ^ ( ap_logname argv ) } {}
     ? ( bx_streq name `ls` ) { ^ ( ap_ls argv ) } {}
     ? ( bx_streq name `md5sum` ) { ^ ( ap_md5sum argv ) } {}
     ? ( bx_streq name `mkdir` ) { ^ ( ap_mkdir argv ) } {}
     ? ( bx_streq name `mktemp` ) { ^ ( ap_mktemp argv ) } {}
+    ? ( bx_streq name `mount` ) { ^ ( ap_mount argv ) } {}
     ? ( bx_streq name `mv` ) { ^ ( ap_mv argv ) } {}
     ? ( bx_streq name `nl` ) { ^ ( ap_nl argv ) } {}
     ? ( bx_streq name `nproc` ) { ^ ( ap_nproc argv ) } {}
+    ? ( bx_streq name `od` ) { ^ ( ap_od argv ) } {}
+    ? ( bx_streq name `paste` ) { ^ ( ap_paste argv ) } {}
+    ? ( bx_streq name `pidof` ) { ^ ( ap_pidof argv ) } {}
     ? ( bx_streq name `printenv` ) { ^ ( ap_printenv argv ) } {}
     ? ( bx_streq name `printf` ) { ^ ( ap_printf argv ) } {}
+    ? ( bx_streq name `ps` ) { ^ ( ap_ps argv ) } {}
     ? ( bx_streq name `pwd` ) { ^ ( ap_pwd argv ) } {}
     ? ( bx_streq name `readlink` ) { ^ ( ap_readlink argv ) } {}
     ? ( bx_streq name `realpath` ) { ^ ( ap_realpath argv ) } {}
@@ -167,15 +223,21 @@ $ `sed.nu`
     ? ( bx_streq name `rmdir` ) { ^ ( ap_rmdir argv ) } {}
     ? ( bx_streq name `sed` ) { ^ ( ap_sed argv ) } {}
     ? ( bx_streq name `seq` ) { ^ ( ap_seq argv ) } {}
+    ? ( bx_streq name `sh` ) { ^ ( ap_sh argv ) } {}
     ? ( bx_streq name `sha1sum` ) { ^ ( ap_sha1sum argv ) } {}
     ? ( bx_streq name `sha256sum` ) { ^ ( ap_sha256sum argv ) } {}
     ? ( bx_streq name `sha512sum` ) { ^ ( ap_sha512sum argv ) } {}
+    ? ( bx_streq name `shuf` ) { ^ ( ap_shuf argv ) } {}
     ? ( bx_streq name `sleep` ) { ^ ( ap_sleep argv ) } {}
     ? ( bx_streq name `sort` ) { ^ ( ap_sort argv ) } {}
+    ? ( bx_streq name `split` ) { ^ ( ap_split argv ) } {}
     ? ( bx_streq name `stat` ) { ^ ( ap_stat argv ) } {}
+    ? ( bx_streq name `strings` ) { ^ ( ap_strings argv ) } {}
+    ? ( bx_streq name `sum` ) { ^ ( ap_sum argv ) } {}
     ? ( bx_streq name `sync` ) { ^ ( ap_sync argv ) } {}
     ? ( bx_streq name `tac` ) { ^ ( ap_tac argv ) } {}
     ? ( bx_streq name `tail` ) { ^ ( ap_tail argv ) } {}
+    ? ( bx_streq name `tar` ) { ^ ( ap_tar argv ) } {}
     ? ( bx_streq name `tee` ) { ^ ( ap_tee argv ) } {}
     ? ( bx_streq name `test` ) { ^ ( ap_test argv ) } {}
     ? ( bx_streq name `touch` ) { ^ ( ap_touch argv ) } {}
@@ -184,13 +246,18 @@ $ `sed.nu`
     ? ( bx_streq name `truncate` ) { ^ ( ap_truncate argv ) } {}
     ? ( bx_streq name `tty` ) { ^ ( ap_tty argv ) } {}
     ? ( bx_streq name `uname` ) { ^ ( ap_uname argv ) } {}
+    ? ( bx_streq name `unexpand` ) { ^ ( ap_unexpand argv ) } {}
     ? ( bx_streq name `uniq` ) { ^ ( ap_uniq argv ) } {}
+    ? ( bx_streq name `unix2dos` ) { ^ ( ap_dos2unix argv ) } {}
+    ? ( bx_streq name `uptime` ) { ^ ( ap_uptime argv ) } {}
     ? ( bx_streq name `usleep` ) { ^ ( ap_usleep argv ) } {}
     ? ( bx_streq name `wc` ) { ^ ( ap_wc argv ) } {}
     ? ( bx_streq name `which` ) { ^ ( ap_which argv ) } {}
     ? ( bx_streq name `whoami` ) { ^ ( ap_whoami argv ) } {}
     ? ( bx_streq name `xargs` ) { ^ ( ap_xargs argv ) } {}
+    ? ( bx_streq name `xxd` ) { ^ ( ap_xxd argv ) } {}
     ? ( bx_streq name `yes` ) { ^ ( ap_yes argv ) } {}
+    ? ( bx_streq name `zcat` ) { ^ ( ap_gzip argv ) } {}
     ( bx_set_name `nurlbox` )
     ( bx_err_at name `applet not found` )
     ^ 127
@@ -222,7 +289,7 @@ $ `sed.nu`
 // implement is the MULTIPLEXER — that is how `nurlbox` behaves when the
 // unikernel's loader calls it `main`, and how a copy named anything else
 // still works.
-@ __is_applet s name → b {
+@ bx_is_applet s name → b {
     : ( Vec String ) names ( __applet_names )
     : i n ( vec_len [String] names )
     : ~ b found F
@@ -239,39 +306,130 @@ $ `sed.nu`
     : ( Vec String ) argv ( env_args_list )
     : String me ( __invoked_as argv )
     : ~ i rc 0
-    ? ! ( __is_applet ( string_data me ) ) {
+    ? ! ( bx_is_applet ( string_data me ) ) {
         ? < ( vec_len [String] argv ) 2 {
             ( __list_applets )
             = rc 0
         } {
             : s sub ( bx_at argv 1 )
-            ? | ( bx_streq sub `--help` ) ( bx_streq sub `-h` ) {
-                ( __list_applets )
-                = rc 0
+            ? ( bx_streq sub `--install` ) {
+                : ~ b symlink F
+                : ~ s dir ``
+                : ~ i k 2
+                ~ < k ( vec_len [String] argv ) {
+                    : s a ( bx_at argv k )
+                    ? ( bx_streq a `-s` ) { = symlink T } { = dir a }
+                    = k + k 1
+                }
+                ? == ( nurl_str_len dir ) 0 {
+                    // No directory given: next to the binary itself,
+                    // which is the only place we can name without
+                    // guessing at the caller's $PATH.
+                    : String me2 ( path_dirname ( bx_at argv 0 ) )
+                    = rc ( __install ( string_data me2 ) symlink )
+                    ( string_free me2 )
+                } { = rc ( __install dir symlink ) }
             } {
-                ? | ( bx_streq sub `--version` ) ( bx_streq sub `-V` ) {
-                    ( nurl_print `nurlbox ` )
-                    ( nurl_print NURLBOX_VERSION )
-                    ( nurl_print `\n` )
+                ? | ( bx_streq sub `--help` ) ( bx_streq sub `-h` ) {
+                    ( __list_applets )
                     = rc 0
                 } {
-                    // shift: the applet sees argv[0] = its own name
-                    : ( Vec String ) sub_argv ( vec_new [String] )
-                    : i n ( vec_len [String] argv )
-                    : ~ i i 1
-                    ~ < i n {
-                        ( vec_push [String] sub_argv ( string_from ( bx_at argv i ) ) )
-                        = i + i 1
+                    ? | ( bx_streq sub `--version` ) ( bx_streq sub `-V` ) {
+                        ( nurl_print `nurlbox ` )
+                        ( nurl_print NURLBOX_VERSION )
+                        ( nurl_print `\n` )
+                        = rc 0
+                    } {
+                        // shift: the applet sees argv[0] = its own name
+                        : ( Vec String ) sub_argv ( vec_new [String] )
+                        : i n ( vec_len [String] argv )
+                        : ~ i i 1
+                        ~ < i n {
+                            ( vec_push [String] sub_argv ( string_from ( bx_at argv i ) ) )
+                            = i + i 1
+                        }
+                        = rc ( bx_run_applet sub sub_argv )
+                        ( vec_free_with [String] sub_argv \ String x → v { ( string_free x ) } )
                     }
-                    = rc ( __run sub sub_argv )
-                    ( vec_free_with [String] sub_argv \ String x → v { ( string_free x ) } )
                 }
             }
         }
     } {
-        = rc ( __run ( string_data me ) argv )
+        = rc ( bx_run_applet ( string_data me ) argv )
     }
     ( string_free me )
     ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// `nurlbox --install [-s] [DIR]` — one entry per applet pointing back
+// at this binary, which is how a single file becomes a userland.
+//
+// Hard links by default and symlinks with -s, the same split busybox
+// makes: a hard link costs nothing and survives the original being
+// moved, a symlink crosses filesystems. An entry that already exists is
+// left alone and reported, because silently replacing a system `cat` is
+// not a thing a tool should do without being asked twice.
+//
+// Kept at the end of the file, below the generated applet table, so a
+// regeneration of that table cannot take it with it.
+@ __install s dir b symlink → i {
+    : ( Vec String ) argv0 ( env_args_list )
+    : String self ( string_new )
+    : Path me ( path_new ( bx_at argv0 0 ) )
+    ?? ( path_canonical me ) {
+        T c → {
+            ( string_push_str self ( path_str c ) )
+            ( path_free c )
+        }
+        F _ → { ( string_push_str self ( bx_at argv0 0 ) ) }
+    }
+    ( path_free me )
+    ( vec_free_with [String] argv0 \ String x → v { ( string_free x ) } )
+    : ( Vec String ) names ( __applet_names )
+    : i n ( vec_len [String] names )
+    : ~ i rc 0
+    : ~ i made 0
+    : ~ i i 0
+    ~ < i n {
+        : String target ( path_join dir ( bx_at names i ) )
+        : ~ b exists F
+        ?? ( fs_lstat ( string_data target ) ) {
+            T _ → { = exists T }
+            F _ → {}
+        }
+        ? exists {
+            ( nurl_eprint `nurlbox: ` )
+            ( nurl_eprint ( string_data target ) )
+            ( nurl_eprint `: exists, left alone\n` )
+        } {
+            : ~ b ok T
+            ? symlink {
+                ?? ( fs_symlink ( string_data self ) ( string_data target ) ) {
+                    T _ → {}
+                    F e → {
+                        ( bx_err_at ( string_data target ) ( bx_ioerr e ) )
+                        = ok F
+                    }
+                }
+            } {
+                : i32 lr ( link ( string_data self ) ( string_data target ) )
+                ? != # i lr 0 {
+                    ( bx_err_at ( string_data target ) ( bx_ioerr ( _io_err_of_kind ( errno_kind ) ) ) )
+                    = ok F
+                } {}
+            }
+            ? ok { = made + made 1 } { = rc 1 }
+        }
+        ( string_free target )
+        = i + i 1
+    }
+    ( nurl_print `nurlbox: ` )
+    ( nurl_print ( nurl_str_int made ) )
+    ( nurl_print ` applets installed into ` )
+    ( nurl_print dir )
+    ( nurl_print `\n` )
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+    ( string_free self )
     ^ rc
 }

--- a/packages/nurlbox/src/proc.nu
+++ b/packages/nurlbox/src/proc.nu
@@ -1,0 +1,846 @@
+// nurlbox/proc.nu — what the machine is doing.
+//
+// ps / kill / killall / pidof / free / uptime / df / mount.
+//
+// Everything except `kill` and `df` reads `/proc`, because on Linux that
+// IS the process table — there is no syscall that enumerates processes,
+// and a tool that pretended otherwise would be reading the same files
+// through a wrapper. On a machine with no `/proc` (the unikernel, a
+// container without it mounted) each of these says so rather than
+// reporting an empty system: "no processes" and "I cannot see the
+// processes" are different answers.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/std/time.nu`
+$ `bx.nu`
+$ `filter.nu`
+
+: s PROC_ROOT `/proc`
+
+@ __proc_available → b {
+    ?? ( fs_stat `/proc/self` ) {
+        T _ → { ^ T }
+        F _ → { ^ F }
+    }
+}
+
+@ __proc_no_procfs → i {
+    ( bx_err `/proc is not mounted — this machine cannot answer that` )
+    ^ 1
+}
+
+// Read a whole /proc file. They report size 0, so `read_file` (which
+// trusts the size) comes back empty — the streaming reader is the only
+// one that works here, and that is not a detail a caller should have to
+// know.
+@ __proc_read s path String out → b {
+    ( string_clear out )
+    ?? ( bufreader_open path ) {
+        F _ → { ^ F }
+        T br → {
+            : String line ( string_new )
+            : ~ b more T
+            ~ more {
+                ? ( bufreader_read_line_raw br line ) {
+                    ( string_push_bytes out # *u ( string_data line ) ( string_len line ) )
+                } { = more F }
+            }
+            ( string_free line )
+            ( bufreader_close br )
+            ^ T
+        }
+    }
+}
+
+// The `n`-th whitespace-separated field of `text`, 0-based.
+@ __field s text i want → String {
+    : i n ( nurl_str_len text )
+    : ~ i i 0
+    : ~ i idx 0
+    ~ < i n {
+        ~ & < i n ( bx_is_blank ( nurl_str_get text i ) ) { = i + i 1 }
+        : i start i
+        ~ & < i n ! ( bx_is_blank ( nurl_str_get text i ) ) { = i + i 1 }
+        ? > i start {
+            ? == idx want { ^ ( string_from ( nurl_str_slice text start - i start ) ) } {}
+            = idx + idx 1
+        } {}
+    }
+    ^ ( string_new )
+}
+
+@ __is_pid_name s name → b {
+    : i n ( nurl_str_len name )
+    ? == n 0 { ^ F } {}
+    : ~ i i 0
+    ~ < i n {
+        ? ! ( bx_is_digit ( nurl_str_get name i ) ) { ^ F } {}
+        = i + i 1
+    }
+    ^ T
+}
+
+// Every pid under /proc, ascending.
+@ __proc_pids ( Vec i ) out → b {
+    ?? ( dir_list PROC_ROOT ) {
+        F _ → { ^ F }
+        T names → {
+            : i n ( vec_len [String] names )
+            : ~ i i 0
+            ~ < i n {
+                : s nm ( bx_at names i )
+                ? ( __is_pid_name nm ) { ( vec_push [i] out ( nurl_str_to_int nm ) ) } {}
+                = i + i 1
+            }
+            ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+            ( sort_by [i] out \ i a i b → i { ^ ( cmp_int a b ) } )
+            ^ T
+        }
+    }
+}
+
+@ __proc_path i pid s leaf → String {
+    : String p ( string_from PROC_ROOT )
+    ( string_push_char p 47 )
+    ( string_push_int p pid )
+    ( string_push_char p 47 )
+    ( string_push_str p leaf )
+    ^ p
+}
+
+// A process's command as `ps` shows it: the full argv with NULs turned
+// into spaces, or the kernel thread's name in brackets when argv is
+// empty — which is exactly how the kernel distinguishes the two.
+@ __proc_command i pid String out → b {
+    ( string_clear out )
+    : String p ( __proc_path pid `cmdline` )
+    : String raw ( string_new )
+    : b ok ( __proc_read ( string_data p ) raw )
+    ( string_free p )
+    ? ! ok {
+        ( string_free raw )
+        ^ F
+    } {}
+    : i n ( string_len raw )
+    ? > n 0 {
+        : ~ i i 0
+        ~ < i n {
+            : i c ( string_get raw i )
+            ? == c 0 {
+                ? < + i 1 n { ( string_push_char out 32 ) } {}
+            } { ( string_push_char out c ) }
+            = i + i 1
+        }
+    } {
+        : String cp ( __proc_path pid `comm` )
+        : String comm ( string_new )
+        ? ( __proc_read ( string_data cp ) comm ) {
+            : ~ i cn ( string_len comm )
+            ~ & > cn 0 == ( string_get comm - cn 1 ) 10 { = cn - cn 1 }
+            ( string_push_char out 91 )
+            ( string_push_bytes out # *u ( string_data comm ) cn )
+            ( string_push_char out 93 )
+        } {}
+        ( string_free comm )
+        ( string_free cp )
+    }
+    ( string_free raw )
+    ^ T
+}
+
+// The uid a process runs as, from /proc/PID/status's `Uid:` line.
+@ __proc_uid i pid → i {
+    : String p ( __proc_path pid `status` )
+    : String text ( string_new )
+    : ~ i uid -1
+    ? ( __proc_read ( string_data p ) text ) {
+        : i n ( string_len text )
+        : ~ i i 0
+        ~ < i n {
+            : ~ i e i
+            ~ & < e n != ( string_get text e ) 10 { = e + e 1 }
+            : String line ( string_substr text i - e i )
+            ? ( string_starts_with line `Uid:` ) {
+                : String f ( __field ( string_data line ) 1 )
+                = uid ( nurl_str_to_int ( string_data f ) )
+                ( string_free f )
+                = i n
+            } { = i + e 1 }
+            ( string_free line )
+        }
+    } {}
+    ( string_free text )
+    ( string_free p )
+    ^ uid
+}
+
+// ── ps ────────────────────────────────────────────────────────────
+
+@ ap_ps ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `aefluwo:` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        ? ! ( __proc_available ) { = rc ( __proc_no_procfs ) } {
+            : ( Vec i ) pids ( vec_new [i] )
+            ? ! ( __proc_pids pids ) { = rc ( __proc_no_procfs ) } {
+                : String out ( string_from `PID   USER     COMMAND\n` )
+                : String cmd ( string_new )
+                : i n ( vec_len [i] pids )
+                : ~ i i 0
+                ~ < i n {
+                    ?? ( vec_get [i] pids i ) {
+                        T pid → {
+                            ? ( __proc_command pid cmd ) {
+                                ( bx_push_right out ( nurl_str_int pid ) 5 )
+                                ( string_push_char out 32 )
+                                : i uid ( __proc_uid pid )
+                                : ~ String user ( string_from `?` )
+                                ? >= uid 0 {
+                                    ?? ( fs_user_name uid ) {
+                                        T nm → {
+                                            ( string_free user )
+                                            = user nm
+                                        }
+                                        F _ → {
+                                            ( string_free user )
+                                            = user ( string_from ( nurl_str_int uid ) )
+                                        }
+                                    }
+                                } {}
+                                : i w ( string_len user )
+                                ( string_push_bytes out # *u ( string_data user ) ? > w 8 8 w )
+                                : ~ i pad - 8 ? > w 8 8 w
+                                ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+                                ( string_free user )
+                                ( string_push_char out 32 )
+                                ( string_push_bytes out # *u ( string_data cmd ) ( string_len cmd ) )
+                                ( string_push_char out 10 )
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                    = i + i 1
+                }
+                ( bx_write out )
+                ( string_free out )
+                ( string_free cmd )
+            }
+            ( vec_free [i] pids )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── kill / killall / pidof ────────────────────────────────────────
+
+: s BX_SIGNAMES `HUP INT QUIT ILL TRAP ABRT BUS FPE KILL USR1 SEGV USR2 PIPE ALRM TERM STKFLT CHLD CONT STOP TSTP TTIN TTOU URG XCPU XFSZ VTALRM PROF WINCH POLL PWR SYS`
+
+@ __sig_name i n → String {
+    : String table ( string_from BX_SIGNAMES )
+    : ( Vec String ) names ( string_split table ` ` )
+    : ~ String out ( string_new )
+    ? & >= n 1 <= n ( vec_len [String] names ) {
+        ( string_push_str out ( bx_at names - n 1 ) )
+    } {}
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+    ( string_free table )
+    ^ out
+}
+
+@ __sig_number s spec → i {
+    : i n ( nurl_str_len spec )
+    ? == n 0 { ^ -1 } {}
+    ? ( bx_is_digit ( nurl_str_get spec 0 ) ) { ^ ( nurl_str_to_int spec ) } {}
+    // `-SIGTERM` and `-TERM` name the same signal.
+    : s bare ? != 0 ( nurl_str_starts spec `SIG` ) ( nurl_str_slice spec 3 - n 3 ) spec
+    : String table ( string_from BX_SIGNAMES )
+    : ( Vec String ) names ( string_split table ` ` )
+    : i cnt ( vec_len [String] names )
+    : ~ i found -1
+    : ~ i i 0
+    ~ < i cnt {
+        ? ( bx_streq ( bx_at names i ) bare ) { = found + i 1 } {}
+        = i + i 1
+    }
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+    ( string_free table )
+    ^ found
+}
+
+@ ap_kill ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    : ~ i sig 15
+    : ~ i i 1
+    : ~ b list F
+    ~ & < i n T {
+        : s a ( bx_at argv i )
+        : i al ( nurl_str_len a )
+        ? & > al 1 == 45 ( nurl_str_get a 0 ) {
+            ? ( bx_streq a `-l` ) {
+                = list T
+                = i + i 1
+            } {
+                : i s2 ( __sig_number ( nurl_str_slice a 1 - al 1 ) )
+                ? < s2 0 {
+                    ( bx_err_at a `unknown signal` )
+                    ^ 1
+                } {}
+                = sig s2
+                = i + i 1
+            }
+        } { = i n }
+    }
+    ? list {
+        : String out ( string_new )
+        : ~ i k 1
+        ~ <= k 31 {
+            : String nm ( __sig_name k )
+            ( bx_push_right out ( nurl_str_int k ) 2 )
+            ( string_push_str out `) ` )
+            ( string_push_bytes out # *u ( string_data nm ) ( string_len nm ) )
+            ( string_push_char out 10 )
+            ( string_free nm )
+            = k + k 1
+        }
+        ( bx_write out )
+        ( string_free out )
+        ^ 0
+    } {}
+    ? >= i n {
+        ( bx_err `usage: kill [-SIGNAL] PID...` )
+        ^ 1
+    } {}
+    : ~ i rc 0
+    ~ < i n {
+        : s a ( bx_at argv i )
+        : i pid ( nurl_str_to_int a )
+        : i32 r ( kill # i32 pid # i32 sig )
+        ? != # i r 0 {
+            ( bx_err_at a `No such process` )
+            = rc 1
+        } {}
+        = i + i 1
+    }
+    ^ rc
+}
+
+// Pids whose command matches `name`, either as the whole argv[0] or as
+// its basename — `killall sshd` must find `/usr/sbin/sshd`.
+@ __pids_named s name ( Vec i ) out → b {
+    : ( Vec i ) pids ( vec_new [i] )
+    ? ! ( __proc_pids pids ) {
+        ( vec_free [i] pids )
+        ^ F
+    } {}
+    : String cmd ( string_new )
+    : i n ( vec_len [i] pids )
+    : ~ i i 0
+    ~ < i n {
+        ?? ( vec_get [i] pids i ) {
+            T pid → {
+                ? ( __proc_command pid cmd ) {
+                    : String first ( __field ( string_data cmd ) 0 )
+                    : String base ( path_basename ( string_data first ) )
+                    ? | ( bx_streq ( string_data first ) name ) ( bx_streq ( string_data base ) name ) {
+                        ( vec_push [i] out pid )
+                    } {}
+                    ( string_free base )
+                    ( string_free first )
+                } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ( string_free cmd )
+    ( vec_free [i] pids )
+    ^ T
+}
+
+@ ap_killall ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    : ~ i sig 15
+    : ~ i i 1
+    ? & > n 1 == 45 ( nurl_str_get ( bx_at argv 1 ) 0 ) {
+        : s a ( bx_at argv 1 )
+        = sig ( __sig_number ( nurl_str_slice a 1 - ( nurl_str_len a ) 1 ) )
+        = i 2
+    } {}
+    ? >= i n {
+        ( bx_err `usage: killall [-SIGNAL] NAME...` )
+        ^ 1
+    } {}
+    ? ! ( __proc_available ) { ^ ( __proc_no_procfs ) } {}
+    : ~ i rc 0
+    ~ < i n {
+        : s name ( bx_at argv i )
+        : ( Vec i ) pids ( vec_new [i] )
+        ? ( __pids_named name pids ) {
+            : i cnt ( vec_len [i] pids )
+            ? == cnt 0 {
+                ( bx_err_at name `no process killed` )
+                = rc 1
+            } {
+                : ~ i k 0
+                ~ < k cnt {
+                    ?? ( vec_get [i] pids k ) {
+                        T pid → { : i32 _r ( kill # i32 pid # i32 sig ) }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            }
+        } { = rc 1 }
+        ( vec_free [i] pids )
+        = i + i 1
+    }
+    ^ rc
+}
+
+@ ap_pidof ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    ? <= n 1 {
+        ( bx_err `usage: pidof NAME...` )
+        ^ 1
+    } {}
+    ? ! ( __proc_available ) { ^ ( __proc_no_procfs ) } {}
+    : String out ( string_new )
+    : ~ b any F
+    : ~ i i 1
+    ~ < i n {
+        : ( Vec i ) pids ( vec_new [i] )
+        ? ( __pids_named ( bx_at argv i ) pids ) {
+            // Newest first, which is what a caller piping into `kill`
+            // expects: the process it just started is the one it means.
+            : ~ i k ( vec_len [i] pids )
+            ~ > k 0 {
+                ?? ( vec_get [i] pids - k 1 ) {
+                    T pid → {
+                        ? any { ( string_push_char out 32 ) } {}
+                        ( string_push_int out pid )
+                        = any T
+                    }
+                    F _ → {}
+                }
+                = k - k 1
+            }
+        } {}
+        ( vec_free [i] pids )
+        = i + i 1
+    }
+    ? any { ( string_push_char out 10 ) } {}
+    ( bx_write out )
+    ( string_free out )
+    ^ ? any 0 1
+}
+
+// ── free ──────────────────────────────────────────────────────────
+
+// One `Key:  value kB` line out of /proc/meminfo, in kibibytes.
+@ __meminfo String text s key → i {
+    : i n ( string_len text )
+    : ~ i i 0
+    ~ < i n {
+        : ~ i e i
+        ~ & < e n != ( string_get text e ) 10 { = e + e 1 }
+        : String line ( string_substr text i - e i )
+        : ~ i v -1
+        ? ( string_starts_with line key ) {
+            : String f ( __field ( string_data line ) 1 )
+            = v ( nurl_str_to_int ( string_data f ) )
+            ( string_free f )
+        } {}
+        ( string_free line )
+        ? >= v 0 { ^ v } {}
+        = i + e 1
+    }
+    ^ -1
+}
+
+@ ap_free ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `bkmgh` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : String text ( string_new )
+        ? ! ( __proc_read `/proc/meminfo` text ) {
+            ( bx_err `/proc/meminfo is not readable — this machine cannot answer that` )
+            = rc 1
+        } {
+            : i total ( __meminfo text `MemTotal:` )
+            : i free_ ( __meminfo text `MemFree:` )
+            : i avail ( __meminfo text `MemAvailable:` )
+            : i buffers ( __meminfo text `Buffers:` )
+            : i cached ( __meminfo text `Cached:` )
+            : i shared ( __meminfo text `Shmem:` )
+            : i swtotal ( __meminfo text `SwapTotal:` )
+            : i swfree ( __meminfo text `SwapFree:` )
+            : i reclaim ( __meminfo text `SReclaimable:` )
+            // `free(1)` counts reclaimable slab as cache, because that is
+            // what it is: memory the kernel will hand back on demand.
+            : i buffcache + + ? > buffers 0 buffers 0 ? > cached 0 cached 0 ? > reclaim 0 reclaim 0
+            : i used - - total free_ buffcache
+            : String out ( string_from `              total        used        free      shared  buff/cache   available\n` )
+            // The label sits in the same 19-column field the header's
+            // `total` ends in, so the numbers line up under it.
+            ( string_push_str out `Mem:` )
+            ( bx_push_right out ( nurl_str_int total ) 15 )
+            ( bx_push_right out ( nurl_str_int used ) 12 )
+            ( bx_push_right out ( nurl_str_int free_ ) 12 )
+            ( bx_push_right out ( nurl_str_int ? > shared 0 shared 0 ) 12 )
+            ( bx_push_right out ( nurl_str_int buffcache ) 12 )
+            ( bx_push_right out ( nurl_str_int ? > avail 0 avail 0 ) 12 )
+            ( string_push_char out 10 )
+            ( string_push_str out `Swap:` )
+            ( bx_push_right out ( nurl_str_int ? > swtotal 0 swtotal 0 ) 14 )
+            ( bx_push_right out ( nurl_str_int - ? > swtotal 0 swtotal 0 ? > swfree 0 swfree 0 ) 12 )
+            ( bx_push_right out ( nurl_str_int ? > swfree 0 swfree 0 ) 12 )
+            ( string_push_char out 10 )
+            ( bx_write out )
+            ( string_free out )
+        }
+        ( string_free text )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── uptime ────────────────────────────────────────────────────────
+
+// Logged-in users, counted out of /var/run/utmp. The record is 384
+// bytes on Linux with `ut_type` a short at offset 0; USER_PROCESS is 7.
+// A machine with no utmp answers -1 and `uptime` leaves the field out
+// rather than claiming nobody is here.
+@ __count_users → i {
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp `/var/run/utmp` ok )
+    ? ! ok {
+        ( vec_free [u] data )
+        ^ -1
+    } {}
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : ~ i count 0
+    : ~ i off 0
+    ~ <= + off 384 n {
+        : i kind | & 255 # i . p off << & 255 # i . p + off 1 8
+        ? == kind 7 { = count + count 1 } {}
+        = off + off 384
+    }
+    ( vec_free [u] data )
+    ^ count
+}
+
+@ ap_uptime ( Vec String ) argv → i {
+    : String up ( string_new )
+    ? ! ( __proc_read `/proc/uptime` up ) {
+        ( string_free up )
+        ( bx_err `/proc/uptime is not readable — this machine cannot answer that` )
+        ^ 1
+    } {}
+    : String f ( __field ( string_data up ) 0 )
+    : i secs # i ( nurl_str_to_float ( string_data f ) )
+    ( string_free f )
+    ( string_free up )
+    : String out ( string_new )
+    ( string_push_char out 32 )
+    : Time now ( time_now_local )
+    : String clock ( time_format now `%H:%M:%S` )
+    ( string_push_bytes out # *u ( string_data clock ) ( string_len clock ) )
+    ( string_free clock )
+    ( string_push_str out ` up ` )
+    : i days / secs 86400
+    ? > days 0 {
+        ( string_push_int out days )
+        ( string_push_str out ? == days 1 ` day, ` ` days, ` )
+    } {}
+    : i hh / - secs * days 86400 3600
+    : i mm / - - secs * days 86400 * hh 3600 60
+    ? > hh 0 {
+        ( bx_push_right out ( nurl_str_int hh ) 2 )
+        ( string_push_char out 58 )
+        ? < mm 10 { ( string_push_char out 48 ) } {}
+        ( string_push_int out mm )
+    } {
+        ( string_push_int out mm )
+        ( string_push_str out ` min` )
+    }
+    : i users ( __count_users )
+    ? >= users 0 {
+        ( string_push_str out `,  ` )
+        ( string_push_int out users )
+        ( string_push_str out ? == users 1 ` user` ` users` )
+    } {}
+    : String load ( string_new )
+    ? ( __proc_read `/proc/loadavg` load ) {
+        ( string_push_str out `,  load average: ` )
+        : ~ i k 0
+        ~ < k 3 {
+            ? > k 0 { ( string_push_str out `, ` ) } {}
+            : String lf ( __field ( string_data load ) k )
+            ( string_push_bytes out # *u ( string_data lf ) ( string_len lf ) )
+            ( string_free lf )
+            = k + k 1
+        }
+    } {}
+    ( string_free load )
+    ( string_push_char out 10 )
+    ( bx_write out )
+    ( string_free out )
+    ^ 0
+}
+
+// ── df / mount ────────────────────────────────────────────────────
+
+: MountEnt {
+    String dev
+    String dir
+    String kind
+    String opts
+}
+
+@ __mounts ( Vec MountEnt ) out → b {
+    : String text ( string_new )
+    ? ! ( __proc_read `/proc/mounts` text ) {
+        ( string_free text )
+        ^ F
+    } {}
+    : i n ( string_len text )
+    : ~ i i 0
+    ~ < i n {
+        : ~ i e i
+        ~ & < e n != ( string_get text e ) 10 { = e + e 1 }
+        ? > e i {
+            : String line ( string_substr text i - e i )
+            ( vec_push [MountEnt] out @ MountEnt {
+                ( __field ( string_data line ) 0 )
+                ( __field ( string_data line ) 1 )
+                ( __field ( string_data line ) 2 )
+                ( __field ( string_data line ) 3 )
+            } )
+            ( string_free line )
+        } {}
+        = i + e 1
+    }
+    ( string_free text )
+    ^ T
+}
+
+@ __mount_free MountEnt m → v {
+    ( string_free . m dev )
+    ( string_free . m dir )
+    ( string_free . m kind )
+    ( string_free . m opts )
+}
+
+@ ap_mount ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    ? > n 1 {
+        // Mounting is a privileged syscall this package does not wrap;
+        // saying so beats a wrong error from somewhere deeper.
+        ( bx_err `only the listing form is supported` )
+        ^ 1
+    } {}
+    : ( Vec MountEnt ) ms ( vec_new [MountEnt] )
+    ? ! ( __mounts ms ) {
+        ( vec_free [MountEnt] ms )
+        ^ ( __proc_no_procfs )
+    } {}
+    : String out ( string_new )
+    : i cnt ( vec_len [MountEnt] ms )
+    : ~ i i 0
+    ~ < i cnt {
+        ?? ( vec_get [MountEnt] ms i ) {
+            T m → {
+                ( string_push_bytes out # *u ( string_data . m dev ) ( string_len . m dev ) )
+                ( string_push_str out ` on ` )
+                ( string_push_bytes out # *u ( string_data . m dir ) ( string_len . m dir ) )
+                ( string_push_str out ` type ` )
+                ( string_push_bytes out # *u ( string_data . m kind ) ( string_len . m kind ) )
+                ( string_push_str out ` (` )
+                ( string_push_bytes out # *u ( string_data . m opts ) ( string_len . m opts ) )
+                ( string_push_str out `)\n` )
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ( bx_write out )
+    ( string_free out )
+    ( vec_free_with [MountEnt] ms \ MountEnt m → v { ( __mount_free m ) } )
+    ^ 0
+}
+
+// df's own humaniser: always one decimal, unlike `ls -h`, which drops
+// it above 10. Two tools, two long-standing conventions.
+@ __df_human i bytes → String {
+    : String out ( string_new )
+    ? < bytes 1024 {
+        ( string_push_int out bytes )
+        ^ out
+    } {}
+    : s units `KMGTPE`
+    : ~ i v bytes
+    : ~ i unit -1
+    : ~ i rem 0
+    ~ & >= v 1024 < unit 5 {
+        = rem - v * 1024 / v 1024
+        = v / v 1024
+        = unit + unit 1
+    }
+    : i tenth / + * rem 10 512 1024
+    : ~ i whole v
+    : ~ i frac tenth
+    ? >= frac 10 { = whole + whole 1 = frac 0 } {}
+    ( string_push_int out whole )
+    ( string_push_char out 46 )
+    ( string_push_int out frac )
+    ( string_push_char out ( nurl_str_get units unit ) )
+    ^ out
+}
+
+@ __df_row String out s dev s dir b human FsStat st → v {
+    : i unit . st frsize
+    : i total * . st blocks unit
+    : i avail * . st bavail unit
+    : i used - total * . st bfree unit
+    : i dw ( nurl_str_len dev )
+    ( string_push_str out dev )
+    : ~ i pad - 20 dw
+    ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+    ? human {
+        : String a ( __df_human total )
+        : String b ( __df_human used )
+        : String c ( __df_human avail )
+        ( bx_push_right out ( string_data a ) 10 )
+        ( bx_push_right out ( string_data b ) 10 )
+        ( bx_push_right out ( string_data c ) 10 )
+        ( string_free a )
+        ( string_free b )
+        ( string_free c )
+    } {
+        ( bx_push_right out ( nurl_str_int / total 1024 ) 10 )
+        ( bx_push_right out ( nurl_str_int / used 1024 ) 10 )
+        ( bx_push_right out ( nurl_str_int / avail 1024 ) 10 )
+    }
+    // Truncated, not rounded: a filesystem 91.2% full is 91% full, and
+    // this is the number every df has printed for forty years.
+    : i denom + used avail
+    : i pct ? > denom 0 / * used 100 denom 0
+    ( bx_push_right out ( nurl_str_int pct ) 4 )
+    ( string_push_str out `% ` )
+    ( string_push_str out dir )
+    ( string_push_char out 10 )
+}
+
+// The device whose mount point is the longest prefix of `path` — the
+// same "most specific mount wins" rule the kernel resolves paths with.
+@ __device_for s path → String {
+    : ( Vec MountEnt ) ms ( vec_new [MountEnt] )
+    : ~ String best ( string_from path )
+    : ~ i bestlen -1
+    ? ( __mounts ms ) {
+        : String real ( string_new )
+        : Path pp ( path_new path )
+        ?? ( path_canonical pp ) {
+            T c → {
+                ( string_push_str real ( path_str c ) )
+                ( path_free c )
+            }
+            F _ → { ( string_push_str real path ) }
+        }
+        ( path_free pp )
+        : i cnt ( vec_len [MountEnt] ms )
+        : ~ i i 0
+        ~ < i cnt {
+            ?? ( vec_get [MountEnt] ms i ) {
+                T m → {
+                    : i dl ( string_len . m dir )
+                    ? & > dl bestlen ( string_starts_with real ( string_data . m dir ) ) {
+                        = bestlen dl
+                        ( string_free best )
+                        = best ( string_clone . m dev )
+                    } {}
+                }
+                F _ → {}
+            }
+            = i + i 1
+        }
+        ( string_free real )
+    } {}
+    ( vec_free_with [MountEnt] ms \ MountEnt m → v { ( __mount_free m ) } )
+    ^ best
+}
+
+@ ap_df ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `hkmPia` `human-readable=h,portability=P,all=a` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b human ( bx_has o `h` )
+        : String out ( string_new )
+        ( string_push_str out ? human
+        `Filesystem                Size      Used Available Use% Mounted on\n`
+        `Filesystem           1K-blocks      Used Available Use% Mounted on\n` )
+        : i nops ( bx_operand_count o )
+        ? > nops 0 {
+            : ~ i i 0
+            ~ < i nops {
+                : s p ( bx_operand o i )
+                ?? ( fs_statfs p ) {
+                    T st → {
+                        // The Filesystem column names the DEVICE, which
+                        // only the mount table knows.
+                        : String dev ( __device_for p )
+                        ( __df_row out ( string_data dev ) p human st )
+                        ( string_free dev )
+                    }
+                    F e → {
+                        ( bx_err_at p ( bx_ioerr e ) )
+                        = rc 1
+                    }
+                }
+                = i + i 1
+            }
+        } {
+            : ( Vec MountEnt ) ms ( vec_new [MountEnt] )
+            ? ! ( __mounts ms ) {
+                = rc ( __proc_no_procfs )
+            } {
+                : i cnt ( vec_len [MountEnt] ms )
+                : ~ i i 0
+                ~ < i cnt {
+                    ?? ( vec_get [MountEnt] ms i ) {
+                        T m → {
+                            ?? ( fs_statfs ( string_data . m dir ) ) {
+                                T st → {
+                                    // A pseudo-filesystem with no blocks
+                                    // is not a disk; -a asks for it
+                                    // anyway.
+                                    ? | ( bx_has o `a` ) > . st blocks 0 {
+                                        ( __df_row out ( string_data . m dev ) ( string_data . m dir ) human st )
+                                    } {}
+                                }
+                                F _ → {}
+                            }
+                        }
+                        F _ → {}
+                    }
+                    = i + i 1
+                }
+            }
+            ( vec_free_with [MountEnt] ms \ MountEnt m → v { ( __mount_free m ) } )
+        }
+        ( bx_write out )
+        ( string_free out )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/src/sh.nu
+++ b/packages/nurlbox/src/sh.nu
@@ -1,0 +1,2652 @@
+// nurlbox/sh.nu — the shell.
+//
+// A POSIX-shaped `sh`: quoting, parameter and command substitution,
+// arithmetic, globbing, pipelines, redirections, `&&` / `||`, `if`,
+// `while`, `until`, `for`, `case`, functions, and the builtins a script
+// cannot be written without.
+//
+// Two decisions shape the implementation.
+//
+// **Applets run in-process.** When a command names one of nurlbox's own
+// applets, the shell calls it directly rather than exec'ing itself.
+// That is busybox's standalone-shell trick, and here it is what makes
+// the shell work on a machine with no `fork` at all — the unikernel runs
+// one program in one address space, and a shell that could only work by
+// spawning would be a shell that could not run there.
+//
+// **Quoting is tracked per byte.** Every word carries a mask parallel to
+// its text saying how each byte was quoted: 0 unquoted, 1 single-quoted,
+// 2 double-quoted. Expansion consults it, so `$x` expands inside `"` and
+// not inside `'`, and the RESULT of an expansion is split into fields
+// and globbed only where the `$` itself was unquoted. Anything less than
+// a per-byte answer gets `"$@"` or `echo "a b"` wrong.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/ext/env.nu`
+$ `bx.nu`
+
+// ── Words ─────────────────────────────────────────────────────────
+
+: ShWord {
+    String text
+    String mask  // one byte per text byte: 0 bare, 1 single, 2 double
+}
+
+@ __shw_new → ShWord { ^ @ ShWord { ( string_new ) ( string_new ) } }
+
+@ __shw_free ShWord w → v {
+    ( string_free . w text )
+    ( string_free . w mask )
+}
+
+@ __shw_push ShWord w i c i q → v {
+    ( string_push_char . w text c )
+    ( string_push_char . w mask q )
+}
+
+@ __shw_push_str ShWord w s t i q → v {
+    : i n ( nurl_str_len t )
+    : ~ i i 0
+    ~ < i n {
+        ( __shw_push w ( nurl_str_get t i ) q )
+        = i + i 1
+    }
+}
+
+@ __shw_clone ShWord w → ShWord {
+    ^ @ ShWord { ( string_clone . w text ) ( string_clone . w mask ) }
+}
+
+@ __shw_len ShWord w → i { ^ ( string_len . w text ) }
+
+@ __shw_at ShWord w i k → i { ^ ( string_get . w text k ) }
+
+@ __shw_q ShWord w i k → i { ^ ( string_get . w mask k ) }
+
+@ __shw_free_vec ( Vec ShWord ) v → v {
+    ( vec_free_with [ShWord] v \ ShWord w → v { ( __shw_free w ) } )
+}
+
+// ── Tokens ────────────────────────────────────────────────────────
+
+: i SHT_WORD 0
+: i SHT_OP 1
+: i SHT_NEWLINE 2
+: i SHT_EOF 3
+
+: ShTok {
+    i kind
+    ShWord word  // for SHT_WORD
+    String op  // for SHT_OP
+}
+
+@ __sht_free ShTok t → v {
+    ( __shw_free . t word )
+    ( string_free . t op )
+}
+
+@ __sht_free_vec ( Vec ShTok ) v → v {
+    ( vec_free_with [ShTok] v \ ShTok t → v { ( __sht_free t ) } )
+}
+
+@ __sh_is_op_char i c → b {
+    ^ | | | | | | | == c 124 == c 38 == c 59 == c 40 == c 41 == c 60 == c 62 == c 10
+}
+
+@ __sh_is_blank_c i c → b { ^ | == c 32 == c 9 }
+
+// The lexer. Quoting is resolved here — the parser and the expander
+// never see a quote character again, only the mask.
+//
+// Heredoc bodies are collected too, in the order their `<<` appeared,
+// because a heredoc's text is NOT part of the token stream: it starts on
+// the line after the operator and runs to its delimiter. Lexing it as
+// words would turn `cat <<EOF` followed by `if false` into a parse
+// error about an `if` nobody wrote.
+@ __sh_lex s src ( Vec ShTok ) out ( Vec String ) bodies → b {
+    : i n ( nurl_str_len src )
+    : ~ i i 0
+    : ~ b ok T
+    // Delimiters awaiting their body, and whether `<<-` asked for the
+    // leading tabs to be stripped.
+    : ~ ( Vec String ) pending ( vec_new [String] )
+    : ~ ( Vec i ) pending_strip ( vec_new [i] )
+    : ~ b want_delim F
+    : ~ b want_strip F
+    ~ < i n {
+        // Blanks between words, and comments to end of line.
+        ~ & < i n ( __sh_is_blank_c ( nurl_str_get src i ) ) { = i + i 1 }
+        ? & < i n == ( nurl_str_get src i ) 35 {
+            ~ & < i n != ( nurl_str_get src i ) 10 { = i + i 1 }
+        } {}
+        ? >= i n { = i n } {
+            : i c ( nurl_str_get src i )
+            ? == c 10 {
+                ( vec_push [ShTok] out @ ShTok { SHT_NEWLINE ( __shw_new ) ( string_from `\n` ) } )
+                = i + i 1
+                // Every heredoc opened on this line takes its body now.
+                : i np ( vec_len [String] pending )
+                : ~ i pi 0
+                ~ < pi np {
+                    : ~ i strip 0
+                    ?? ( vec_get [i] pending_strip pi ) { T x → { = strip x } F _ → {} }
+                    : String body ( string_new )
+                    : ~ b closed F
+                    ~ & ! closed < i n {
+                        : ~ i e i
+                        ~ & < e n != ( nurl_str_get src e ) 10 { = e + e 1 }
+                        : ~ i ls i
+                        ? != strip 0 {
+                            ~ & < ls e == ( nurl_str_get src ls ) 9 { = ls + ls 1 }
+                        } {}
+                        : s line ( nurl_str_slice src ls - e ls )
+                        ? ( bx_streq line ( bx_at pending pi ) ) {
+                            = closed T
+                        } {
+                            ( string_push_str body line )
+                            ( string_push_char body 10 )
+                        }
+                        = i ? < e n + e 1 e
+                    }
+                    ( vec_push [String] bodies body )
+                    = pi + pi 1
+                }
+                ( vec_free_with [String] pending \ String x → v { ( string_free x ) } )
+                ( vec_free [i] pending_strip )
+                = pending ( vec_new [String] )
+                = pending_strip ( vec_new [i] )
+            } {
+                // `2>file` / `1>&2`: a digit run touching a redirection
+                // operator is that operator's descriptor, not a word.
+                // Only adjacency distinguishes them — `echo 2 > f` is an
+                // argument and a redirect, `echo 2> f` is a redirect.
+                : ~ i digit_end i
+                ~ & < digit_end n ( bx_is_digit ( nurl_str_get src digit_end ) ) { = digit_end + digit_end 1 }
+                : b fd_prefix & > digit_end i & < digit_end n | == ( nurl_str_get src digit_end ) 60 == ( nurl_str_get src digit_end ) 62
+                ? fd_prefix {
+                    : String op ( string_from ( nurl_str_slice src i - digit_end i ) )
+                    = i digit_end
+                    : i oc ( nurl_str_get src i )
+                    : i oc2 ? < + i 1 n ( nurl_str_get src + i 1 ) 0
+                    ( string_push_char op oc )
+                    = i + i 1
+                    ? | & == oc 62 == oc2 62 & == oc 60 == oc2 60 {
+                        ( string_push_char op oc2 )
+                        = i + i 1
+                    } {
+                        ? == oc2 38 {
+                            ( string_push_char op 38 )
+                            = i + i 1
+                        } {}
+                    }
+                    ( vec_push [ShTok] out @ ShTok { SHT_OP ( __shw_new ) op } )
+                } {
+                    ? ( __sh_is_op_char c ) {
+                        // Longest operator first: `>>` before `>`, `&&`
+                        // before `&`, `;;` before `;`.
+                        : ~ String op ( string_new )
+                        : i c2 ? < + i 1 n ( nurl_str_get src + i 1 ) 0
+                        ? | | & == c 62 == c2 62 & == c 60 == c2 60 | & == c 38 == c2 38 | & == c 124 == c2 124 & == c 59 == c2 59 {
+                            ( string_push_char op c )
+                            ( string_push_char op c2 )
+                            = i + i 2
+                            // `<<-` is a heredoc that strips leading tabs.
+                            ? & & == c 60 < i n == 45 ( nurl_str_get src i ) {
+                                ( string_push_char op 45 )
+                                = i + i 1
+                            } {}
+                        } {
+                            ? & | == c 62 == c 60 & < + i 1 n == 38 c2 {
+                                // `>&` / `<&` — a descriptor duplication.
+                                ( string_push_char op c )
+                                ( string_push_char op 38 )
+                                = i + i 2
+                            } {
+                                ( string_push_char op c )
+                                = i + i 1
+                            }
+                        }
+                        ? ( nurl_str_starts ( string_data op ) `<<` ) {
+                            ? ! ( bx_streq ( string_data op ) `<<&` ) {
+                                = want_delim T
+                                = want_strip ( bx_streq ( string_data op ) `<<-` )
+                            } {}
+                        } {}
+                        ( vec_push [ShTok] out @ ShTok { SHT_OP ( __shw_new ) op } )
+                    } {
+                        // A word: everything up to an unquoted blank or
+                        // operator, with quotes folded into the mask.
+                        : ShWord w ( __shw_new )
+                        : ~ b done F
+                        ~ & ! done < i n {
+                            : i ch ( nurl_str_get src i )
+                            ? | ( __sh_is_blank_c ch ) ( __sh_is_op_char ch ) { = done T } {
+                                ? == ch 39 {
+                                    = i + i 1
+                                    ~ & < i n != ( nurl_str_get src i ) 39 {
+                                        ( __shw_push w ( nurl_str_get src i ) 1 )
+                                        = i + i 1
+                                    }
+                                    ? >= i n {
+                                        ( bx_err `unterminated '` )
+                                        = ok F
+                                        = done T
+                                    } { = i + i 1 }
+                                } {
+                                    ? == ch 34 {
+                                        = i + i 1
+                                        ~ & < i n != ( nurl_str_get src i ) 34 {
+                                            : i q ( nurl_str_get src i )
+                                            ? & == q 92 < + i 1 n {
+                                                : i e ( nurl_str_get src + i 1 )
+                                                // Inside "…", a backslash
+                                                // only escapes these five.
+                                                ? | | | | == e 34 == e 92 == e 36 == e 96 == e 10 {
+                                                    ? != e 10 { ( __shw_push w e 2 ) } {}
+                                                    = i + i 2
+                                                } {
+                                                    ( __shw_push w 92 2 )
+                                                    = i + i 1
+                                                }
+                                            } {
+                                                ( __shw_push w q 2 )
+                                                = i + i 1
+                                            }
+                                        }
+                                        ? >= i n {
+                                            ( bx_err `unterminated "` )
+                                            = ok F
+                                            = done T
+                                        } { = i + i 1 }
+                                    } {
+                                        ? == ch 92 {
+                                            ? < + i 1 n {
+                                                : i e ( nurl_str_get src + i 1 )
+                                                // A backslash-newline is a
+                                                // line continuation and
+                                                // disappears entirely.
+                                                ? != e 10 { ( __shw_push w e 1 ) } {}
+                                                = i + i 2
+                                            } { = i + i 1 }
+                                        } {
+                                            // `$(` and backticks swallow a
+                                            // nested run whole; the expander
+                                            // parses it later.
+                                            ? & == ch 36 & < + i 1 n == 40 ( nurl_str_get src + i 1 ) {
+                                                : ~ i depth 0
+                                                : i start i
+                                                ~ & < i n | > depth 0 <= i + start 1 {
+                                                    : i q ( nurl_str_get src i )
+                                                    ? == q 40 { = depth + depth 1 } {}
+                                                    ? == q 41 { = depth - depth 1 } {}
+                                                    ( __shw_push w q 0 )
+                                                    = i + i 1
+                                                }
+                                            } {
+                                                ? == ch 96 {
+                                                    ( __shw_push w ch 0 )
+                                                    = i + i 1
+                                                    ~ & < i n != ( nurl_str_get src i ) 96 {
+                                                        ( __shw_push w ( nurl_str_get src i ) 0 )
+                                                        = i + i 1
+                                                    }
+                                                    ? < i n {
+                                                        ( __shw_push w 96 0 )
+                                                        = i + i 1
+                                                    } {}
+                                                } {
+                                                    ( __shw_push w ch 0 )
+                                                    = i + i 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ? want_delim {
+                            // The delimiter is taken literally, quotes and
+                            // all — `<<'EOF'` and `<<EOF` name the same one.
+                            ( vec_push [String] pending ( string_clone . w text ) )
+                            ( vec_push [i] pending_strip ? want_strip 1 0 )
+                            = want_delim F
+                            = want_strip F
+                        } {}
+                        ( vec_push [ShTok] out @ ShTok { SHT_WORD w ( string_new ) } )
+                    }
+                }
+            }
+        }
+    }
+    // A heredoc opened on the last line, with no newline after it.
+    : i np2 ( vec_len [String] pending )
+    : ~ i pj 0
+    ~ < pj np2 {
+        ( vec_push [String] bodies ( string_new ) )
+        = pj + pj 1
+    }
+    ( vec_free_with [String] pending \ String x → v { ( string_free x ) } )
+    ( vec_free [i] pending_strip )
+    ( vec_push [ShTok] out @ ShTok { SHT_EOF ( __shw_new ) ( string_new ) } )
+    ^ ok
+}
+
+// ── The syntax tree ───────────────────────────────────────────────
+//
+// A flat arena: every node is an index into one Vec, and a parent names
+// its children by index. NURL has no cyclic ownership, and an arena is
+// the shape that needs none — the whole tree is freed by walking the Vec
+// once, in any order.
+
+: i SH_SIMPLE 0
+: i SH_PIPE 1
+: i SH_AND 2
+: i SH_OR 3
+: i SH_SEQ 4
+: i SH_IF 5
+: i SH_WHILE 6
+: i SH_UNTIL 7
+: i SH_FOR 8
+: i SH_CASE 9
+: i SH_GROUP 10
+: i SH_SUBSHELL 11
+: i SH_FUNC 12
+: i SH_BACKGROUND 13
+: i SH_NOT 14
+
+: i SHR_IN 0  // <
+: i SHR_OUT 1  // >
+: i SHR_APPEND 2  // >>
+: i SHR_HEREDOC 3  // <<
+: i SHR_DUP 4  // >&N / <&N
+
+: ShRedir {
+    i kind
+    i fd  // the descriptor being redirected
+    ShWord word  // filename, heredoc body, or target descriptor
+}
+
+: ShNode {
+    i kind
+    i a
+    i b
+    i c
+    ( Vec i ) kids
+    ( Vec ShWord ) words
+    ( Vec ShRedir ) redirs
+    String text
+}
+
+@ __shn_blank i kind → ShNode {
+    ^ @ ShNode { kind -1 -1 -1 ( vec_new [i] ) ( vec_new [ShWord] ) ( vec_new [ShRedir] ) ( string_new ) }
+}
+
+@ __shn_free ShNode n → v {
+    ( vec_free [i] . n kids )
+    ( __shw_free_vec . n words )
+    ( vec_free_with [ShRedir] . n redirs \ ShRedir r → v { ( __shw_free . r word ) } )
+    ( string_free . n text )
+}
+
+@ __shn_free_arena ( Vec ShNode ) arena → v {
+    ( vec_free_with [ShNode] arena \ ShNode n → v { ( __shn_free n ) } )
+}
+
+@ __shn_push ( Vec ShNode ) arena ShNode n → i {
+    : i idx ( vec_len [ShNode] arena )
+    ( vec_push [ShNode] arena n )
+    ^ idx
+}
+
+// ── The parser ────────────────────────────────────────────────────
+
+: ~ i g_sh_pos 0
+: ~ i g_sh_here 0
+: ~ b g_sh_perr F
+
+@ __sh_kind ( Vec ShTok ) t i idx → i {
+    ?? ( vec_get [ShTok] t idx ) {
+        T x → { ^ . x kind }
+        F _ → { ^ SHT_EOF }
+    }
+}
+
+@ __sh_op ( Vec ShTok ) t i idx → s {
+    ?? ( vec_get [ShTok] t idx ) {
+        T x → { ^ ( string_data . x op ) }
+        F _ → { ^ `` }
+    }
+}
+
+@ __sh_word_at ( Vec ShTok ) t i idx → ShWord {
+    ?? ( vec_get [ShTok] t idx ) {
+        T x → { ^ . x word }
+        F _ → { ^ ( __shw_new ) }
+    }
+}
+
+// The literal text of a token, only meaningful for reserved-word tests.
+@ __sh_text ( Vec ShTok ) t i idx → s {
+    ?? ( vec_get [ShTok] t idx ) {
+        T x → { ^ ( string_data . . x word text ) }
+        F _ → { ^ `` }
+    }
+}
+
+// A word is a RESERVED word only when nothing about it was quoted:
+// `if` opens a conditional, `'if'` is the name of a command.
+@ __sh_bare ( Vec ShTok ) t i idx → b {
+    ?? ( vec_get [ShTok] t idx ) {
+        T x → {
+            : i n ( string_len . . x word mask )
+            : ~ i k 0
+            ~ < k n {
+                ? != 0 ( string_get . . x word mask k ) { ^ F } {}
+                = k + k 1
+            }
+            ^ T
+        }
+        F _ → { ^ F }
+    }
+}
+
+@ __sh_is_word ( Vec ShTok ) t i idx s want → b {
+    ? != ( __sh_kind t idx ) SHT_WORD { ^ F } {}
+    ? ! ( __sh_bare t idx ) { ^ F } {}
+    ^ ( bx_streq ( __sh_text t idx ) want )
+}
+
+@ __sh_is_op ( Vec ShTok ) t i idx s want → b {
+    ? != ( __sh_kind t idx ) SHT_OP { ^ F } {}
+    ^ ( bx_streq ( __sh_op t idx ) want )
+}
+
+@ __sh_reserved ( Vec ShTok ) t i idx → b {
+    ? != ( __sh_kind t idx ) SHT_WORD { ^ F } {}
+    ? ! ( __sh_bare t idx ) { ^ F } {}
+    : s w ( __sh_text t idx )
+    ^ | | | | | | | | | | | | | ( bx_streq w `if` ) ( bx_streq w `then` ) ( bx_streq w `elif` ) ( bx_streq w `else` ) ( bx_streq w `fi` ) ( bx_streq w `while` ) ( bx_streq w `until` ) ( bx_streq w `do` ) ( bx_streq w `done` ) ( bx_streq w `for` ) ( bx_streq w `in` ) ( bx_streq w `case` ) ( bx_streq w `esac` ) | ( bx_streq w `{` ) ( bx_streq w `}` )
+}
+
+@ __sh_skip_newlines ( Vec ShTok ) t → v {
+    ~ == ( __sh_kind t g_sh_pos ) SHT_NEWLINE { = g_sh_pos + g_sh_pos 1 }
+}
+
+@ __sh_perr s msg → v {
+    ? ! g_sh_perr {
+        ( bx_err_at `syntax error` msg )
+        = g_sh_perr T
+    } {}
+}
+
+// `2>file`, `>>file`, `<<EOF`, `2>&1` — the fd may be glued to the left
+// of the operator, which the lexer has already split off as its own
+// word, so the check is "did a bare number end right where the operator
+// begins".
+@ __sh_redir ( Vec ShTok ) t ( Vec String ) bodies ( Vec ShRedir ) out → b {
+    : i k ( __sh_kind t g_sh_pos )
+    ? != k SHT_OP { ^ F } {}
+    : s raw ( __sh_op t g_sh_pos )
+    : ~ i explicit -1
+    : ~ i skip 0
+    ~ & < skip ( nurl_str_len raw ) ( bx_is_digit ( nurl_str_get raw skip ) ) { = skip + skip 1 }
+    ? > skip 0 { = explicit ( nurl_str_to_int ( nurl_str_slice raw 0 skip ) ) } {}
+    : s op ? > skip 0 ( nurl_str_slice raw skip - ( nurl_str_len raw ) skip ) raw
+    : ~ i kind -1
+    : ~ i fd -1
+    ? ( bx_streq op `<` ) { = kind SHR_IN = fd 0 } {}
+    ? ( bx_streq op `>` ) { = kind SHR_OUT = fd 1 } {}
+    ? ( bx_streq op `>>` ) { = kind SHR_APPEND = fd 1 } {}
+    ? | ( bx_streq op `<<` ) ( bx_streq op `<<-` ) { = kind SHR_HEREDOC = fd 0 } {}
+    ? ( bx_streq op `>&` ) { = kind SHR_DUP = fd 1 } {}
+    ? ( bx_streq op `<&` ) { = kind SHR_DUP = fd 0 } {}
+    ? < kind 0 { ^ F } {}
+    ? >= explicit 0 { = fd explicit } {}
+    = g_sh_pos + g_sh_pos 1
+    ? == kind SHR_HEREDOC {
+        // The delimiter word was consumed by the lexer; the body is
+        // waiting in `bodies`, in the order the operators appeared.
+        ? == ( __sh_kind t g_sh_pos ) SHT_WORD { = g_sh_pos + g_sh_pos 1 } {}
+        : ShWord w ( __shw_new )
+        ? < g_sh_here ( vec_len [String] bodies ) {
+            ( __shw_push_str w ( bx_at bodies g_sh_here ) 2 )
+            = g_sh_here + g_sh_here 1
+        } {}
+        ( vec_push [ShRedir] out @ ShRedir { kind fd w } )
+        ^ T
+    } {}
+    ? != ( __sh_kind t g_sh_pos ) SHT_WORD {
+        ( __sh_perr `a redirection needs a target` )
+        ^ T
+    } {}
+    ( vec_push [ShRedir] out @ ShRedir { kind fd ( __shw_clone ( __sh_word_at t g_sh_pos ) ) } )
+    = g_sh_pos + g_sh_pos 1
+    ^ T
+}
+
+// `name=value` at the head of a simple command, unquoted `=`.
+@ __sh_is_assign ShWord w → b {
+    : i n ( __shw_len w )
+    ? == n 0 { ^ F } {}
+    : i c0 ( __shw_at w 0 )
+    ? ! | | & >= c0 65 <= c0 90 & >= c0 97 <= c0 122 == c0 95 { ^ F } {}
+    : ~ i i 1
+    ~ < i n {
+        : i c ( __shw_at w i )
+        ? & == c 61 == 0 ( __shw_q w i ) { ^ T } {}
+        ? ! | | | & >= c 65 <= c 90 & >= c 97 <= c 122 & >= c 48 <= c 57 == c 95 { ^ F } {}
+        = i + i 1
+    }
+    ^ F
+}
+
+@ __sh_parse_simple ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    : ShNode n ( __shn_blank SH_SIMPLE )
+    : ~ b done F
+    ~ ! done {
+        ? ( __sh_redir t bodies . n redirs ) {} {
+            ? == ( __sh_kind t g_sh_pos ) SHT_WORD {
+                ( vec_push [ShWord] . n words ( __shw_clone ( __sh_word_at t g_sh_pos ) ) )
+                = g_sh_pos + g_sh_pos 1
+            } { = done T }
+        }
+        ? g_sh_perr { = done T } {}
+    }
+    ^ ( __shn_push arena n )
+}
+
+// `pattern) list ;;` arms, flattened into the node's kid list as
+// alternating (pattern-word-index, body-node) — the words live in the
+// node's word vector and the bodies in its kid vector, index for index.
+@ __sh_parse_case ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    : ShNode n ( __shn_blank SH_CASE )
+    ? != ( __sh_kind t g_sh_pos ) SHT_WORD {
+        ( __sh_perr `case needs a word` )
+        ^ ( __shn_push arena n )
+    } {}
+    ( vec_push [ShWord] . n words ( __shw_clone ( __sh_word_at t g_sh_pos ) ) )
+    = g_sh_pos + g_sh_pos 1
+    ( __sh_skip_newlines t )
+    ? ! ( __sh_is_word t g_sh_pos `in` ) {
+        ( __sh_perr `case needs 'in'` )
+        ^ ( __shn_push arena n )
+    } {}
+    = g_sh_pos + g_sh_pos 1
+    ( __sh_skip_newlines t )
+    ~ & ! g_sh_perr ! ( __sh_is_word t g_sh_pos `esac` ) {
+        ? == ( __sh_kind t g_sh_pos ) SHT_EOF {
+            ( __sh_perr `case without esac` )
+        } {
+            // One arm: `(`? pat ( `|` pat )* `)` list `;;`
+            ? ( __sh_is_op t g_sh_pos `(` ) { = g_sh_pos + g_sh_pos 1 } {}
+            : ShWord pat ( __shw_new )
+            : ~ b first T
+            ~ & ! g_sh_perr == ( __sh_kind t g_sh_pos ) SHT_WORD {
+                ? first { = first F } { ( __shw_push pat 124 1 ) }
+                : ShWord w ( __sh_word_at t g_sh_pos )
+                : i wn ( __shw_len w )
+                : ~ i k 0
+                ~ < k wn {
+                    ( __shw_push pat ( __shw_at w k ) ( __shw_q w k ) )
+                    = k + k 1
+                }
+                = g_sh_pos + g_sh_pos 1
+                ? ( __sh_is_op t g_sh_pos `|` ) { = g_sh_pos + g_sh_pos 1 } { = k wn }
+            }
+            ? ! ( __sh_is_op t g_sh_pos `)` ) {
+                ( __sh_perr `case pattern needs ')'` )
+            } { = g_sh_pos + g_sh_pos 1 }
+            : i body ( __sh_parse_list arena t bodies )
+            ( vec_push [ShWord] . n words pat )
+            ( vec_push [i] . n kids body )
+            ( __sh_skip_newlines t )
+            ? ( __sh_is_op t g_sh_pos `;;` ) {
+                = g_sh_pos + g_sh_pos 1
+                ( __sh_skip_newlines t )
+            } {}
+        }
+    }
+    ? ( __sh_is_word t g_sh_pos `esac` ) { = g_sh_pos + g_sh_pos 1 } {}
+    ^ ( __shn_push arena n )
+}
+
+@ __sh_parse_command ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    ( __sh_skip_newlines t )
+    ? ( __sh_is_op t g_sh_pos `!` ) {
+        = g_sh_pos + g_sh_pos 1
+        : i child ( __sh_parse_command arena t bodies )
+        : ShNode n ( __shn_blank SH_NOT )
+        = . n a child
+        ^ ( __shn_push arena n )
+    } {}
+    ? ( __sh_is_word t g_sh_pos `if` ) {
+        = g_sh_pos + g_sh_pos 1
+        : i cond ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ! ( __sh_is_word t g_sh_pos `then` ) { ( __sh_perr `if without then` ) } { = g_sh_pos + g_sh_pos 1 }
+        : i thenb ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        : ~ i elseb -1
+        ? ( __sh_is_word t g_sh_pos `elif` ) {
+            // `elif` is `else if …fi`, and building it that way means
+            // one code path instead of two.
+            = g_sh_pos + g_sh_pos 1
+            : i inner_cond ( __sh_parse_list arena t bodies )
+            ( __sh_skip_newlines t )
+            ? ! ( __sh_is_word t g_sh_pos `then` ) { ( __sh_perr `elif without then` ) } { = g_sh_pos + g_sh_pos 1 }
+            : i inner_then ( __sh_parse_list arena t bodies )
+            ( __sh_skip_newlines t )
+            : ~ i inner_else -1
+            ? ( __sh_is_word t g_sh_pos `else` ) {
+                = g_sh_pos + g_sh_pos 1
+                = inner_else ( __sh_parse_list arena t bodies )
+                ( __sh_skip_newlines t )
+            } {}
+            : ShNode inner ( __shn_blank SH_IF )
+            = . inner a inner_cond
+            = . inner b inner_then
+            = . inner c inner_else
+            = elseb ( __shn_push arena inner )
+        } {
+            ? ( __sh_is_word t g_sh_pos `else` ) {
+                = g_sh_pos + g_sh_pos 1
+                = elseb ( __sh_parse_list arena t bodies )
+                ( __sh_skip_newlines t )
+            } {}
+        }
+        ? ( __sh_is_word t g_sh_pos `fi` ) { = g_sh_pos + g_sh_pos 1 } { ( __sh_perr `if without fi` ) }
+        : ShNode n ( __shn_blank SH_IF )
+        = . n a cond
+        = . n b thenb
+        = . n c elseb
+        ^ ( __shn_push arena n )
+    } {}
+    ? | ( __sh_is_word t g_sh_pos `while` ) ( __sh_is_word t g_sh_pos `until` ) {
+        : b until ( __sh_is_word t g_sh_pos `until` )
+        = g_sh_pos + g_sh_pos 1
+        : i cond ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ! ( __sh_is_word t g_sh_pos `do` ) { ( __sh_perr `loop without do` ) } { = g_sh_pos + g_sh_pos 1 }
+        : i body ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ( __sh_is_word t g_sh_pos `done` ) { = g_sh_pos + g_sh_pos 1 } { ( __sh_perr `loop without done` ) }
+        : ShNode n ( __shn_blank ? until SH_UNTIL SH_WHILE )
+        = . n a cond
+        = . n b body
+        ^ ( __shn_push arena n )
+    } {}
+    ? ( __sh_is_word t g_sh_pos `for` ) {
+        = g_sh_pos + g_sh_pos 1
+        : ShNode n ( __shn_blank SH_FOR )
+        ? != ( __sh_kind t g_sh_pos ) SHT_WORD {
+            ( __sh_perr `for needs a variable name` )
+            ^ ( __shn_push arena n )
+        } {}
+        ( string_push_str . n text ( __sh_text t g_sh_pos ) )
+        = g_sh_pos + g_sh_pos 1
+        : ~ b had_in F
+        ? ( __sh_is_word t g_sh_pos `in` ) {
+            = had_in T
+            = g_sh_pos + g_sh_pos 1
+            ~ == ( __sh_kind t g_sh_pos ) SHT_WORD {
+                ? ( __sh_reserved t g_sh_pos ) { = g_sh_pos g_sh_pos } {}
+                ( vec_push [ShWord] . n words ( __shw_clone ( __sh_word_at t g_sh_pos ) ) )
+                = g_sh_pos + g_sh_pos 1
+            }
+        } {}
+        // `for x; do` with no `in` iterates the positional parameters,
+        // which is spelled by leaving the word list empty and saying so.
+        = . n c ? had_in 1 0
+        ? ( __sh_is_op t g_sh_pos `;` ) { = g_sh_pos + g_sh_pos 1 } {}
+        ( __sh_skip_newlines t )
+        ? ! ( __sh_is_word t g_sh_pos `do` ) { ( __sh_perr `for without do` ) } { = g_sh_pos + g_sh_pos 1 }
+        = . n a ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ( __sh_is_word t g_sh_pos `done` ) { = g_sh_pos + g_sh_pos 1 } { ( __sh_perr `for without done` ) }
+        ^ ( __shn_push arena n )
+    } {}
+    ? ( __sh_is_word t g_sh_pos `case` ) {
+        = g_sh_pos + g_sh_pos 1
+        ^ ( __sh_parse_case arena t bodies )
+    } {}
+    ? ( __sh_is_word t g_sh_pos `{` ) {
+        = g_sh_pos + g_sh_pos 1
+        : i body ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ( __sh_is_word t g_sh_pos `}` ) { = g_sh_pos + g_sh_pos 1 } { ( __sh_perr `{ without }` ) }
+        : ShNode n ( __shn_blank SH_GROUP )
+        = . n a body
+        ^ ( __shn_push arena n )
+    } {}
+    ? ( __sh_is_op t g_sh_pos `(` ) {
+        = g_sh_pos + g_sh_pos 1
+        : i body ( __sh_parse_list arena t bodies )
+        ( __sh_skip_newlines t )
+        ? ( __sh_is_op t g_sh_pos `)` ) { = g_sh_pos + g_sh_pos 1 } { ( __sh_perr `( without )` ) }
+        : ShNode n ( __shn_blank SH_SUBSHELL )
+        = . n a body
+        ^ ( __shn_push arena n )
+    } {}
+    // `name() { … }` — a function definition, recognised by the two
+    // tokens after the name.
+    ? & & == ( __sh_kind t g_sh_pos ) SHT_WORD ( __sh_is_op t + g_sh_pos 1 `(` ) ( __sh_is_op t + g_sh_pos 2 `)` ) {
+        : ShNode n ( __shn_blank SH_FUNC )
+        ( string_push_str . n text ( __sh_text t g_sh_pos ) )
+        = g_sh_pos + g_sh_pos 3
+        ( __sh_skip_newlines t )
+        = . n a ( __sh_parse_command arena t bodies )
+        ^ ( __shn_push arena n )
+    } {}
+    ^ ( __sh_parse_simple arena t bodies )
+}
+
+@ __sh_parse_pipeline ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    : i first ( __sh_parse_command arena t bodies )
+    ? ! ( __sh_is_op t g_sh_pos `|` ) { ^ first } {}
+    : ShNode n ( __shn_blank SH_PIPE )
+    ( vec_push [i] . n kids first )
+    ~ ( __sh_is_op t g_sh_pos `|` ) {
+        = g_sh_pos + g_sh_pos 1
+        ( __sh_skip_newlines t )
+        ( vec_push [i] . n kids ( __sh_parse_command arena t bodies ) )
+        ? g_sh_perr { = g_sh_pos g_sh_pos } {}
+    }
+    ^ ( __shn_push arena n )
+}
+
+@ __sh_parse_and_or ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    : ~ i left ( __sh_parse_pipeline arena t bodies )
+    ~ & ! g_sh_perr | ( __sh_is_op t g_sh_pos `&&` ) ( __sh_is_op t g_sh_pos `||` ) {
+        : b is_and ( __sh_is_op t g_sh_pos `&&` )
+        = g_sh_pos + g_sh_pos 1
+        ( __sh_skip_newlines t )
+        : i right ( __sh_parse_pipeline arena t bodies )
+        : ShNode n ( __shn_blank ? is_and SH_AND SH_OR )
+        = . n a left
+        = . n b right
+        = left ( __shn_push arena n )
+    }
+    ^ left
+}
+
+// A list ends where its enclosing construct's keyword begins — `done`,
+// `fi`, `esac`, `}`, `)`, or end of input.
+@ __sh_list_ends ( Vec ShTok ) t → b {
+    ? == ( __sh_kind t g_sh_pos ) SHT_EOF { ^ T } {}
+    ? ( __sh_is_op t g_sh_pos `)` ) { ^ T } {}
+    ? ( __sh_is_op t g_sh_pos `;;` ) { ^ T } {}
+    ? != ( __sh_kind t g_sh_pos ) SHT_WORD { ^ F } {}
+    ? ! ( __sh_bare t g_sh_pos ) { ^ F } {}
+    : s w ( __sh_text t g_sh_pos )
+    ^ | | | | | | | ( bx_streq w `then` ) ( bx_streq w `elif` ) ( bx_streq w `else` ) ( bx_streq w `fi` ) ( bx_streq w `do` ) ( bx_streq w `done` ) ( bx_streq w `esac` ) ( bx_streq w `}` )
+}
+
+@ __sh_parse_list ( Vec ShNode ) arena ( Vec ShTok ) t ( Vec String ) bodies → i {
+    : ShNode n ( __shn_blank SH_SEQ )
+    ( __sh_skip_newlines t )
+    ~ & ! g_sh_perr ! ( __sh_list_ends t ) {
+        : ~ i item ( __sh_parse_and_or arena t bodies )
+        ? ( __sh_is_op t g_sh_pos `&` ) {
+            = g_sh_pos + g_sh_pos 1
+            : ShNode bg ( __shn_blank SH_BACKGROUND )
+            = . bg a item
+            = item ( __shn_push arena bg )
+        } {
+            ? ( __sh_is_op t g_sh_pos `;` ) { = g_sh_pos + g_sh_pos 1 } {}
+        }
+        ( vec_push [i] . n kids item )
+        ( __sh_skip_newlines t )
+    }
+    ^ ( __shn_push arena n )
+}
+
+// ── Shell state ───────────────────────────────────────────────────
+//
+// One heap block reached through a global. The alternative — threading
+// an `inout` parameter through every function — cannot work here: the
+// evaluator is mutually recursive (a command substitution runs the
+// evaluator again), and an `inout` callee must be defined before its
+// caller, which no cycle can satisfy.
+
+: ShState {
+    ( Vec String ) names
+    ( Vec String ) values
+    ( Vec String ) fnames
+    ( Vec i ) fnodes
+    ( Vec String ) params
+    String argv0
+    i status
+    i exiting  // 1 once `exit` has been run
+    i exit_code
+    i brk  // pending `break` levels
+    i cont  // pending `continue` levels
+    i returning
+    i depth  // command-substitution nesting, for a sanity bound
+}
+
+: ~ i g_sh_state 0
+
+@ __st → *ShState { ^ # *ShState g_sh_state }
+
+@ __sh_state_new → v {
+    : *ShState st # *ShState ( nurl_alloc Z ShState )
+    = . st names ( vec_new [String] )
+    = . st values ( vec_new [String] )
+    = . st fnames ( vec_new [String] )
+    = . st fnodes ( vec_new [i] )
+    = . st params ( vec_new [String] )
+    = . st argv0 ( string_from `sh` )
+    = . st status 0
+    = . st exiting 0
+    = . st exit_code 0
+    = . st brk 0
+    = . st cont 0
+    = . st returning 0
+    = . st depth 0
+    = g_sh_state # i st
+}
+
+@ __sh_state_free → v {
+    : *ShState st ( __st )
+    ( vec_free_with [String] . st names \ String x → v { ( string_free x ) } )
+    ( vec_free_with [String] . st values \ String x → v { ( string_free x ) } )
+    ( vec_free_with [String] . st fnames \ String x → v { ( string_free x ) } )
+    ( vec_free [i] . st fnodes )
+    ( vec_free_with [String] . st params \ String x → v { ( string_free x ) } )
+    ( string_free . st argv0 )
+    ( nurl_free # s st )
+    = g_sh_state 0
+}
+
+@ __sh_var_index s name → i {
+    : *ShState st ( __st )
+    : i n ( vec_len [String] . st names )
+    : ~ i i 0
+    ~ < i n {
+        ? ( bx_streq ( bx_at . st names i ) name ) { ^ i } {}
+        = i + i 1
+    }
+    ^ -1
+}
+
+@ __sh_set s name s value → v {
+    : *ShState st ( __st )
+    : i idx ( __sh_var_index name )
+    ? >= idx 0 {
+        ?? ( vec_get [String] . st values idx ) {
+            T slot → {
+                ( string_clear slot )
+                ( string_push_str slot value )
+            }
+            F _ → {}
+        }
+    } {
+        ( vec_push [String] . st names ( string_from name ) )
+        ( vec_push [String] . st values ( string_from value ) )
+    }
+}
+
+// A shell variable, then the environment, then the empty string — the
+// order every shell resolves in.
+@ __sh_get s name → String {
+    : *ShState st ( __st )
+    : i idx ( __sh_var_index name )
+    ? >= idx 0 { ^ ( string_from ( bx_at . st values idx ) ) } {}
+    ?? ( env_get name ) {
+        T v → { ^ v }
+        F _ → { ^ ( string_new ) }
+    }
+}
+
+@ __sh_unset s name → v {
+    : *ShState st ( __st )
+    : i idx ( __sh_var_index name )
+    ? >= idx 0 {
+        ?? ( vec_remove [String] . st names idx ) {
+            T x → { ( string_free x ) }
+            F _ → {}
+        }
+        ?? ( vec_remove [String] . st values idx ) {
+            T x → { ( string_free x ) }
+            F _ → {}
+        }
+    } {}
+    ?? ( env_unset name ) { T _ → {} F _ → {} }
+}
+
+@ __sh_func_index s name → i {
+    : *ShState st ( __st )
+    : i n ( vec_len [String] . st fnames )
+    : ~ i i 0
+    ~ < i n {
+        ? ( bx_streq ( bx_at . st fnames i ) name ) { ^ i } {}
+        = i + i 1
+    }
+    ^ -1
+}
+
+// ── Expansion ─────────────────────────────────────────────────────
+
+@ __sh_is_name_char i c b first → b {
+    ? | | & >= c 65 <= c 90 & >= c 97 <= c 122 == c 95 { ^ T } {}
+    ? first { ^ F } {}
+    ^ & >= c 48 <= c 57
+}
+
+// `${VAR#pat}` and friends: strip a prefix or suffix matching `pat`.
+// `greedy` picks the longest match, which is the difference between
+// `#` and `##`.
+@ __sh_strip s value s pat b suffix b greedy → String {
+    : i n ( nurl_str_len value )
+    : ~ i best -1
+    : ~ i k 0
+    ~ <= k n {
+        : ~ b hit F
+        ? suffix {
+            : s tail ( nurl_str_slice value - n k k )
+            = hit ( fs_match pat tail )
+        } {
+            : s head ( nurl_str_slice value 0 k )
+            = hit ( fs_match pat head )
+        }
+        ? hit {
+            ? | greedy < best 0 { = best k } {}
+        } {}
+        = k + k 1
+    }
+    ? < best 0 { ^ ( string_from value ) } {}
+    ? suffix { ^ ( string_from ( nurl_str_slice value 0 - n best ) ) } {}
+    ^ ( string_from ( nurl_str_slice value best - n best ) )
+}
+
+// Positional parameters joined with a space — `$*`, and `$@` outside
+// quotes where the split puts them back apart anyway.
+@ __sh_params_joined → String {
+    : *ShState st ( __st )
+    : String out ( string_new )
+    : i n ( vec_len [String] . st params )
+    : ~ i i 0
+    ~ < i n {
+        ? > i 0 { ( string_push_char out 32 ) } {}
+        ( string_push_str out ( bx_at . st params i ) )
+        = i + i 1
+    }
+    ^ out
+}
+
+// ── Arithmetic, for `$(( … ))` ────────────────────────────────────
+
+: ~ i g_ari_pos 0
+
+@ __ari_skip s src → v {
+    : i n ( nurl_str_len src )
+    ~ & < g_ari_pos n ( bx_is_blank ( nurl_str_get src g_ari_pos ) ) { = g_ari_pos + g_ari_pos 1 }
+}
+
+@ __ari_primary s src → i {
+    : i n ( nurl_str_len src )
+    ( __ari_skip src )
+    ? >= g_ari_pos n { ^ 0 } {}
+    : i c ( nurl_str_get src g_ari_pos )
+    ? == c 40 {
+        = g_ari_pos + g_ari_pos 1
+        : i v ( __ari_or src )
+        ( __ari_skip src )
+        ? & < g_ari_pos n == ( nurl_str_get src g_ari_pos ) 41 { = g_ari_pos + g_ari_pos 1 } {}
+        ^ v
+    } {}
+    ? == c 33 {
+        = g_ari_pos + g_ari_pos 1
+        ^ ? == ( __ari_primary src ) 0 1 0
+    } {}
+    ? == c 45 {
+        = g_ari_pos + g_ari_pos 1
+        ^ - 0 ( __ari_primary src )
+    } {}
+    ? == c 43 {
+        = g_ari_pos + g_ari_pos 1
+        ^ ( __ari_primary src )
+    } {}
+    ? ( bx_is_digit c ) {
+        : ~ i v 0
+        ~ & < g_ari_pos n ( bx_is_digit ( nurl_str_get src g_ari_pos ) ) {
+            = v + * v 10 - ( nurl_str_get src g_ari_pos ) 48
+            = g_ari_pos + g_ari_pos 1
+        }
+        ^ v
+    } {}
+    // A bare name is a variable, and an unset one is zero — the rule
+    // that makes `i=$((i+1))` work without initialising `i`.
+    ? ( __sh_is_name_char c T ) {
+        : i start g_ari_pos
+        ~ & < g_ari_pos n ( __sh_is_name_char ( nurl_str_get src g_ari_pos ) F ) { = g_ari_pos + g_ari_pos 1 }
+        : String v ( __sh_get ( nurl_str_slice src start - g_ari_pos start ) )
+        : i r ( nurl_str_to_int ( string_data v ) )
+        ( string_free v )
+        ^ r
+    } {}
+    = g_ari_pos + g_ari_pos 1
+    ^ 0
+}
+
+@ __ari_mul s src → i {
+    : i n ( nurl_str_len src )
+    : ~ i acc ( __ari_primary src )
+    ( __ari_skip src )
+    ~ & < g_ari_pos n | | == ( nurl_str_get src g_ari_pos ) 42 == ( nurl_str_get src g_ari_pos ) 47 == ( nurl_str_get src g_ari_pos ) 37 {
+        : i op ( nurl_str_get src g_ari_pos )
+        = g_ari_pos + g_ari_pos 1
+        : i rhs ( __ari_primary src )
+        ? == op 42 { = acc * acc rhs } {
+            ? == rhs 0 { = acc 0 } {
+                ? == op 47 { = acc / acc rhs } { = acc - acc * rhs / acc rhs }
+            }
+        }
+        ( __ari_skip src )
+    }
+    ^ acc
+}
+
+@ __ari_add s src → i {
+    : i n ( nurl_str_len src )
+    : ~ i acc ( __ari_mul src )
+    ( __ari_skip src )
+    ~ & < g_ari_pos n | == ( nurl_str_get src g_ari_pos ) 43 == ( nurl_str_get src g_ari_pos ) 45 {
+        : i op ( nurl_str_get src g_ari_pos )
+        = g_ari_pos + g_ari_pos 1
+        : i rhs ( __ari_mul src )
+        = acc ? == op 43 + acc rhs - acc rhs
+        ( __ari_skip src )
+    }
+    ^ acc
+}
+
+@ __ari_cmp s src → i {
+    : i n ( nurl_str_len src )
+    : ~ i acc ( __ari_add src )
+    ( __ari_skip src )
+    ~ & < g_ari_pos n | | | == ( nurl_str_get src g_ari_pos ) 60 == ( nurl_str_get src g_ari_pos ) 62 & == ( nurl_str_get src g_ari_pos ) 61 == ( nurl_str_get src + g_ari_pos 1 ) 61 & == ( nurl_str_get src g_ari_pos ) 33 == ( nurl_str_get src + g_ari_pos 1 ) 61 {
+        : i c1 ( nurl_str_get src g_ari_pos )
+        : i c2 ? < + g_ari_pos 1 n ( nurl_str_get src + g_ari_pos 1 ) 0
+        : ~ i op 0  // 0 <, 1 <=, 2 >, 3 >=, 4 ==, 5 !=
+        ? == c1 60 { = op ? == c2 61 1 0 = g_ari_pos + g_ari_pos ? == c2 61 2 1 } {}
+        ? == c1 62 { = op ? == c2 61 3 2 = g_ari_pos + g_ari_pos ? == c2 61 2 1 } {}
+        ? == c1 61 { = op 4 = g_ari_pos + g_ari_pos 2 } {}
+        ? == c1 33 { = op 5 = g_ari_pos + g_ari_pos 2 } {}
+        : i rhs ( __ari_add src )
+        : ~ b r F
+        ? == op 0 { = r < acc rhs } {}
+        ? == op 1 { = r <= acc rhs } {}
+        ? == op 2 { = r > acc rhs } {}
+        ? == op 3 { = r >= acc rhs } {}
+        ? == op 4 { = r == acc rhs } {}
+        ? == op 5 { = r != acc rhs } {}
+        = acc ? r 1 0
+        ( __ari_skip src )
+    }
+    ^ acc
+}
+
+@ __ari_and s src → i {
+    : i n ( nurl_str_len src )
+    : ~ i acc ( __ari_cmp src )
+    ( __ari_skip src )
+    ~ & < + g_ari_pos 1 n & == ( nurl_str_get src g_ari_pos ) 38 == ( nurl_str_get src + g_ari_pos 1 ) 38 {
+        = g_ari_pos + g_ari_pos 2
+        : i rhs ( __ari_cmp src )
+        = acc ? & != acc 0 != rhs 0 1 0
+        ( __ari_skip src )
+    }
+    ^ acc
+}
+
+@ __ari_or s src → i {
+    : i n ( nurl_str_len src )
+    : ~ i acc ( __ari_and src )
+    ( __ari_skip src )
+    ~ & < + g_ari_pos 1 n & == ( nurl_str_get src g_ari_pos ) 124 == ( nurl_str_get src + g_ari_pos 1 ) 124 {
+        = g_ari_pos + g_ari_pos 2
+        : i rhs ( __ari_and src )
+        = acc ? | != acc 0 != rhs 0 1 0
+        ( __ari_skip src )
+    }
+    ^ acc
+}
+
+@ __sh_arith s src → i {
+    = g_ari_pos 0
+    ^ ( __ari_or src )
+}
+
+// ── Expansion ─────────────────────────────────────────────────────
+
+// Forward-declared shapes the expander calls back into; the evaluator
+// is mutually recursive with it because `$(…)` runs a whole script.
+
+@ __sh_default_ifs → s { ^ ` \t\n` }
+
+@ __sh_ifs → String {
+    : i idx ( __sh_var_index `IFS` )
+    ? >= idx 0 {
+        : *ShState st ( __st )
+        ^ ( string_from ( bx_at . st values idx ) )
+    } {}
+    ^ ( string_from ( __sh_default_ifs ) )
+}
+
+@ __sh_in_ifs String ifs i c → b {
+    : i n ( string_len ifs )
+    : ~ i i 0
+    ~ < i n {
+        ? == ( string_get ifs i ) c { ^ T } {}
+        = i + i 1
+    }
+    ^ F
+}
+
+@ __sh_has_glob ShWord w → b {
+    : i n ( __shw_len w )
+    : ~ i i 0
+    ~ < i n {
+        ? == 0 ( __shw_q w i ) {
+            : i c ( __shw_at w i )
+            ? | | == c 42 == c 63 == c 91 { ^ T } {}
+        } {}
+        = i + i 1
+    }
+    ^ F
+}
+
+// `${NAME<op>word}` — the braced form, cursor just past the `{`.
+@ __sh_brace ShWord src i from i to ShWord acc i q → v {
+    : ~ i i from
+    // `${#NAME}` is the length of NAME.
+    ? & < i to == ( __shw_at src i ) 35 {
+        : String nm ( string_new )
+        = i + i 1
+        ~ < i to {
+            ( string_push_char nm ( __shw_at src i ) )
+            = i + i 1
+        }
+        : String v ? ( bx_streq ( string_data nm ) `@` ) ( __sh_params_joined ) ( __sh_get ( string_data nm ) )
+        ( __shw_push_str acc ( nurl_str_int ( string_len v ) ) q )
+        ( string_free v )
+        ( string_free nm )
+        ^
+    } {}
+    : String nm ( string_new )
+    ~ & < i to ( __sh_is_name_char ( __shw_at src i ) == ( string_len nm ) 0 ) {
+        ( string_push_char nm ( __shw_at src i ) )
+        = i + i 1
+    }
+    // `$1` … `$9` and `$@` inside braces.
+    ? == ( string_len nm ) 0 {
+        ~ & < i to ! | | | | == ( __shw_at src i ) 58 == ( __shw_at src i ) 45 == ( __shw_at src i ) 61 == ( __shw_at src i ) 43 | == ( __shw_at src i ) 35 == ( __shw_at src i ) 37 {
+            ( string_push_char nm ( __shw_at src i ) )
+            = i + i 1
+        }
+    } {}
+    : String value ( __sh_special ( string_data nm ) )
+    : ~ b unset == ( string_len value ) 0
+    ? >= i to {
+        ( __shw_push_str acc ( string_data value ) q )
+        ( string_free value )
+        ( string_free nm )
+        ^
+    } {}
+    // The operator, and the word it applies to.
+    : ~ i op ( __shw_at src i )
+    : ~ b colon F
+    ? == op 58 {
+        = colon T
+        = i + i 1
+        = op ? < i to ( __shw_at src i ) 0
+    } {}
+    : ~ b greedy F
+    ? & | == op 35 == op 37 & < + i 1 to == ( __shw_at src + i 1 ) op {
+        = greedy T
+    } {}
+    = i + i ? greedy 2 1
+    : ShWord rest ( __shw_new )
+    ~ < i to {
+        ( __shw_push rest ( __shw_at src i ) ( __shw_q src i ) )
+        = i + i 1
+    }
+    : String repl ( __sh_expand_to_string rest )
+    ( __shw_free rest )
+    ? | == op 45 == op 61 {
+        ? unset {
+            ( __shw_push_str acc ( string_data repl ) q )
+            ? == op 61 { ( __sh_set ( string_data nm ) ( string_data repl ) ) } {}
+        } { ( __shw_push_str acc ( string_data value ) q ) }
+    } {
+        ? == op 43 {
+            ? unset {} { ( __shw_push_str acc ( string_data repl ) q ) }
+        } {
+            ? == op 63 {
+                ? unset {
+                    ( bx_err ? > ( string_len repl ) 0 ( string_data repl ) `parameter not set` )
+                    : *ShState st ( __st )
+                    = . st exiting 1
+                    = . st exit_code 1
+                } { ( __shw_push_str acc ( string_data value ) q ) }
+            } {
+                ? | == op 35 == op 37 {
+                    : String cut ( __sh_strip ( string_data value ) ( string_data repl ) == op 37 greedy )
+                    ( __shw_push_str acc ( string_data cut ) q )
+                    ( string_free cut )
+                } { ( __shw_push_str acc ( string_data value ) q ) }
+            }
+        }
+    }
+    ( string_free repl )
+    ( string_free value )
+    ( string_free nm )
+}
+
+// `$?`, `$#`, `$$`, `$0`…`$9`, `$*`, and ordinary names.
+@ __sh_special s name → String {
+    : *ShState st ( __st )
+    ? ( bx_streq name `?` ) { ^ ( string_from ( nurl_str_int . st status ) ) } {}
+    ? ( bx_streq name `#` ) { ^ ( string_from ( nurl_str_int ( vec_len [String] . st params ) ) ) } {}
+    ? ( bx_streq name `$` ) { ^ ( string_from ( nurl_str_int # i ( getpid ) ) ) } {}
+    ? | ( bx_streq name `*` ) ( bx_streq name `@` ) { ^ ( __sh_params_joined ) } {}
+    ? ( bx_streq name `0` ) { ^ ( string_clone . st argv0 ) } {}
+    : i n ( nurl_str_len name )
+    ? > n 0 {
+        : ~ b digits T
+        : ~ i k 0
+        ~ < k n {
+            ? ! ( bx_is_digit ( nurl_str_get name k ) ) { = digits F } {}
+            = k + k 1
+        }
+        ? digits {
+            : i idx ( nurl_str_to_int name )
+            ? & >= idx 1 <= idx ( vec_len [String] . st params ) {
+                ^ ( string_from ( bx_at . st params - idx 1 ) )
+            } {}
+            ^ ( string_new )
+        } {}
+    } {}
+    ^ ( __sh_get name )
+}
+
+// One word, expanded into `acc`; `$@` splits, so completed fields go to
+// `fields` and `acc` restarts.
+@ __sh_expand_into ShWord w ShWord acc ( Vec ShWord ) fields → v {
+    : *ShState st ( __st )
+    : i n ( __shw_len w )
+    : ~ i i 0
+    // A leading unquoted `~` is $HOME.
+    ? & & > n 0 == ( __shw_at w 0 ) 126 == 0 ( __shw_q w 0 ) {
+        ? | == n 1 == ( __shw_at w 1 ) 47 {
+            : String home ( __sh_get `HOME` )
+            ( __shw_push_str acc ( string_data home ) 2 )
+            ( string_free home )
+            = i 1
+        } {}
+    } {}
+    ~ < i n {
+        : i c ( __shw_at w i )
+        : i q ( __shw_q w i )
+        ? & == c 36 != q 1 {
+            ? >= + i 1 n {
+                ( __shw_push acc c q )
+                = i + i 1
+            } {
+                : i c2 ( __shw_at w + i 1 )
+                ? == c2 40 {
+                    ? & < + i 2 n == ( __shw_at w + i 2 ) 40 {
+                        // `$(( … ))` — arithmetic.
+                        : ~ i depth 0
+                        : ~ i k + i 1
+                        : String expr ( string_new )
+                        ~ < k n {
+                            : i ch ( __shw_at w k )
+                            ? == ch 40 { = depth + depth 1 } {}
+                            ? == ch 41 { = depth - depth 1 } {}
+                            ? == depth 0 { = k n } {
+                                ? > k + i 2 { ( string_push_char expr ch ) } {}
+                                = k + k 1
+                            }
+                        }
+                        // Drop the inner `))`.
+                        : i el ( string_len expr )
+                        : String body ( string_substr expr 0 ? > el 1 - el 1 0 )
+                        ( __shw_push_str acc ( nurl_str_int ( __sh_arith ( string_data body ) ) ) q )
+                        ( string_free body )
+                        ( string_free expr )
+                        : ~ i skip + i 2
+                        : ~ i d2 0
+                        ~ < skip n {
+                            : i ch ( __shw_at w skip )
+                            ? == ch 40 { = d2 + d2 1 } {}
+                            ? == ch 41 { = d2 - d2 1 } {}
+                            = skip + skip 1
+                            ? == d2 0 { = i skip = skip n } {}
+                        }
+                        ? >= skip n { = i n } {}
+                    } {
+                        // `$( … )` — command substitution.
+                        : ~ i depth 0
+                        : ~ i k + i 1
+                        : String script ( string_new )
+                        ~ < k n {
+                            : i ch ( __shw_at w k )
+                            ? == ch 40 { = depth + depth 1 } {}
+                            ? == ch 41 { = depth - depth 1 } {}
+                            ? == depth 0 {
+                                = i + k 1
+                                = k n
+                            } {
+                                ? > k + i 1 { ( string_push_char script ch ) } {}
+                                = k + k 1
+                            }
+                        }
+                        : String captured ( __sh_capture ( string_data script ) )
+                        ( __shw_push_str acc ( string_data captured ) q )
+                        ( string_free captured )
+                        ( string_free script )
+                    }
+                } {
+                    ? == c2 96 {
+                        ( __shw_push acc c q )
+                        = i + i 1
+                    } {
+                        ? == c2 123 {
+                            : ~ i k + i 2
+                            : ~ i close -1
+                            ~ & < k n < close 0 {
+                                ? == ( __shw_at w k ) 125 { = close k } { = k + k 1 }
+                            }
+                            ? < close 0 {
+                                ( __shw_push acc c q )
+                                = i + i 1
+                            } {
+                                ( __sh_brace w + i 2 close acc q )
+                                = i + close 1
+                            }
+                        } {
+                            // `$@` unquoted or quoted: each parameter is
+                            // its own field either way when quoted.
+                            ? & == c2 64 == q 2 {
+                                : i np ( vec_len [String] . st params )
+                                : ~ i pi 0
+                                ~ < pi np {
+                                    ? > pi 0 {
+                                        ( vec_push [ShWord] fields ( __shw_clone acc ) )
+                                        ( string_clear . acc text )
+                                        ( string_clear . acc mask )
+                                    } {}
+                                    ( __shw_push_str acc ( bx_at . st params pi ) 2 )
+                                    = pi + pi 1
+                                }
+                                = i + i 2
+                            } {
+                                ? ( __sh_is_name_char c2 T ) {
+                                    : ~ i k + i 1
+                                    : String nm ( string_new )
+                                    ~ & < k n ( __sh_is_name_char ( __shw_at w k ) == ( string_len nm ) 0 ) {
+                                        ( string_push_char nm ( __shw_at w k ) )
+                                        = k + k 1
+                                    }
+                                    : String v ( __sh_special ( string_data nm ) )
+                                    ( __shw_push_str acc ( string_data v ) q )
+                                    ( string_free v )
+                                    ( string_free nm )
+                                    = i k
+                                } {
+                                    ? | | | ( bx_is_digit c2 ) == c2 63 == c2 35 | == c2 36 | == c2 42 == c2 64 {
+                                        : String nm ( string_new )
+                                        ( string_push_char nm c2 )
+                                        : String v ( __sh_special ( string_data nm ) )
+                                        ( __shw_push_str acc ( string_data v ) q )
+                                        ( string_free v )
+                                        ( string_free nm )
+                                        = i + i 2
+                                    } {
+                                        ( __shw_push acc c q )
+                                        = i + i 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } {
+            ? & == c 96 != q 1 {
+                : ~ i k + i 1
+                : String script ( string_new )
+                ~ & < k n != ( __shw_at w k ) 96 {
+                    ( string_push_char script ( __shw_at w k ) )
+                    = k + k 1
+                }
+                : String captured ( __sh_capture ( string_data script ) )
+                ( __shw_push_str acc ( string_data captured ) q )
+                ( string_free captured )
+                ( string_free script )
+                = i ? < k n + k 1 n
+            } {
+                ( __shw_push acc c q )
+                = i + i 1
+            }
+        }
+    }
+}
+
+// The whole word as one string, no splitting and no globbing — what a
+// redirection target, a `${VAR:-word}` replacement and a case pattern
+// all need.
+@ __sh_expand_to_string ShWord w → String {
+    : ShWord acc ( __shw_new )
+    : ( Vec ShWord ) extra ( vec_new [ShWord] )
+    ( __sh_expand_into w acc extra )
+    : String out ( string_clone . acc text )
+    ( __shw_free acc )
+    ( __shw_free_vec extra )
+    ^ out
+}
+
+// Full expansion: substitution, then field splitting on unquoted IFS
+// bytes, then globbing. The mask is what keeps the three honest.
+@ __sh_expand_word ShWord w ( Vec String ) out → v {
+    : ShWord acc ( __shw_new )
+    : ( Vec ShWord ) pre ( vec_new [ShWord] )
+    ( __sh_expand_into w acc pre )
+    ( vec_push [ShWord] pre ( __shw_clone acc ) )
+    ( __shw_free acc )
+    : String ifs ( __sh_ifs )
+    : i np ( vec_len [ShWord] pre )
+    : ~ i p 0
+    ~ < p np {
+        ?? ( vec_get [ShWord] pre p ) {
+            T field → {
+                : i n ( __shw_len field )
+                : ShWord cur ( __shw_new )
+                : ~ b started > np 1
+                : ~ i i 0
+                ~ < i n {
+                    : i c ( __shw_at field i )
+                    : i q ( __shw_q field i )
+                    ? & == q 0 ( __sh_in_ifs ifs c ) {
+                        ? > ( __shw_len cur ) 0 {
+                            ( __sh_emit_field cur out )
+                            ( string_clear . cur text )
+                            ( string_clear . cur mask )
+                        } {}
+                        = started T
+                    } {
+                        ( __shw_push cur c q )
+                        = started T
+                    }
+                    = i + i 1
+                }
+                ? | > ( __shw_len cur ) 0 & == n 0 == np 1 {
+                    ( __sh_emit_field cur out )
+                } {}
+                ( __shw_free cur )
+            }
+            F _ → {}
+        }
+        = p + p 1
+    }
+    ( string_free ifs )
+    ( __shw_free_vec pre )
+}
+
+// One field: globbed if it has unquoted metacharacters and matches
+// something, literal otherwise — the shell's "no match, no change" rule.
+@ __sh_emit_field ShWord w ( Vec String ) out → v {
+    ? ( __sh_has_glob w ) {
+        ?? ( fs_glob ( string_data . w text ) ) {
+            T matches → {
+                : i n ( vec_len [String] matches )
+                ? > n 0 {
+                    ( sort_by [String] matches \ String a String b → i { ^ ( cmp_string a b ) } )
+                    : ~ i k 0
+                    ~ < k n {
+                        ( vec_push [String] out ( string_from ( bx_at matches k ) ) )
+                        = k + k 1
+                    }
+                    ( vec_free_with [String] matches \ String x → v { ( string_free x ) } )
+                    ^
+                } {}
+                ( vec_free_with [String] matches \ String x → v { ( string_free x ) } )
+            }
+            F _ → {}
+        }
+    } {}
+    ( vec_push [String] out ( string_clone . w text ) )
+}
+
+// ── Execution ─────────────────────────────────────────────────────
+
+& `c` @ dup i32 fd → i32
+
+: i SH_O_RDONLY 0
+: i SH_O_WRONLY 1
+: i SH_O_CREAT 64
+: i SH_O_TRUNC 512
+: i SH_O_APPEND 1024
+
+// Does this machine have processes at all? Asked once, because the
+// answer changes what a pipeline and a `$(…)` can mean, and a unikernel
+// says no.
+: ~ i g_sh_have_fork -1
+
+@ __sh_can_fork → b {
+    ? < g_sh_have_fork 0 {
+        : i32 pid ( fork )
+        ? < # i pid 0 { = g_sh_have_fork 0 } {
+            ? == # i pid 0 { ( _exit # i32 0 ) } {}
+            : s buf ( nurl_zalloc 8 )
+            : i32 _w ( waitpid pid # *u buf # i32 0 )
+            ( nurl_free buf )
+            = g_sh_have_fork 1
+        }
+    } {}
+    ^ != g_sh_have_fork 0
+}
+
+@ __sh_no_processes s what → v {
+    ( bx_err_at what `not available on a machine with no processes` )
+}
+
+// Save fd `fd` somewhere above 10 so the redirection can be undone.
+// `fcntl(F_DUPFD)` rather than `dup`, because that is the call the
+// freestanding target already carries.
+@ __sh_save_fd i fd → i {
+    : i32 r ( fcntl # i32 fd # i32 0 10 )
+    ^ # i r
+}
+
+@ __sh_apply_redirs ( Vec ShRedir ) rs ( Vec i ) saved_fd ( Vec i ) saved_to → b {
+    : i n ( vec_len [ShRedir] rs )
+    : ~ i i 0
+    : ~ b ok T
+    ~ & ok < i n {
+        ?? ( vec_get [ShRedir] rs i ) {
+            T r → {
+                : ~ i newfd -1
+                ? == . r kind SHR_HEREDOC {
+                    // The body has to live somewhere a descriptor can
+                    // point at; a temporary file is that somewhere, and
+                    // it is unlinked immediately so nothing outlives the
+                    // command.
+                    ?? ( fs_tempfile `` `sh-here.` ) {
+                        T path → {
+                            ?? ( write_file ( string_data path ) ( string_data . . r word text ) ) {
+                                T _ → {}
+                                F _ → { = ok F }
+                            }
+                            : i32 fd ( open ( string_data path ) # i32 SH_O_RDONLY )
+                            = newfd # i fd
+                            ?? ( file_delete ( string_data path ) ) { T _ → {} F _ → {} }
+                            ( string_free path )
+                        }
+                        F _ → {
+                            ( bx_err `cannot create a temporary file for the here-document` )
+                            = ok F
+                        }
+                    }
+                } {
+                    : String target ( __sh_expand_to_string . r word )
+                    ? == . r kind SHR_DUP {
+                        : s t ( string_data target )
+                        ? ( bx_streq t `-` ) {
+                            : i32 _c ( close # i32 . r fd )
+                            = newfd -2
+                        } {
+                            : i32 d ( fcntl # i32 ( nurl_str_to_int t ) # i32 0 10 )
+                            = newfd # i d
+                        }
+                    } {
+                        : ~ i flags SH_O_RDONLY
+                        ? == . r kind SHR_OUT { = flags | | SH_O_WRONLY SH_O_CREAT SH_O_TRUNC } {}
+                        ? == . r kind SHR_APPEND { = flags | | SH_O_WRONLY SH_O_CREAT SH_O_APPEND } {}
+                        : i32 fd ( open ( string_data target ) # i32 flags 420 )
+                        = newfd # i fd
+                        ? < newfd 0 {
+                            ( bx_err_at ( string_data target ) `cannot open` )
+                            = ok F
+                        } {}
+                    }
+                    ( string_free target )
+                }
+                ? & ok >= newfd 0 {
+                    : i old ( __sh_save_fd . r fd )
+                    ( vec_push [i] saved_fd . r fd )
+                    ( vec_push [i] saved_to old )
+                    ( flush )
+                    : i32 d2 ( dup2 # i32 newfd # i32 . r fd )
+                    ? < # i d2 0 {
+                        ( __sh_no_processes `redirection` )
+                        = ok F
+                    } {}
+                    : i32 _c ( close # i32 newfd )
+                } {}
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ^ ok
+}
+
+@ __sh_undo_redirs ( Vec i ) saved_fd ( Vec i ) saved_to → v {
+    ( flush )
+    : ~ i i ( vec_len [i] saved_fd )
+    ~ > i 0 {
+        : ~ i fd -1
+        : ~ i old -1
+        ?? ( vec_get [i] saved_fd - i 1 ) { T x → { = fd x } F _ → {} }
+        ?? ( vec_get [i] saved_to - i 1 ) { T x → { = old x } F _ → {} }
+        ? >= old 0 {
+            : i32 _d ( dup2 # i32 old # i32 fd )
+            : i32 _c ( close # i32 old )
+        } {}
+        = i - i 1
+    }
+}
+
+// ── Builtins ──────────────────────────────────────────────────────
+
+@ __sh_is_builtin s name → b {
+    ^ | | | | | | | | | | | | | | | ( bx_streq name `cd` ) ( bx_streq name `exit` ) ( bx_streq name `export` ) ( bx_streq name `unset` ) ( bx_streq name `shift` ) ( bx_streq name `set` ) ( bx_streq name `read` ) ( bx_streq name `eval` ) ( bx_streq name `.` ) ( bx_streq name `source` ) ( bx_streq name `return` ) ( bx_streq name `break` ) ( bx_streq name `continue` ) ( bx_streq name `:` ) ( bx_streq name `local` ) ( bx_streq name `type` )
+}
+
+@ __sh_builtin ( Vec String ) argv → i {
+    : *ShState st ( __st )
+    : s name ( bx_at argv 0 )
+    : i n ( vec_len [String] argv )
+    ? ( bx_streq name `:` ) { ^ 0 } {}
+    ? ( bx_streq name `cd` ) {
+        : ~ String dest ( string_new )
+        ? > n 1 { ( string_push_str dest ( bx_at argv 1 ) ) } {
+            : String home ( __sh_get `HOME` )
+            ( string_push_bytes dest # *u ( string_data home ) ( string_len home ) )
+            ( string_free home )
+        }
+        ? == ( string_len dest ) 0 {
+            ( string_free dest )
+            ^ 0
+        } {}
+        // `cd -` returns to $OLDPWD, and says where it went.
+        : ~ b announce F
+        ? ( bx_streq ( string_data dest ) `-` ) {
+            : String old ( __sh_get `OLDPWD` )
+            ( string_clear dest )
+            ( string_push_bytes dest # *u ( string_data old ) ( string_len old ) )
+            ( string_free old )
+            = announce T
+        } {}
+        : ~ String before ( string_new )
+        ?? ( env_cwd ) {
+            T c → {
+                ( string_free before )
+                = before c
+            }
+            F _ → {}
+        }
+        ?? ( env_chdir ( string_data dest ) ) {
+            T _ → {
+                ( __sh_set `OLDPWD` ( string_data before ) )
+                ?? ( env_cwd ) {
+                    T c2 → {
+                        ( __sh_set `PWD` ( string_data c2 ) )
+                        ? announce {
+                            ( nurl_print ( string_data c2 ) )
+                            ( nurl_print `\n` )
+                        } {}
+                        ( string_free c2 )
+                    }
+                    F _ → {}
+                }
+                ( string_free before )
+                ( string_free dest )
+                ^ 0
+            }
+            F e → {
+                ( bx_err_at ( string_data dest ) ( bx_ioerr e ) )
+                ( string_free before )
+                ( string_free dest )
+                ^ 1
+            }
+        }
+    } {}
+    ? ( bx_streq name `exit` ) {
+        = . st exiting 1
+        = . st exit_code ? > n 1 ( nurl_str_to_int ( bx_at argv 1 ) ) . st status
+        ^ . st exit_code
+    } {}
+    ? ( bx_streq name `export` ) {
+        : ~ i i 1
+        ~ < i n {
+            : s a ( bx_at argv i )
+            : i eq ( nurl_str_find a `=` )
+            ? > eq 0 {
+                : s nm ( nurl_str_slice a 0 eq )
+                : s val ( nurl_str_slice a + eq 1 - ( nurl_str_len a ) + eq 1 )
+                ( __sh_set nm val )
+                ?? ( env_set nm val ) { T _ → {} F _ → {} }
+            } {
+                : String v ( __sh_get a )
+                ?? ( env_set a ( string_data v ) ) { T _ → {} F _ → {} }
+                ( string_free v )
+            }
+            = i + i 1
+        }
+        ^ 0
+    } {}
+    ? ( bx_streq name `unset` ) {
+        : ~ i i 1
+        ~ < i n {
+            ( __sh_unset ( bx_at argv i ) )
+            = i + i 1
+        }
+        ^ 0
+    } {}
+    ? ( bx_streq name `shift` ) {
+        : i by ? > n 1 ( nurl_str_to_int ( bx_at argv 1 ) ) 1
+        : ~ i k 0
+        ~ & < k by > ( vec_len [String] . st params ) 0 {
+            ?? ( vec_remove [String] . st params 0 ) {
+                T x → { ( string_free x ) }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        ^ 0
+    } {}
+    ? ( bx_streq name `set` ) {
+        ? > n 1 {
+            ( vec_free_with [String] . st params \ String x → v { ( string_free x ) } )
+            = . st params ( vec_new [String] )
+            : ~ i i 1
+            // `set --` ends the option list; nothing here takes options.
+            ? ( bx_streq ( bx_at argv 1 ) `--` ) { = i 2 } {}
+            ~ < i n {
+                ( vec_push [String] . st params ( string_from ( bx_at argv i ) ) )
+                = i + i 1
+            }
+        } {
+            : String out ( string_new )
+            : i vn ( vec_len [String] . st names )
+            : ~ i i 0
+            ~ < i vn {
+                ( string_push_str out ( bx_at . st names i ) )
+                ( string_push_char out 61 )
+                ( string_push_str out ( bx_at . st values i ) )
+                ( string_push_char out 10 )
+                = i + i 1
+            }
+            ( bx_write out )
+            ( string_free out )
+        }
+        ^ 0
+    } {}
+    ? ( bx_streq name `read` ) {
+        : String line ( read_line )
+        : b eof & == ( string_len line ) 0 ( stdin_eof )
+        ? > n 1 {
+            // Fields go to the named variables, the last one taking
+            // whatever is left — POSIX's rule.
+            : ( Vec String ) fields ( string_split line ` ` )
+            : i nf ( vec_len [String] fields )
+            : ~ i vi 1
+            ~ < vi n {
+                : String val ( string_new )
+                ? < - vi 1 nf {
+                    ? == vi - n 1 {
+                        : ~ i k - vi 1
+                        ~ < k nf {
+                            ? > k - vi 1 { ( string_push_char val 32 ) } {}
+                            ( string_push_str val ( bx_at fields k ) )
+                            = k + k 1
+                        }
+                    } { ( string_push_str val ( bx_at fields - vi 1 ) ) }
+                } {}
+                ( __sh_set ( bx_at argv vi ) ( string_data val ) )
+                ( string_free val )
+                = vi + vi 1
+            }
+            ( vec_free_with [String] fields \ String x → v { ( string_free x ) } )
+        } { ( __sh_set `REPLY` ( string_data line ) ) }
+        ( string_free line )
+        ^ ? eof 1 0
+    } {}
+    ? ( bx_streq name `eval` ) {
+        : String script ( string_new )
+        : ~ i i 1
+        ~ < i n {
+            ? > i 1 { ( string_push_char script 32 ) } {}
+            ( string_push_str script ( bx_at argv i ) )
+            = i + i 1
+        }
+        : i r ( __sh_run_string ( string_data script ) )
+        ( string_free script )
+        ^ r
+    } {}
+    ? | ( bx_streq name `.` ) ( bx_streq name `source` ) {
+        ? < n 2 {
+            ( bx_err `. needs a file` )
+            ^ 1
+        } {}
+        ?? ( read_file ( bx_at argv 1 ) ) {
+            T text → {
+                : i r ( __sh_run_string ( string_data text ) )
+                ( string_free text )
+                ^ r
+            }
+            F e → {
+                ( bx_err_at ( bx_at argv 1 ) ( bx_ioerr e ) )
+                ^ 1
+            }
+        }
+    } {}
+    ? ( bx_streq name `return` ) {
+        = . st returning 1
+        ^ ? > n 1 ( nurl_str_to_int ( bx_at argv 1 ) ) . st status
+    } {}
+    ? ( bx_streq name `break` ) {
+        = . st brk ? > n 1 ( nurl_str_to_int ( bx_at argv 1 ) ) 1
+        ^ 0
+    } {}
+    ? ( bx_streq name `continue` ) {
+        = . st cont ? > n 1 ( nurl_str_to_int ( bx_at argv 1 ) ) 1
+        ^ 0
+    } {}
+    ? ( bx_streq name `local` ) {
+        // No scoping yet: `local x=1` sets it, which is the behaviour a
+        // script depends on; the scope it does not get is documented
+        // rather than faked.
+        : ~ i i 1
+        ~ < i n {
+            : s a ( bx_at argv i )
+            : i eq ( nurl_str_find a `=` )
+            ? > eq 0 {
+                ( __sh_set ( nurl_str_slice a 0 eq ) ( nurl_str_slice a + eq 1 - ( nurl_str_len a ) + eq 1 ) )
+            } { ( __sh_set a `` ) }
+            = i + i 1
+        }
+        ^ 0
+    } {}
+    ? ( bx_streq name `type` ) {
+        : ~ i rc 0
+        : ~ i i 1
+        ~ < i n {
+            : s a ( bx_at argv i )
+            ( nurl_print a )
+            ? >= ( __sh_func_index a ) 0 { ( nurl_print ` is a function\n` ) } {
+                ? ( __sh_is_builtin a ) { ( nurl_print ` is a shell builtin\n` ) } {
+                    ? ( bx_is_applet a ) { ( nurl_print ` is a nurlbox applet\n` ) } {
+                        ( nurl_print ` not found\n` )
+                        = rc 1
+                    }
+                }
+            }
+            = i + i 1
+        }
+        ^ rc
+    } {}
+    ^ 0
+}
+
+// ── Running commands ──────────────────────────────────────────────
+
+// A function body, with `$1…` swapped for the call's arguments and put
+// back afterwards.
+@ __sh_call_func ( Vec ShNode ) arena i fidx ( Vec String ) argv → i {
+    : *ShState st ( __st )
+    : ( Vec String ) saved ( vec_new [String] )
+    : i pn ( vec_len [String] . st params )
+    : ~ i i 0
+    ~ < i pn {
+        ( vec_push [String] saved ( string_from ( bx_at . st params i ) ) )
+        = i + i 1
+    }
+    ( vec_free_with [String] . st params \ String x → v { ( string_free x ) } )
+    = . st params ( vec_new [String] )
+    : i an ( vec_len [String] argv )
+    : ~ i k 1
+    ~ < k an {
+        ( vec_push [String] . st params ( string_from ( bx_at argv k ) ) )
+        = k + k 1
+    }
+    : ~ i body -1
+    ?? ( vec_get [i] . st fnodes fidx ) { T x → { = body x } F _ → {} }
+    : i rc ? >= body 0 ( __sh_exec arena body ) 0
+    = . st returning 0
+    ( vec_free_with [String] . st params \ String x → v { ( string_free x ) } )
+    = . st params saved
+    ^ rc
+}
+
+// An external program: fork, exec, wait. A machine with no processes
+// says so rather than reporting "not found" about a program that is
+// right there.
+@ __sh_exec_external ( Vec String ) argv → i {
+    ? ! ( __sh_can_fork ) {
+        ( __sh_no_processes ( bx_at argv 0 ) )
+        ^ 127
+    } {}
+    ( flush )
+    : i32 pid ( fork )
+    ? == # i pid 0 {
+        : i n ( vec_len [String] argv )
+        : s buf ( nurl_zalloc * 8 + n 1 )
+        : ~ i k 0
+        ~ < k n {
+            ( nurl_poke buf k # i ( bx_at argv k ) )
+            = k + k 1
+        }
+        : i32 _r ( execvp ( bx_at argv 0 ) # *u buf )
+        ( nurl_eprint ( bx_at argv 0 ) )
+        ( nurl_eprint `: not found\n` )
+        ( _exit # i32 127 )
+        ^ 127
+    } {}
+    ? < # i pid 0 { ^ 127 } {}
+    : s statusbuf ( nurl_zalloc 8 )
+    : i32 _w ( waitpid pid # *u statusbuf # i32 0 )
+    : i raw ( nurl_peek statusbuf 0 )
+    ( nurl_free statusbuf )
+    ^ ( nurl_wait_exit_status & raw 65535 )
+}
+
+@ __sh_exec_simple ( Vec ShNode ) arena i idx → i {
+    : *ShState st ( __st )
+    : ~ i rc 0
+    ?? ( vec_get [ShNode] arena idx ) {
+        F _ → { ^ 0 }
+        T n → {
+            : ( Vec String ) argv ( vec_new [String] )
+            : ( Vec String ) assigns ( vec_new [String] )
+            : i wn ( vec_len [ShWord] . n words )
+            : ~ b in_prefix T
+            : ~ i i 0
+            ~ < i wn {
+                ?? ( vec_get [ShWord] . n words i ) {
+                    T w → {
+                        ? & in_prefix ( __sh_is_assign w ) {
+                            : String flat ( __sh_expand_to_string w )
+                            ( vec_push [String] assigns flat )
+                        } {
+                            = in_prefix F
+                            ( __sh_expand_word w argv )
+                        }
+                    }
+                    F _ → {}
+                }
+                = i + i 1
+            }
+            : i argc ( vec_len [String] argv )
+            ? == argc 0 {
+                // Assignments with no command set the shell's variables
+                // for good; with a command they are that command's
+                // environment only.
+                : i an ( vec_len [String] assigns )
+                : ~ i k 0
+                ~ < k an {
+                    : s a ( bx_at assigns k )
+                    : i eq ( nurl_str_find a `=` )
+                    ? > eq 0 {
+                        ( __sh_set ( nurl_str_slice a 0 eq ) ( nurl_str_slice a + eq 1 - ( nurl_str_len a ) + eq 1 ) )
+                    } {}
+                    = k + k 1
+                }
+                ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+                ( vec_free_with [String] assigns \ String x → v { ( string_free x ) } )
+                ^ 0
+            } {}
+            : ( Vec i ) saved_fd ( vec_new [i] )
+            : ( Vec i ) saved_to ( vec_new [i] )
+            ? ( __sh_apply_redirs . n redirs saved_fd saved_to ) {
+                // A command's assignments go into the environment it
+                // sees, and are undone after.
+                : i an ( vec_len [String] assigns )
+                : ~ i k 0
+                ~ < k an {
+                    : s a ( bx_at assigns k )
+                    : i eq ( nurl_str_find a `=` )
+                    ? > eq 0 {
+                        ?? ( env_set ( nurl_str_slice a 0 eq ) ( nurl_str_slice a + eq 1 - ( nurl_str_len a ) + eq 1 ) ) {
+                            T _ → {}
+                            F _ → {}
+                        }
+                    } {}
+                    = k + k 1
+                }
+                : s cmd ( bx_at argv 0 )
+                : i fidx ( __sh_func_index cmd )
+                ? >= fidx 0 {
+                    = rc ( __sh_call_func arena fidx argv )
+                } {
+                    ? ( __sh_is_builtin cmd ) {
+                        = rc ( __sh_builtin argv )
+                    } {
+                        ? ( bx_is_applet cmd ) {
+                            // In-process: no fork needed, which is what
+                            // makes this shell work on a unikernel.
+                            = rc ( bx_run_applet cmd argv )
+                            ( bx_set_name `sh` )
+                        } { = rc ( __sh_exec_external argv ) }
+                    }
+                }
+                ( flush )
+            } { = rc 1 }
+            ( __sh_undo_redirs saved_fd saved_to )
+            ( vec_free [i] saved_fd )
+            ( vec_free [i] saved_to )
+            ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+            ( vec_free_with [String] assigns \ String x → v { ( string_free x ) } )
+        }
+    }
+    = . st status rc
+    ^ rc
+}
+
+// One pipeline stage in a child, with its ends already chosen.
+@ __sh_stage ( Vec ShNode ) arena i idx i in_fd i out_fd → i32 {
+    ( flush )
+    : i32 pid ( fork )
+    ? == # i pid 0 {
+        ? >= in_fd 0 {
+            : i32 _a ( dup2 # i32 in_fd # i32 0 )
+            : i32 _b ( close # i32 in_fd )
+        } {}
+        ? >= out_fd 0 {
+            : i32 _c ( dup2 # i32 out_fd # i32 1 )
+            : i32 _d ( close # i32 out_fd )
+        } {}
+        : i rc ( __sh_exec arena idx )
+        ( flush )
+        ( _exit # i32 rc )
+    } {}
+    ^ pid
+}
+
+// A pipeline on a machine with no processes: each stage runs to
+// completion with its output in a temporary file, and the next stage
+// reads that file. It is NOT a pipeline — there is no concurrency and
+// the buffering is unbounded — but it is what a shell without processes
+// can honestly do, and it is what makes `seq 3 | wc -l` answer on a
+// unikernel instead of refusing. A stage that never terminates will
+// never hand anything on; a real pipeline would have streamed it.
+@ __sh_pipe_sequential ( Vec ShNode ) arena i idx i stages → i {
+    : ~ i rc 0
+    ?? ( vec_get [ShNode] arena idx ) {
+        F _ → { ^ 1 }
+        T n → {
+            : ~ String carry ( string_new )
+            : ~ b have_carry F
+            : ~ i s 0
+            ~ < s stages {
+                : ~ i node -1
+                ?? ( vec_get [i] . n kids s ) { T k → { = node k } F _ → {} }
+                : b last == s - stages 1
+                : ~ i in_saved -1
+                : ~ String in_path ( string_new )
+                ? have_carry {
+                    ?? ( fs_tempfile `` `sh-pipe-in.` ) {
+                        T p → {
+                            ?? ( write_file ( string_data p ) ( string_data carry ) ) { T _ → {} F _ → {} }
+                            : i32 fd ( open ( string_data p ) # i32 SH_O_RDONLY )
+                            ? >= # i fd 0 {
+                                ( flush )
+                                = in_saved ( __sh_save_fd 0 )
+                                : i32 _d ( dup2 fd # i32 0 )
+                                : i32 _c ( close fd )
+                            } {}
+                            ( string_clear in_path )
+                            ( string_push_bytes in_path # *u ( string_data p ) ( string_len p ) )
+                            ( string_free p )
+                        }
+                        F _ → {
+                            ( bx_err `a pipeline needs somewhere writable, and this machine has nowhere` )
+                            = rc 1
+                            = s stages
+                        }
+                    }
+                } {}
+                ? == rc 0 {
+                    ? last {
+                        = rc ( __sh_exec arena node )
+                    } {
+                        : String captured ( string_new )
+                        ?? ( fs_tempfile `` `sh-pipe-out.` ) {
+                            T p → {
+                                : i32 fd ( open ( string_data p ) # i32 | | SH_O_WRONLY SH_O_CREAT SH_O_TRUNC 420 )
+                                ? >= # i fd 0 {
+                                    ( flush )
+                                    : i saved ( __sh_save_fd 1 )
+                                    : i32 _d ( dup2 fd # i32 1 )
+                                    : i32 _c ( close fd )
+                                    = rc ( __sh_exec arena node )
+                                    ( flush )
+                                    ? >= saved 0 {
+                                        : i32 _d2 ( dup2 # i32 saved # i32 1 )
+                                        : i32 _c2 ( close # i32 saved )
+                                    } {}
+                                } { = rc ( __sh_exec arena node ) }
+                                ?? ( read_file ( string_data p ) ) {
+                                    T text → {
+                                        ( string_push_bytes captured # *u ( string_data text ) ( string_len text ) )
+                                        ( string_free text )
+                                    }
+                                    F _ → {}
+                                }
+                                ?? ( file_delete ( string_data p ) ) { T _ → {} F _ → {} }
+                                ( string_free p )
+                            }
+                            F _ → {
+                                ( bx_err `a pipeline needs somewhere writable, and this machine has nowhere` )
+                                = rc 1
+                                = s stages
+                            }
+                        }
+                        ( string_free carry )
+                        = carry captured
+                        = have_carry T
+                    }
+                } {}
+                ? >= in_saved 0 {
+                    ( flush )
+                    : i32 _r ( dup2 # i32 in_saved # i32 0 )
+                    : i32 _rc ( close # i32 in_saved )
+                } {}
+                ? > ( string_len in_path ) 0 {
+                    ?? ( file_delete ( string_data in_path ) ) { T _ → {} F _ → {} }
+                } {}
+                ( string_free in_path )
+                = s + s 1
+            }
+            ( string_free carry )
+        }
+    }
+    : *ShState st ( __st )
+    = . st status rc
+    ^ rc
+}
+
+@ __sh_exec_pipe ( Vec ShNode ) arena i idx → i {
+    : ~ i rc 0
+    ?? ( vec_get [ShNode] arena idx ) {
+        F _ → { ^ 0 }
+        T n → {
+            : i stages ( vec_len [i] . n kids )
+            ? <= stages 1 {
+                ?? ( vec_get [i] . n kids 0 ) {
+                    T k → { ^ ( __sh_exec arena k ) }
+                    F _ → { ^ 0 }
+                }
+            } {}
+            ? ! ( __sh_can_fork ) { ^ ( __sh_pipe_sequential arena idx stages ) } {}
+            : s fdbuf ( nurl_zalloc 16 )
+            : ( Vec i ) pids ( vec_new [i] )
+            : ~ i prev_read -1
+            : ~ i s 0
+            ~ < s stages {
+                : ~ i wfd -1
+                : ~ i rfd -1
+                ? < s - stages 1 {
+                    : i32 pr ( pipe # *u fdbuf )
+                    ? < # i pr 0 {
+                        ( bx_err `cannot create a pipe` )
+                        = s stages
+                    } {
+                        = rfd ( __le32_at fdbuf 0 )
+                        = wfd ( __le32_at fdbuf 4 )
+                    }
+                } {}
+                : ~ i node -1
+                ?? ( vec_get [i] . n kids s ) { T k → { = node k } F _ → {} }
+                ? >= node 0 {
+                    : i32 pid ( __sh_stage arena node prev_read wfd )
+                    ( vec_push [i] pids # i pid )
+                } {}
+                ? >= prev_read 0 { : i32 _c ( close # i32 prev_read ) } {}
+                ? >= wfd 0 { : i32 _c2 ( close # i32 wfd ) } {}
+                = prev_read rfd
+                = s + s 1
+            }
+            ( nurl_free fdbuf )
+            : s statusbuf ( nurl_zalloc 8 )
+            : i np ( vec_len [i] pids )
+            : ~ i k 0
+            ~ < k np {
+                ?? ( vec_get [i] pids k ) {
+                    T pid → {
+                        : i32 _w ( waitpid # i32 pid # *u statusbuf # i32 0 )
+                        // A pipeline's status is its LAST stage's.
+                        ? == k - np 1 {
+                            = rc ( nurl_wait_exit_status & ( nurl_peek statusbuf 0 ) 65535 )
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( nurl_free statusbuf )
+            ( vec_free [i] pids )
+        }
+    }
+    : *ShState st ( __st )
+    = . st status rc
+    ^ rc
+}
+
+// `pipe(2)` writes two ints; NURL reads them back a byte at a time
+// because an int is 32 bits and `nurl_peek` steps in 64.
+@ __le32_at s buf i off → i {
+    : *u p # *u buf
+    ^ | | | & 255 # i . p off << & 255 # i . p + off 1 8 << & 255 # i . p + off 2 16 << & 255 # i . p + off 3 24
+}
+
+@ __sh_exec ( Vec ShNode ) arena i idx → i {
+    : *ShState st ( __st )
+    ? < idx 0 { ^ 0 } {}
+    ? != 0 . st exiting { ^ . st exit_code } {}
+    : ~ i rc 0
+    ?? ( vec_get [ShNode] arena idx ) {
+        F _ → { ^ 0 }
+        T n → {
+            : i k . n kind
+            ? == k SH_SIMPLE { = rc ( __sh_exec_simple arena idx ) } {
+                ? == k SH_PIPE { = rc ( __sh_exec_pipe arena idx ) } {
+                    ? == k SH_SEQ {
+                        : i cnt ( vec_len [i] . n kids )
+                        : ~ i i 0
+                        ~ < i cnt {
+                            ?? ( vec_get [i] . n kids i ) {
+                                T child → { = rc ( __sh_exec arena child ) }
+                                F _ → {}
+                            }
+                            ? | | != 0 . st exiting | != 0 . st brk != 0 . st cont != 0 . st returning { = i cnt } { = i + i 1 }
+                        }
+                    } {
+                        ? == k SH_AND {
+                            = rc ( __sh_exec arena . n a )
+                            ? == rc 0 { = rc ( __sh_exec arena . n b ) } {}
+                        } {
+                            ? == k SH_OR {
+                                = rc ( __sh_exec arena . n a )
+                                ? != rc 0 { = rc ( __sh_exec arena . n b ) } {}
+                            } {
+                                ? == k SH_NOT {
+                                    = rc ? == ( __sh_exec arena . n a ) 0 1 0
+                                    = . st status rc
+                                } {
+                                    ? == k SH_IF {
+                                        ? == ( __sh_exec arena . n a ) 0 {
+                                            = rc ( __sh_exec arena . n b )
+                                        } { = rc ? >= . n c 0 ( __sh_exec arena . n c ) 0 }
+                                    } {
+                                        ? | == k SH_WHILE == k SH_UNTIL {
+                                            : ~ b go T
+                                            ~ go {
+                                                : i cond ( __sh_exec arena . n a )
+                                                : b enter ? == k SH_WHILE == cond 0 != cond 0
+                                                ? & enter == 0 . st exiting {
+                                                    = rc ( __sh_exec arena . n b )
+                                                    ? != 0 . st brk {
+                                                        = . st brk - . st brk 1
+                                                        = go F
+                                                    } {}
+                                                    ? != 0 . st cont { = . st cont - . st cont 1 } {}
+                                                    ? != 0 . st returning { = go F } {}
+                                                } { = go F }
+                                            }
+                                        } {
+                                            ? == k SH_FOR {
+                                                : ( Vec String ) items ( vec_new [String] )
+                                                ? == . n c 0 {
+                                                    : i pn ( vec_len [String] . st params )
+                                                    : ~ i p 0
+                                                    ~ < p pn {
+                                                        ( vec_push [String] items ( string_from ( bx_at . st params p ) ) )
+                                                        = p + p 1
+                                                    }
+                                                } {
+                                                    : i wn ( vec_len [ShWord] . n words )
+                                                    : ~ i w 0
+                                                    ~ < w wn {
+                                                        ?? ( vec_get [ShWord] . n words w ) {
+                                                            T word → { ( __sh_expand_word word items ) }
+                                                            F _ → {}
+                                                        }
+                                                        = w + w 1
+                                                    }
+                                                }
+                                                : i cnt ( vec_len [String] items )
+                                                : ~ i i 0
+                                                ~ < i cnt {
+                                                    ( __sh_set ( string_data . n text ) ( bx_at items i ) )
+                                                    = rc ( __sh_exec arena . n a )
+                                                    ? != 0 . st brk {
+                                                        = . st brk - . st brk 1
+                                                        = i cnt
+                                                    } {
+                                                        ? != 0 . st cont { = . st cont - . st cont 1 } {}
+                                                        ? | != 0 . st returning != 0 . st exiting { = i cnt } { = i + i 1 }
+                                                    }
+                                                }
+                                                ( vec_free_with [String] items \ String x → v { ( string_free x ) } )
+                                            } {
+                                                ? == k SH_CASE {
+                                                    : ~ String subject ( string_new )
+                                                    ?? ( vec_get [ShWord] . n words 0 ) {
+                                                        T w → {
+                                                            ( string_free subject )
+                                                            = subject ( __sh_expand_to_string w )
+                                                        }
+                                                        F _ → {}
+                                                    }
+                                                    : i arms ( vec_len [i] . n kids )
+                                                    : ~ i i 0
+                                                    : ~ b matched F
+                                                    ~ & ! matched < i arms {
+                                                        ?? ( vec_get [ShWord] . n words + i 1 ) {
+                                                            T pw → {
+                                                                : String pat ( __sh_expand_to_string pw )
+                                                                // The arm's alternatives are joined with a
+                                                                // `|`; each is a glob pattern.
+                                                                : ( Vec String ) alts ( string_split pat `|` )
+                                                                : i na ( vec_len [String] alts )
+                                                                : ~ i a 0
+                                                                ~ & ! matched < a na {
+                                                                    ? ( fs_match ( bx_at alts a ) ( string_data subject ) ) { = matched T } {}
+                                                                    = a + a 1
+                                                                }
+                                                                ( vec_free_with [String] alts \ String x → v { ( string_free x ) } )
+                                                                ( string_free pat )
+                                                                ? matched {
+                                                                    ?? ( vec_get [i] . n kids i ) {
+                                                                        T body → { = rc ( __sh_exec arena body ) }
+                                                                        F _ → {}
+                                                                    }
+                                                                } {}
+                                                            }
+                                                            F _ → {}
+                                                        }
+                                                        = i + i 1
+                                                    }
+                                                    ( string_free subject )
+                                                } {
+                                                    ? == k SH_GROUP { = rc ( __sh_exec arena . n a ) } {
+                                                        ? == k SH_SUBSHELL {
+                                                            // A subshell is a separate PROCESS — that is the whole
+                                                            // difference between `( … )` and `{ … }`, and it is why
+                                                            // an assignment inside one does not reach the parent.
+                                                            // A machine with no processes cannot have one, so it
+                                                            // runs the body here and says so rather than pretending
+                                                            // the isolation happened.
+                                                            ? ( __sh_can_fork ) {
+                                                                ( flush )
+                                                                : i32 pid ( fork )
+                                                                ? == # i pid 0 {
+                                                                    : i r2 ( __sh_exec arena . n a )
+                                                                    ( flush )
+                                                                    ( _exit # i32 r2 )
+                                                                } {}
+                                                                ? < # i pid 0 { = rc ( __sh_exec arena . n a ) } {
+                                                                    : s statusbuf ( nurl_zalloc 8 )
+                                                                    : i32 _w ( waitpid pid # *u statusbuf # i32 0 )
+                                                                    = rc ( nurl_wait_exit_status & ( nurl_peek statusbuf 0 ) 65535 )
+                                                                    ( nurl_free statusbuf )
+                                                                }
+                                                            } {
+                                                                ( __sh_no_processes `a subshell` )
+                                                                = rc ( __sh_exec arena . n a )
+                                                            }
+                                                        } {
+                                                            ? == k SH_FUNC {
+                                                                : i existing ( __sh_func_index ( string_data . n text ) )
+                                                                ? >= existing 0 {
+                                                                    : b _s ( vec_set [i] . st fnodes existing . n a )
+                                                                } {
+                                                                    ( vec_push [String] . st fnames ( string_clone . n text ) )
+                                                                    ( vec_push [i] . st fnodes . n a )
+                                                                }
+                                                                = rc 0
+                                                            } {
+                                                                ? == k SH_BACKGROUND {
+                                                                    ? ! ( __sh_can_fork ) {
+                                                                        ( __sh_no_processes `a background job` )
+                                                                        = rc 1
+                                                                    } {
+                                                                        ( flush )
+                                                                        : i32 pid ( fork )
+                                                                        ? == # i pid 0 {
+                                                                            : i r2 ( __sh_exec arena . n a )
+                                                                            ( flush )
+                                                                            ( _exit # i32 r2 )
+                                                                        } {}
+                                                                        ( nurl_print `[1] ` )
+                                                                        ( nurl_print ( nurl_str_int # i pid ) )
+                                                                        ( nurl_print `\n` )
+                                                                        = rc 0
+                                                                    }
+                                                                } { = rc 0 } } } } } } } } } } } } } }
+        }
+    }
+    ? != ( __sh_node_kind arena idx ) SH_SIMPLE { = . st status rc } {}
+    ^ rc
+}
+
+@ __sh_node_kind ( Vec ShNode ) arena i idx → i {
+    ?? ( vec_get [ShNode] arena idx ) {
+        T n → { ^ . n kind }
+        F _ → { ^ -1 }
+    }
+}
+
+// ── Driving a script ──────────────────────────────────────────────
+
+@ __sh_run_string s script → i {
+    : ( Vec ShTok ) toks ( vec_new [ShTok] )
+    : ( Vec String ) bodies ( vec_new [String] )
+    : ~ i rc 0
+    ? ! ( __sh_lex script toks bodies ) { = rc 2 } {
+        : ( Vec ShNode ) arena ( vec_new [ShNode] )
+        : i saved_pos g_sh_pos
+        : i saved_here g_sh_here
+        : b saved_err g_sh_perr
+        = g_sh_pos 0
+        = g_sh_here 0
+        = g_sh_perr F
+        : i root ( __sh_parse_list arena toks bodies )
+        ? g_sh_perr { = rc 2 } { = rc ( __sh_exec arena root ) }
+        = g_sh_pos saved_pos
+        = g_sh_here saved_here
+        = g_sh_perr saved_err
+        ( __shn_free_arena arena )
+    }
+    ( __sht_free_vec toks )
+    ( vec_free_with [String] bodies \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// `$(…)`: the script runs in a child with stdout on a pipe, and the
+// trailing newlines come off the result — both of those are what makes
+// `x=$(pwd)` behave.
+@ __sh_capture s script → String {
+    : String out ( string_new )
+    ? ! ( __sh_can_fork ) {
+        // No processes: run it HERE with stdout pointed at a temporary
+        // file, then read the file back. That needs somewhere writable
+        // to put the file, which a machine with only a read-only image
+        // does not have — and then it says so rather than returning an
+        // empty string that looks like a command producing no output.
+        ?? ( fs_tempfile `` `sh-cap.` ) {
+            F _ → {
+                ( bx_err `command substitution needs somewhere writable, and this machine has nowhere` )
+                ^ out
+            }
+            T path → {
+                : i32 fd ( open ( string_data path ) # i32 | | SH_O_WRONLY SH_O_CREAT SH_O_TRUNC 420 )
+                ? < # i fd 0 {
+                    ( bx_err_at ( string_data path ) `cannot open` )
+                    ( string_free path )
+                    ^ out
+                } {}
+                ( flush )
+                : i saved ( __sh_save_fd 1 )
+                : i32 _d ( dup2 fd # i32 1 )
+                : i32 _c ( close fd )
+                : i rc ( __sh_run_string script )
+                ( flush )
+                ? >= saved 0 {
+                    : i32 _d2 ( dup2 # i32 saved # i32 1 )
+                    : i32 _c2 ( close # i32 saved )
+                } {}
+                : *ShState st0 ( __st )
+                = . st0 status rc
+                ?? ( read_file ( string_data path ) ) {
+                    T text → {
+                        ( string_push_bytes out # *u ( string_data text ) ( string_len text ) )
+                        ( string_free text )
+                    }
+                    F _ → {}
+                }
+                ?? ( file_delete ( string_data path ) ) { T _ → {} F _ → {} }
+                ( string_free path )
+                : ~ i tn ( string_len out )
+                ~ & > tn 0 == ( string_get out - tn 1 ) 10 { = tn - tn 1 }
+                : String trimmed0 ( string_substr out 0 tn )
+                ( string_free out )
+                ^ trimmed0
+            }
+        }
+    } {}
+    : s fdbuf ( nurl_zalloc 16 )
+    : i32 pr ( pipe # *u fdbuf )
+    ? < # i pr 0 {
+        ( nurl_free fdbuf )
+        ^ out
+    } {}
+    : i rfd ( __le32_at fdbuf 0 )
+    : i wfd ( __le32_at fdbuf 4 )
+    ( nurl_free fdbuf )
+    ( flush )
+    : i32 pid ( fork )
+    ? == # i pid 0 {
+        : i32 _c ( close # i32 rfd )
+        : i32 _d ( dup2 # i32 wfd # i32 1 )
+        : i32 _e ( close # i32 wfd )
+        : i rc ( __sh_run_string script )
+        ( flush )
+        ( _exit # i32 rc )
+    } {}
+    : i32 _c2 ( close # i32 wfd )
+    : s buf ( nurl_alloc 4096 )
+    : ~ b more T
+    ~ more {
+        : i got ( read # i32 rfd # *u buf 4096 )
+        ? <= got 0 { = more F } { ( string_push_bytes out # *u buf got ) }
+    }
+    ( nurl_free buf )
+    : i32 _c3 ( close # i32 rfd )
+    : s statusbuf ( nurl_zalloc 8 )
+    : i32 _w ( waitpid pid # *u statusbuf # i32 0 )
+    : *ShState st ( __st )
+    = . st status ( nurl_wait_exit_status & ( nurl_peek statusbuf 0 ) 65535 )
+    ( nurl_free statusbuf )
+    : ~ i n ( string_len out )
+    ~ & > n 0 == ( string_get out - n 1 ) 10 { = n - n 1 }
+    : String trimmed ( string_substr out 0 n )
+    ( string_free out )
+    ^ trimmed
+}
+
+// ── The applet ────────────────────────────────────────────────────
+
+@ __sh_interactive → i {
+    : *ShState st ( __st )
+    : ~ String line ( string_new )
+    ~ == 0 . st exiting {
+        ( nurl_print `$ ` )
+        ( flush )
+        ( string_free line )
+        = line ( read_line )
+        ? & == ( string_len line ) 0 ( stdin_eof ) { = . st exiting 1 } {
+            ? > ( string_len line ) 0 {
+                : i _r ( __sh_run_string ( string_data line ) )
+            } {}
+        }
+    }
+    ( string_free line )
+    ^ . st exit_code
+}
+
+@ ap_sh ( Vec String ) argv → i {
+    ( __sh_state_new )
+    : *ShState st ( __st )
+    : i n ( vec_len [String] argv )
+    : ~ i rc 0
+    : ~ i i 1
+    : ~ b did_something F
+    : ~ b interactive F
+    ~ & ! did_something < i n {
+        : s a ( bx_at argv i )
+        ? ( bx_streq a `-c` ) {
+            ? < + i 1 n {
+                ( string_clear . st argv0 )
+                ( string_push_str . st argv0 `sh` )
+                : ~ i k + i 2
+                ~ < k n {
+                    ( vec_push [String] . st params ( string_from ( bx_at argv k ) ) )
+                    = k + k 1
+                }
+                = rc ( __sh_run_string ( bx_at argv + i 1 ) )
+                = did_something T
+            } {
+                ( bx_err `-c needs a command` )
+                = rc 2
+                = did_something T
+            }
+        } {
+            ? | ( bx_streq a `-s` ) ( bx_streq a `-i` ) { = i + i 1 } {
+                ? & > ( nurl_str_len a ) 0 == 45 ( nurl_str_get a 0 ) { = i + i 1 } {
+                    // A file operand: run it, with the rest as $1…
+                    ?? ( read_file a ) {
+                        T text → {
+                            ( string_clear . st argv0 )
+                            ( string_push_str . st argv0 a )
+                            : ~ i k + i 1
+                            ~ < k n {
+                                ( vec_push [String] . st params ( string_from ( bx_at argv k ) ) )
+                                = k + k 1
+                            }
+                            = rc ( __sh_run_string ( string_data text ) )
+                            ( string_free text )
+                        }
+                        F e → {
+                            ( bx_err_at a ( bx_ioerr e ) )
+                            = rc 127
+                        }
+                    }
+                    = did_something T
+                }
+            }
+        }
+    }
+    ? ! did_something {
+        // No script: read commands from stdin, prompting when it is a
+        // terminal.
+        = interactive T
+        = rc ( __sh_interactive )
+    } {}
+    ? != 0 . st exiting { = rc . st exit_code } {}
+    ( __sh_state_free )
+    ^ rc
+}

--- a/packages/nurlbox/src/textmisc.nu
+++ b/packages/nurlbox/src/textmisc.nu
@@ -1,0 +1,725 @@
+// nurlbox/textmisc.nu — the smaller text utilities.
+//
+// comm / paste / fold / expand / unexpand / shuf / dos2unix / unix2dos
+// / factor / sum.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bufio.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/rng.nu`
+$ `bx.nu`
+$ `filter.nu`
+
+// ── comm ──────────────────────────────────────────────────────────
+
+@ ap_comm ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `123` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        ? != ( bx_operand_count o ) 2 {
+            ( bx_err `usage: comm [-123] FILE1 FILE2` )
+            = rc 1
+        } {
+            : b hide1 ( bx_has o `1` )
+            : b hide2 ( bx_has o `2` )
+            : b hide3 ( bx_has o `3` )
+            : ( Vec String ) a ( vec_new [String] )
+            : ( Vec String ) b ( vec_new [String] )
+            ? & ( bx_read_lines ( bx_operand o 0 ) a ) ( bx_read_lines ( bx_operand o 1 ) b ) {
+                : i na ( vec_len [String] a )
+                : i nb ( vec_len [String] b )
+                : String out ( string_new )
+                : ~ i i 0
+                : ~ i j 0
+                // comm's merge is only correct on sorted input, so it
+                // says so instead of quietly producing nonsense — the
+                // warning is the whole reason the exit status is 1.
+                : ~ b warned1 F
+                : ~ b warned2 F
+                // Both inputs are assumed sorted; the merge is the
+                // whole algorithm, and it is why comm is O(n) where
+                // `sort | uniq` over the pair is not.
+                ~ | < i na < j nb {
+                    : ~ i cmp 0
+                    ? >= i na { = cmp 1 } {
+                        ? >= j nb { = cmp -1 } {
+                            = cmp ( nurl_str_cmp ( bx_at a i ) ( bx_at b j ) )
+                        }
+                    }
+                    ? & & > i 0 < i na < ( nurl_str_cmp ( bx_at a i ) ( bx_at a - i 1 ) ) 0 {
+                        ? ! warned1 {
+                            ( bx_err `file 1 is not in sorted order` )
+                            = warned1 T
+                            = rc 1
+                        } {}
+                    } {}
+                    ? & & > j 0 < j nb < ( nurl_str_cmp ( bx_at b j ) ( bx_at b - j 1 ) ) 0 {
+                        ? ! warned2 {
+                            ( bx_err `file 2 is not in sorted order` )
+                            = warned2 T
+                            = rc 1
+                        } {}
+                    } {}
+                    ? < cmp 0 {
+                        ? ! hide1 {
+                            ( string_push_str out ( bx_at a i ) )
+                            ( string_push_char out 10 )
+                        } {}
+                        = i + i 1
+                    } {
+                        ? > cmp 0 {
+                            ? ! hide2 {
+                                ? ! hide1 { ( string_push_char out 9 ) } {}
+                                ( string_push_str out ( bx_at b j ) )
+                                ( string_push_char out 10 )
+                            } {}
+                            = j + j 1
+                        } {
+                            ? ! hide3 {
+                                ? ! hide1 { ( string_push_char out 9 ) } {}
+                                ? ! hide2 { ( string_push_char out 9 ) } {}
+                                ( string_push_str out ( bx_at a i ) )
+                                ( string_push_char out 10 )
+                            } {}
+                            = i + i 1
+                            = j + j 1
+                        }
+                    }
+                    ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                }
+                ( bx_write out )
+                ( string_free out )
+            } { = rc 1 }
+            ( bx_free_lines a )
+            ( bx_free_lines b )
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── paste ─────────────────────────────────────────────────────────
+
+@ __paste_delim s list i idx → i {
+    : i n ( nurl_str_len list )
+    ? == n 0 { ^ -1 } {}
+    : i c ( nurl_str_get list ( __i_wrap idx n ) )
+    ? == c 92 { ^ 9 } {}
+    ^ c
+}
+
+@ __i_wrap i v i n → i { ^ - v * n / v n }
+
+@ ap_paste ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `d:s` `delimiters=d,serial=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : s delims ? ( bx_has o `d` ) ( bx_val o `d` ) `\t`
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : i ni ( vec_len [String] ins )
+        : String out ( string_new )
+        ? ( bx_has o `s` ) {
+            // -s puts each FILE on one line instead of merging columns.
+            : ~ i k 0
+            ~ < k ni {
+                : ( Vec String ) lines ( vec_new [String] )
+                ? ( bx_read_lines ( bx_at ins k ) lines ) {
+                    : i n ( vec_len [String] lines )
+                    : ~ i j 0
+                    ~ < j n {
+                        ? > j 0 { ( string_push_char out ( __paste_delim delims - j 1 ) ) } {}
+                        ( string_push_str out ( bx_at lines j ) )
+                        = j + j 1
+                    }
+                    ( string_push_char out 10 )
+                } { = rc 1 }
+                ( bx_free_lines lines )
+                = k + k 1
+            }
+        } {
+            // Column form: one line taken from each file per output
+            // line, until every file is drained.
+            : ( Vec BufReader ) rs ( vec_new [BufReader] )
+            : ( Vec i ) alive ( vec_new [i] )
+            : ~ i k 0
+            ~ < k ni {
+                ?? ( bx_reader ( bx_at ins k ) ) {
+                    T br → {
+                        ( vec_push [BufReader] rs br )
+                        ( vec_push [i] alive 1 )
+                    }
+                    F _ → {
+                        ( vec_push [BufReader] rs ( bufreader_stdin ) )
+                        ( vec_push [i] alive 0 )
+                        = rc 1
+                    }
+                }
+                = k + k 1
+            }
+            : String line ( string_new )
+            : String row ( string_new )
+            : ~ b more T
+            ~ more {
+                // The row is assembled aside and only committed once
+                // some file actually yielded a line — otherwise the
+                // round that discovers end-of-input emits a line of
+                // bare delimiters.
+                ( string_clear row )
+                : ~ b any F
+                : ~ i j 0
+                ~ < j ni {
+                    ? > j 0 { ( string_push_char row ( __paste_delim delims - j 1 ) ) } {}
+                    : ~ i live 0
+                    ?? ( vec_get [i] alive j ) { T x → { = live x } F _ → {} }
+                    ? != live 0 {
+                        ?? ( vec_get [BufReader] rs j ) {
+                            T br → {
+                                ? ( bufreader_read_line_into br line ) {
+                                    ( string_push_bytes row # *u ( string_data line ) ( string_len line ) )
+                                    = any T
+                                } { : b _s ( vec_set [i] alive j 0 ) }
+                            }
+                            F _ → {}
+                        }
+                    } {}
+                    = j + j 1
+                }
+                ? any {
+                    ( string_push_bytes out # *u ( string_data row ) ( string_len row ) )
+                    ( string_push_char out 10 )
+                } { = more F }
+                ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+            }
+            ( string_free row )
+            ( string_free line )
+            : ~ i q 0
+            ~ < q ni {
+                ?? ( vec_get [BufReader] rs q ) {
+                    T br → { ( bufreader_close br ) }
+                    F _ → {}
+                }
+                = q + q 1
+            }
+            ( vec_free [BufReader] rs )
+            ( vec_free [i] alive )
+        }
+        ( bx_write out )
+        ( string_free out )
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── fold ──────────────────────────────────────────────────────────
+
+@ ap_fold ( Vec String ) argv → i {
+    // `fold -20` is the historical spelling.
+    : ( Vec String ) av ( vec_new [String] )
+    : i argn ( vec_len [String] argv )
+    : ~ i ai 0
+    ~ < ai argn {
+        : s tok ( bx_at argv ai )
+        : i tl ( nurl_str_len tok )
+        ? & & > ai 0 > tl 1 & == ( nurl_str_get tok 0 ) 45 ( bx_is_digit ( nurl_str_get tok 1 ) ) {
+            ( vec_push [String] av ( string_from `-w` ) )
+            ( vec_push [String] av ( string_from ( nurl_str_slice tok 1 - tl 1 ) ) )
+        } { ( vec_push [String] av ( string_from tok ) ) }
+        = ai + ai 1
+    }
+    : BxOpts o ( bx_getopt av 1 `w:bs` `width=w,bytes=b,spaces=s` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : i width ? ( bx_has o `w` ) ( nurl_str_to_int ( bx_val o `w` ) ) 80
+        : b at_spaces ( bx_has o `s` )
+        ? <= width 0 {
+            ( bx_err `width must be positive` )
+            = rc 1
+        } {
+            : ( Vec String ) ins ( vec_new [String] )
+            ( bx_inputs o ins )
+            : i ni ( vec_len [String] ins )
+            : String out ( string_new )
+            : ~ i k 0
+            ~ < k ni {
+                ?? ( bx_reader ( bx_at ins k ) ) {
+                    F _ → { = rc 1 }
+                    T br → {
+                        : String line ( string_new )
+                        : ~ b more T
+                        ~ more {
+                            ? ( bufreader_read_line_into br line ) {
+                                : i n ( string_len line )
+                                : ~ i from 0
+                                ~ < from n {
+                                    : ~ i to ? < + from width n + from width n
+                                    ? & at_spaces < to n {
+                                        // Break at the last blank in the
+                                        // window, so a word survives the
+                                        // fold whole.
+                                        : ~ i b - to 1
+                                        : ~ b found F
+                                        ~ & ! found > b from {
+                                            ? ( bx_is_blank ( string_get line b ) ) {
+                                                = to + b 1
+                                                = found T
+                                            } { = b - b 1 }
+                                        }
+                                    } {}
+                                    ( string_push_bytes out # *u + # i ( string_data line ) from - to from )
+                                    ( string_push_char out 10 )
+                                    = from to
+                                }
+                                ? == n 0 { ( string_push_char out 10 ) } {}
+                                ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                            } { = more F }
+                        }
+                        ( string_free line )
+                        ( bufreader_close br )
+                    }
+                }
+                = k + k 1
+            }
+            ( bx_write out )
+            ( string_free out )
+            ( bx_free_lines ins )
+        }
+    }
+    ( bx_opts_free o )
+    ( vec_free_with [String] av \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+
+// ── expand / unexpand ─────────────────────────────────────────────
+
+// A tab-stop list: a single number means "every N columns", a list
+// means "at these columns, then every 8".
+@ __tab_next s spec i col → i {
+    : i n ( nurl_str_len spec )
+    ? == n 0 { ^ + col - 8 ( __i_wrap col 8 ) } {}
+    : ~ i i 0
+    : ~ i last 0
+    : ~ i count 0
+    ~ < i n {
+        : ~ i v 0
+        : ~ b any F
+        ~ & < i n ( bx_is_digit ( nurl_str_get spec i ) ) {
+            = v + * v 10 - ( nurl_str_get spec i ) 48
+            = any T
+            = i + i 1
+        }
+        ? any {
+            = count + count 1
+            ? > v col { ^ v } {}
+            = last v
+        } {}
+        ~ & < i n ! ( bx_is_digit ( nurl_str_get spec i ) ) { = i + i 1 }
+    }
+    // Past the last stop: a single stop repeats, a list falls back to
+    // one column at a time, which is what coreutils does.
+    ? == count 1 { ^ + col - last ( __i_wrap col last ) } {}
+    ^ + col 1
+}
+
+@ ap_expand ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `t:i` `tabs=t,initial=i` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : s tabs ? ( bx_has o `t` ) ( bx_val o `t` ) `8`
+        : b only_leading ( bx_has o `i` )
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : i ni ( vec_len [String] ins )
+        : String out ( string_new )
+        : ~ i k 0
+        ~ < k ni {
+            ?? ( bx_reader ( bx_at ins k ) ) {
+                F _ → { = rc 1 }
+                T br → {
+                    : String line ( string_new )
+                    : ~ b more T
+                    ~ more {
+                        ? ( bufreader_read_line_into br line ) {
+                            : i n ( string_len line )
+                            : ~ i col 0
+                            : ~ b leading T
+                            : ~ i i 0
+                            ~ < i n {
+                                : i c ( string_get line i )
+                                ? & == c 9 | ! only_leading leading {
+                                    : i stop ( __tab_next tabs col )
+                                    ~ < col stop { ( string_push_char out 32 ) = col + col 1 }
+                                } {
+                                    ? ! ( bx_is_blank c ) { = leading F } {}
+                                    ( string_push_char out c )
+                                    = col + col 1
+                                }
+                                = i + i 1
+                            }
+                            ( string_push_char out 10 )
+                            ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                        } { = more F }
+                    }
+                    ( string_free line )
+                    ( bufreader_close br )
+                }
+            }
+            = k + k 1
+        }
+        ( bx_write out )
+        ( string_free out )
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+@ ap_unexpand ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `t:a` `tabs=t,all=a` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : s tabs ? ( bx_has o `t` ) ( bx_val o `t` ) `8`
+        : b all ( bx_has o `a` )
+        : ( Vec String ) ins ( vec_new [String] )
+        ( bx_inputs o ins )
+        : i ni ( vec_len [String] ins )
+        : String out ( string_new )
+        : ~ i k 0
+        ~ < k ni {
+            ?? ( bx_reader ( bx_at ins k ) ) {
+                F _ → { = rc 1 }
+                T br → {
+                    : String line ( string_new )
+                    : ~ b more T
+                    ~ more {
+                        ? ( bufreader_read_line_into br line ) {
+                            : i n ( string_len line )
+                            : ~ i col 0
+                            : ~ i pending 0  // blanks held back, waiting for a stop
+                            : ~ i pend_col 0
+                            : ~ b leading T
+                            : ~ i i 0
+                            ~ < i n {
+                                : i c ( string_get line i )
+                                : b blank ( bx_is_blank c )
+                                ? & blank | all leading {
+                                    ? == pending 0 { = pend_col col } {}
+                                    = pending + pending ? == c 9 - ( __tab_next tabs col ) col 1
+                                    = col ? == c 9 ( __tab_next tabs col ) + col 1
+                                    // A run of blanks that crosses a tab
+                                    // stop collapses into one tab.
+                                    : i stop ( __tab_next tabs pend_col )
+                                    ? >= col stop {
+                                        ( string_push_char out 9 )
+                                        = pend_col stop
+                                        = pending - col stop
+                                        ? < pending 0 { = pending 0 } {}
+                                    } {}
+                                } {
+                                    ~ > pending 0 { ( string_push_char out 32 ) = pending - pending 1 }
+                                    ? ! blank { = leading F } {}
+                                    ( string_push_char out c )
+                                    = col + col 1
+                                }
+                                = i + i 1
+                            }
+                            ~ > pending 0 { ( string_push_char out 32 ) = pending - pending 1 }
+                            ( string_push_char out 10 )
+                            ? > ( string_len out ) 32768 { ( bx_write out ) ( string_clear out ) } {}
+                        } { = more F }
+                    }
+                    ( string_free line )
+                    ( bufreader_close br )
+                }
+            }
+            = k + k 1
+        }
+        ( bx_write out )
+        ( string_free out )
+        ( bx_free_lines ins )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── shuf ──────────────────────────────────────────────────────────
+
+@ ap_shuf ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `n:ei:zr` `head-count=n,echo=e,input-range=i,zero-terminated=z,repeat=r` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : ( Vec String ) items ( vec_new [String] )
+        ? ( bx_has o `e` ) {
+            : i n ( bx_operand_count o )
+            : ~ i k 0
+            ~ < k n {
+                ( vec_push [String] items ( string_from ( bx_operand o k ) ) )
+                = k + k 1
+            }
+        } {
+            ? ( bx_has o `i` ) {
+                : s spec ( bx_val o `i` )
+                : i dash ( nurl_str_find spec `-` )
+                ? < dash 0 {
+                    ( bx_err_at spec `invalid input range` )
+                    = rc 1
+                } {
+                    : i lo ( nurl_str_to_int ( nurl_str_slice spec 0 dash ) )
+                    : i hi ( nurl_str_to_int ( nurl_str_slice spec + dash 1 - ( nurl_str_len spec ) + dash 1 ) )
+                    : ~ i v lo
+                    ~ <= v hi {
+                        ( vec_push [String] items ( string_from ( nurl_str_int v ) ) )
+                        = v + v 1
+                    }
+                }
+            } {
+                : s p ? > ( bx_operand_count o ) 0 ( bx_operand o 0 ) `-`
+                ? ( bx_read_lines p items ) {} { = rc 1 }
+            }
+        }
+        ? == rc 0 {
+            : i n ( vec_len [String] items )
+            // The clock is the seed: two runs in the same millisecond
+            // would otherwise shuffle identically, which `shuf` exists
+            // not to do.
+            : Rng g ( rng_seed ^^ ( now_ms ) * ( monotonic_ns ) 2654435761 )
+            // Fisher-Yates, back to front.
+            : ~ i i - n 1
+            ~ > i 0 {
+                : i j ( rng_below g + i 1 )
+                : b _s ( vec_swap [String] items i j )
+                = i - i 1
+            }
+            : i take ? ( bx_has o `n` ) ( nurl_str_to_int ( bx_val o `n` ) ) n
+            : String out ( string_new )
+            : ~ i k 0
+            ~ & < k n < k take {
+                ( string_push_str out ( bx_at items k ) )
+                ( string_push_char out ? ( bx_has o `z` ) 0 10 )
+                = k + k 1
+            }
+            ( bx_write out )
+            ( string_free out )
+            ( rng_free g )
+        } {}
+        ( bx_free_lines items )
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── dos2unix / unix2dos ───────────────────────────────────────────
+
+@ __crlf_convert s path b to_dos b in_place → i {
+    : ~ b ok T
+    : ( Vec u ) data ( bx_slurp path ok )
+    ? ! ok {
+        ( vec_free [u] data )
+        ^ 1
+    } {}
+    : String out ( string_new )
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : ~ i i 0
+    ~ < i n {
+        : i c & 255 # i . p i
+        ? == c 13 {
+            // A lone CR is data; a CR before LF is a line ending.
+            ? & < + i 1 n == 10 & 255 # i . p + i 1 {} { ( string_push_char out 13 ) }
+        } {
+            ? == c 10 {
+                ? to_dos { ( string_push_char out 13 ) } {}
+                ( string_push_char out 10 )
+            } { ( string_push_char out c ) }
+        }
+        = i + i 1
+    }
+    : ~ i rc 0
+    ? in_place {
+        : ( Vec u ) bytes ( vec_new [u] )
+        : i on ( string_len out )
+        : ~ i k 0
+        ~ < k on { ( vec_push [u] bytes # u ( string_get out k ) ) = k + k 1 }
+        ?? ( write_file_bytes path bytes ) {
+            T _ → {}
+            F e → {
+                ( bx_err_at path ( bx_ioerr e ) )
+                = rc 1
+            }
+        }
+        ( vec_free [u] bytes )
+    } { ( bx_write out ) }
+    ( string_free out )
+    ( vec_free [u] data )
+    ^ rc
+}
+
+@ ap_dos2unix ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `ud` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        // -u forces unix endings, -d forces dos ones, whichever name
+        // the binary was invoked under.
+        : ~ b to_dos ( bx_streq ( bx_name ) `unix2dos` )
+        ? ( bx_has o `u` ) { = to_dos F } {}
+        ? ( bx_has o `d` ) { = to_dos T } {}
+        : i nops ( bx_operand_count o )
+        ? == nops 0 {
+            = rc ( __crlf_convert `-` to_dos F )
+        } {
+            : ~ i i 0
+            ~ < i nops {
+                : i one ( __crlf_convert ( bx_operand o i ) to_dos T )
+                ? != one 0 { = rc 1 } {}
+                = i + i 1
+            }
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}
+
+// ── factor ────────────────────────────────────────────────────────
+
+@ __factor_one String out i n → v {
+    ( string_push_int out n )
+    ( string_push_char out 58 )
+    : ~ i v n
+    ? < v 2 {
+        ( string_push_char out 10 )
+        ^
+    } {}
+    ~ == 0 - v * 2 / v 2 {
+        ( string_push_str out ` 2` )
+        = v / v 2
+    }
+    : ~ i d 3
+    // Trial division to sqrt(v): d*d > v is the stop, written as a
+    // multiply so it never needs a square root.
+    ~ <= * d d v {
+        ~ == 0 - v * d / v d {
+            ( string_push_char out 32 )
+            ( string_push_int out d )
+            = v / v d
+        }
+        = d + d 2
+    }
+    ? > v 1 {
+        ( string_push_char out 32 )
+        ( string_push_int out v )
+    } {}
+    ( string_push_char out 10 )
+}
+
+@ ap_factor ( Vec String ) argv → i {
+    : i n ( vec_len [String] argv )
+    : String out ( string_new )
+    : ~ i rc 0
+    ? <= n 1 {
+        // No operands: numbers come from stdin, one per line.
+        ?? ( bx_reader `-` ) {
+            F _ → { = rc 1 }
+            T br → {
+                : String line ( string_new )
+                : ~ b more T
+                ~ more {
+                    ? ( bufreader_read_line_into br line ) {
+                        ? > ( string_len line ) 0 {
+                            ( __factor_one out ( nurl_str_to_int ( string_data line ) ) )
+                        } {}
+                    } { = more F }
+                }
+                ( string_free line )
+                ( bufreader_close br )
+            }
+        }
+    } {
+        : ~ i i 1
+        ~ < i n {
+            ( __factor_one out ( nurl_str_to_int ( bx_at argv i ) ) )
+            = i + i 1
+        }
+    }
+    ( bx_write out )
+    ( string_free out )
+    ^ rc
+}
+
+// ── sum ───────────────────────────────────────────────────────────
+
+// Two historical checksums, neither of them a hash: the BSD one is a
+// 16-bit rotate-and-add, the System V one a byte sum folded twice.
+@ __sum_bsd ( Vec u ) data → i {
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : ~ i s 0
+    : ~ i i 0
+    ~ < i n {
+        = s | >> s 1 << & s 1 15
+        = s & + s & 255 # i . p i 65535
+        = i + i 1
+    }
+    ^ s
+}
+
+@ __sum_sysv ( Vec u ) data → i {
+    : i n ( vec_len [u] data )
+    : *u p ( vec_data [u] data )
+    : ~ i s 0
+    : ~ i i 0
+    ~ < i n {
+        = s + s & 255 # i . p i
+        = i + i 1
+    }
+    : i r + & s 65535 >> s 16
+    ^ & + & r 65535 >> r 16 65535
+}
+
+@ ap_sum ( Vec String ) argv → i {
+    : BxOpts o ( bx_getopt argv 1 `rs` `` )
+    : ~ i rc 0
+    ? ! ( bx_ok o ) { = rc 1 } {
+        : b sysv ( bx_has o `s` )
+        : i nops ( bx_operand_count o )
+        : ~ i i 0
+        ~ < i ? > nops 0 nops 1 {
+            : s p ? > nops 0 ( bx_operand o i ) `-`
+            : ~ b ok T
+            : ( Vec u ) data ( bx_slurp p ok )
+            ? ok {
+                : String out ( string_new )
+                : i n ( vec_len [u] data )
+                ? sysv {
+                    ( string_push_int out ( __sum_sysv data ) )
+                    ( string_push_char out 32 )
+                    ( string_push_int out / + n 511 512 )
+                } {
+                    : s d ( nurl_str_int ( __sum_bsd data ) )
+                    : ~ i pad - 5 ( nurl_str_len d )
+                    ~ > pad 0 { ( string_push_char out 32 ) = pad - pad 1 }
+                    ( string_push_str out d )
+                    ( string_push_char out 32 )
+                    : s blocks ( nurl_str_int / + n 1023 1024 )
+                    : ~ i pad2 - 5 ( nurl_str_len blocks )
+                    ~ > pad2 0 { ( string_push_char out 32 ) = pad2 - pad2 1 }
+                    ( string_push_str out blocks )
+                }
+                ? > nops 0 {
+                    ( string_push_char out 32 )
+                    ( string_push_str out p )
+                } {}
+                ( string_push_char out 10 )
+                ( bx_write out )
+                ( string_free out )
+            } { = rc 1 }
+            ( vec_free [u] data )
+            = i + i 1
+        }
+    }
+    ( bx_opts_free o )
+    ^ rc
+}

--- a/packages/nurlbox/tests/cases.sh
+++ b/packages/nurlbox/tests/cases.sh
@@ -314,3 +314,103 @@ dtb sed '2a\APPENDED' four.txt
 dtb sed '2c\CHANGED' four.txt
 dtb --stdin four.txt sed 's/a/A/'
 dtb sed 's/x/y/' nonl.txt
+
+echo "[textmisc]"
+# `paste` over ragged inputs: busybox drops the delimiter for an
+# exhausted file, coreutils keeps it — the empty field is still a field,
+# so the reference here is coreutils.
+dtg comm four.txt dupes.txt
+dtg comm -12 four.txt four.txt
+dtg comm -3 four.txt dupes.txt
+dtg paste four.txt words.txt
+dtb paste -s four.txt
+dtg paste -d, four.txt words.txt
+dtb fold -w 4 four.txt
+dtb fold -w 6 -s words.txt
+dtb fold -3 four.txt
+dtb expand tabs.txt
+dtb expand -t 4 tabs.txt
+dtg unexpand -a four.txt
+dtg sum four.txt
+dtg sum -s four.txt
+dtb factor 90
+dtb factor 97
+dtb factor 1 2 3 4 100 101
+
+echo "[binio]"
+dtb od four.txt
+dtb od -c four.txt
+dtb od -b four.txt
+dtb od -tx1 four.txt
+dtb od -An -tx1 four.txt
+dtb od -Ad -td2 four.txt
+dtb od binary.bin
+dtb hexdump -C four.txt
+dtb hexdump four.txt
+dtb hexdump -C binary.bin
+dtb xxd four.txt
+dtb xxd -p four.txt
+dtb xxd -c 8 four.txt
+dtb xxd binary.bin
+dt  cmp four.txt four.txt
+dt  cmp four.txt words.txt
+dt  cmp -l four.txt words.txt
+dt  cmp -s four.txt words.txt
+dtb strings binary.bin
+dtb strings -n 2 four.txt
+
+echo "[archive/proc]"
+dt  kill -l
+
+echo "[sh]"
+dtsh 'echo hello'
+dtsh 'echo "a b" c'
+dtsh "echo 'a b' c"
+dtsh 'x=5; echo $x'
+dtsh 'x=5; echo "${x}0"'
+dtsh 'echo $((2+3*4))'
+dtsh 'echo $(( (2+3) * 4 ))'
+dtsh 'x=3; echo $((x*x))'
+dtsh 'echo ${UNDEF:-fallback}'
+dtsh 'v=abc; echo ${#v}'
+dtsh 'v=hello; echo ${v%llo}; echo ${v#he}'
+dtsh 'v=a.b.c; echo ${v##*.}; echo ${v%%.*}'
+dtsh 'true && echo yes'
+dtsh 'false || echo no'
+dtsh 'if true; then echo t; else echo f; fi'
+dtsh 'if false; then echo a; elif true; then echo b; else echo c; fi'
+dtsh 'for i in a b c; do echo $i; done'
+dtsh 'i=0; while [ $i -lt 3 ]; do echo $i; i=$((i+1)); done'
+dtsh 'x=1; until [ $x -gt 3 ]; do echo $x; x=$((x+1)); done'
+dtsh 'for i in 1 2 3 4; do if [ $i = 3 ]; then break; fi; echo $i; done'
+dtsh 'for i in 1 2 3; do if [ $i = 2 ]; then continue; fi; echo $i; done'
+dtsh 'case abc in a*) echo matched;; *) echo no;; esac'
+dtsh 'case zzz in a*) echo matched;; *) echo no;; esac'
+dtsh 'f() { echo "in f $1"; }; f arg'
+dtsh 'f() { return 3; }; f; echo $?'
+dtsh 'echo $(echo nested)'
+dtsh 'echo `echo backtick`'
+dtsh 'echo a | tr a-z A-Z'
+dtsh 'echo one | cat | tr a-z A-Z'
+dtsh 'echo $?; false; echo $?'
+dtsh 'set a b c; echo $#; echo $1 $3; shift; echo $1'
+dtsh 'set a b c; for x in "$@"; do echo [$x]; done'
+dtsh 'set "a b" c; for x in "$@"; do echo [$x]; done'
+dtsh 'echo *.txt'
+dtsh 'echo nomatch-glob*'
+dtsh 'for f in *.txt; do echo "f=$f"; done'
+dtsh 'x=outer; ( x=inner ); echo $x'
+dtsh 'x=outer; { x=inner; }; echo $x'
+dtsh 'ls nonexistent-entry 2>/dev/null; echo rc=$?'
+dtsh 'echo out 2>&1 | cat'
+dtsh 'seq 3 | while read n; do echo "got $n"; done'
+dtsh 'a=1 b=2; echo $a$b'
+dtsh 'FOO=bar; unset FOO; echo "[${FOO}]"'
+dtsh 'echo a; exit 5; echo b'
+dtsh 'cat <<EOF
+one
+two
+EOF'
+dtsh 'printf "%s-%s\n" x y'
+dtsh 'wc -l < four.txt'
+dtsh 'grep alpha four.txt | wc -l'

--- a/packages/nurlbox/tests/nurlbox_test.sh
+++ b/packages/nurlbox/tests/nurlbox_test.sh
@@ -188,6 +188,23 @@ dtfs() {
     fi
 }
 
+# One shell script, run by both shells. The reference is busybox's ash,
+# which is the `sh` a busybox userland actually gives you.
+dtsh() {
+    local desc="$1"
+    if [ "$HAVE_BB" = 0 ]; then SKIP=$((SKIP+1)); return; fi
+    local go bo gs bs
+    go="$(cd "$FX" && "$NB" sh -c "$1" 2>&1)"; gs=$?
+    bo="$(cd "$FX" && "$BUSYBOX" sh -c "$1" 2>&1)"; bs=$?
+    if [ "$go" = "$bo" ] && [ "$gs" = "$bs" ]; then
+        ok
+    else
+        bad "sh: $desc"
+        [ "$gs" != "$bs" ] && echo "    exit: got $gs want $bs"
+        diff <(printf '%s' "$bo") <(printf '%s' "$go") | head -6 | sed 's/^/    /'
+    fi
+}
+
 # Explicit expectation, for behaviour busybox does not have or where the
 # reference is unavailable.
 expect() {

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1628,6 +1628,7 @@ const char* nurl_read_file(const char *path) {
 #  include <grp.h>
 #  include <sys/time.h>
 #  include <sys/utsname.h>
+#  include <sys/statvfs.h>
 #endif
 #ifdef _WIN32
 #  include <sys/utime.h>
@@ -1858,6 +1859,45 @@ char *nurl_group_name(long long gid) {
     (void)gid;
 #endif
     return NULL;
+}
+
+/* ── filesystem statistics ──────────────────────────────────────────
+ *
+ * `df`'s question — how big is the filesystem holding this path, and how
+ * much of it is free — through statvfs(3), whose struct is POSIX but
+ * whose field ORDER is not something NURL can rely on. Same treatment as
+ * stat: the runtime reads it and hands back a fixed slot layout.
+ *
+ *   0 bsize     3 bfree     6 ffree      9 namemax
+ *   1 frsize    4 bavail    7 favail
+ *   2 blocks    5 files     8 flag
+ *
+ * Returns 0 / -1 with errno. A platform with no statvfs (Windows, the
+ * freestanding target) answers -1 rather than zeroes, so `df` reports
+ * "not supported" instead of an empty disk. */
+long long nurl_statfs_into(const char *path, long long *out) {
+#if defined(__unix__) || defined(__APPLE__)
+    struct statvfs vfs;
+    int i;
+    if (!path || !out) return -1;
+    if (statvfs(path, &vfs) != 0) return -1;
+    for (i = 0; i < 10; i++) out[i] = 0;
+    out[0] = (long long)vfs.f_bsize;
+    out[1] = (long long)vfs.f_frsize;
+    out[2] = (long long)vfs.f_blocks;
+    out[3] = (long long)vfs.f_bfree;
+    out[4] = (long long)vfs.f_bavail;
+    out[5] = (long long)vfs.f_files;
+    out[6] = (long long)vfs.f_ffree;
+    out[7] = (long long)vfs.f_favail;
+    out[8] = (long long)vfs.f_flag;
+    out[9] = (long long)vfs.f_namemax;
+    return 0;
+#else
+    (void)path; (void)out;
+    errno = ENOSYS;
+    return -1;
+#endif
 }
 
 /* ── the machine, and the environment it handed us ──────────────────

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -480,6 +480,49 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ^ @ !FileStat IoErr { T st }
 }
 
+// ── Filesystem statistics ───────────────────────────────────────────
+//
+// How big is the filesystem holding this path, and how much of it is
+// free — `df`'s question, and a writer's before it starts.
+//
+// Sizes are in `frsize` units (the fragment size), which is what POSIX
+// specifies and what makes `blocks * frsize` the byte total. A platform
+// with no statvfs answers an error rather than zeroes: an empty disk and
+// an unanswerable question are different, and a caller that treats the
+// second as the first refuses to write for no reason.
+
+& `c` @ nurl_statfs_into s path s out → i
+
+: FsStat {
+    i bsize  // preferred I/O size
+    i frsize  // fragment size — the unit `blocks` counts
+    i blocks
+    i bfree  // free to root
+    i bavail  // free to an unprivileged writer
+    i files  // inodes
+    i ffree
+    i favail
+    i flag
+    i namemax
+}
+
+@ fs_statfs s path → !FsStat IoErr {
+    ? == # i path 0 { ^ @ !FsStat IoErr { F @ IoErr { NotFound } } } {}
+    : s buf ( nurl_zalloc 96 )
+    ? != 0 ( nurl_statfs_into path buf ) {
+        : IoErr e ( _io_err_of_kind ( errno_kind ) )
+        ( nurl_free buf )
+        ^ @ !FsStat IoErr { F e }
+    } {}
+    : FsStat st @ FsStat {
+        ( nurl_peek buf 0 ) ( nurl_peek buf 1 ) ( nurl_peek buf 2 ) ( nurl_peek buf 3 )
+        ( nurl_peek buf 4 ) ( nurl_peek buf 5 ) ( nurl_peek buf 6 ) ( nurl_peek buf 7 )
+        ( nurl_peek buf 8 ) ( nurl_peek buf 9 )
+    }
+    ( nurl_free buf )
+    ^ @ !FsStat IoErr { T st }
+}
+
 // ── Interpreting a FileStat ─────────────────────────────────────────
 
 @ stat_kind FileStat st → i { ^ ( nurl_stat_kind . st mode ) }
@@ -1286,7 +1329,10 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     : s d ? == 0 ( nurl_str_len dir ) `.` dir
     : String tmpl ( string_with_cap + + ( nurl_str_len d ) ( nurl_str_len prefix ) 10 )
     ( string_push_str tmpl d )
-    ( string_push_char tmpl 47 )  // '/'
+    // No second separator after a root `dir`: `//tmp.XXXXXX` is a
+    // different path on some systems and an unopenable one on a
+    // filesystem driver that walks components itself.
+    ? ! ( string_ends_with tmpl `/` ) { ( string_push_char tmpl 47 ) } {}
     ( string_push_str tmpl prefix )
     ( string_push_str tmpl `XXXXXX` )
     : i32 fd ( mkstemp ( string_data tmpl ) )

--- a/stdlib/std/path.nu
+++ b/stdlib/std/path.nu
@@ -247,7 +247,11 @@ $ `stdlib/core/vec.nu`
         ( string_push_char out ( nurl_str_at a la i ) )
         = i + i 1
     }
-    ( string_push_char out 47 )
+    // The trim keeps at least one byte, so a root `a` — `/` or `C:/` —
+    // still ends in a separator. Adding a second one produced `//d`,
+    // which is a different path on some systems and an ugly one on all
+    // of them.
+    ? ! ( __is_sep ( nurl_str_at a la - ae 1 ) ) { ( string_push_char out 47 ) } {}
     : ~ i j bs
     ~ < j lb {
         ( string_push_char out ( nurl_str_at b lb j ) )

--- a/unikernel/boot/nosys.c
+++ b/unikernel/boot/nosys.c
@@ -75,16 +75,6 @@ long readlink(const char *p, char *b, unsigned long n) {
     return ns_refuse(22);
 }
 
-/* ── the working directory ───────────────────────────────────────
- * There is exactly one namespace and the program starts at its root, so
- * `/` is not a placeholder here — it is the answer. */
-char *getcwd(char *buf, unsigned long size) {
-    if (!buf || size < 2) { nl_errno_slot = 34 /* ERANGE */; return 0; }
-    buf[0] = '/';
-    buf[1] = 0;
-    return buf;
-}
-
 /* ── credentials ─────────────────────────────────────────────────
  * One program, one address space, nothing above it: it is uid 0 in the
  * only sense the word can have here. There is no user database to give
@@ -148,8 +138,9 @@ int pipe(int fds[2]) {
 int fork(void)                          { return ns_refuse(NS_ENOSYS); }
 int execvp(const char *f, char *const a[]) { (void)f; (void)a; return ns_refuse(NS_ENOSYS); }
 int waitpid(int pid, int *st, int opt)  { (void)pid; (void)st; (void)opt; return ns_refuse(NS_ENOSYS); }
-int dup2(int a, int b)                  { (void)a; (void)b; return ns_refuse(NS_ENOSYS); }
-int fcntl(int fd, int cmd, long arg)    { (void)fd; (void)cmd; (void)arg; return ns_refuse(NS_ENOSYS); }
+/* `dup2` and `fcntl(F_DUPFD)` live in boot/vfs.c: on this machine they
+ * are not process plumbing, they are the redirection table for the three
+ * standard descriptors, and that table belongs with the filesystem. */
 
 /* poll over pipes to a child. The guest's own readiness lives in
  * unikernel/net/sockets.nu and never comes through here. */

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -995,9 +995,19 @@ int *__errno_location(void) { return &nl_errno_slot; }
  * the console, where stdout and stderr are the same wire. Until there
  * was a disk this function had no reason to look at `fd` at all — the
  * only writable thing on the machine was the serial port. */
+int vfs_std_of(int fd);
+int vfs_is_std_target(int fd);
+int vfs_close_saved(int fd);
+
 long long write(int fd, const void *buf, unsigned long n) {
     const char *p = (const char *)buf;
     if (fs_is_file_fd(fd)) return (long long)fs_write_fd(fd, buf, n);
+    /* A standard descriptor may have been pointed at a file — that is
+     * what `cmd > file` is, and vfs.c owns the table that says so. */
+    if (fd >= 0 && fd <= 2) {
+        int t = vfs_std_of(fd);
+        if (t >= 0) return (long long)fs_write_fd(t, buf, n);
+    }
     for (unsigned long i = 0; i < n; i++) pf_putc(p[i]);
     return (long long)n;
 }
@@ -1013,6 +1023,10 @@ long long write(int fd, const void *buf, unsigned long n) {
  * opened. */
 long long read(int fd, void *buf, unsigned long n) {
     if (fs_is_file_fd(fd)) return (long long)fs_read_fd(fd, buf, n);
+    if (fd >= 0 && fd <= 2) {
+        int t = vfs_std_of(fd);
+        if (t >= 0) return (long long)fs_read_fd(t, buf, n);
+    }
     (void)buf; (void)n;
     return 0;
 }
@@ -1020,6 +1034,11 @@ long long read(int fd, void *buf, unsigned long n) {
 int nl_open(const char *path, int flags, int mode);
 int open(const char *p, int fl, int mode) { return nl_open(p, fl, mode); }
 int close(int fd) {
+    if (vfs_close_saved(fd)) return 0;
+    /* A descriptor standing in for a standard one stays open: the shell
+     * closes it right after `dup2`, and closing it for real there would
+     * make the redirect it just installed point at nothing. */
+    if (vfs_is_std_target(fd)) return 0;
     if (fs_is_file_fd(fd)) return fs_close_fd(fd);
     return 0;
 }

--- a/unikernel/boot/vfs.c
+++ b/unikernel/boot/vfs.c
@@ -172,8 +172,243 @@ static long long posix_ret_ll(long long rc) {
 #define VFS_O_EXCL      0200
 #define VFS_O_DIRECTORY 0200000
 
-int nl_open(const char *path, int flags, int mode) {
-    if (!path) { nl_errno_slot = 22 /* EINVAL */; return -1; }
+/* ── redirecting the standard descriptors ────────────────────────
+ *
+ * `cmd > file` is not an exotic feature, and a shell that could not do
+ * it would not be a shell. On Linux the kernel's descriptor table
+ * answers `dup2`; here there is no kernel, so the three standard
+ * descriptors get a redirection table of their own and `write` / `read`
+ * consult it.
+ *
+ * Scope, stated rather than discovered: only 0, 1 and 2 may be the
+ * TARGET of a `dup2`. That is what a shell redirects, and a general
+ * descriptor table would be a second filesystem layer for no caller.
+ *
+ * Ownership follows the shell's own idiom — `dup2(newfd, 1)` then
+ * `close(newfd)` — so a descriptor that has become a redirect target is
+ * NOT closed by that `close`; it is closed when the redirect is
+ * replaced or undone. Without that, every `>` would close the file it
+ * had just opened and the next write would go nowhere.
+ */
+#define VFS_SAVED_BASE 300
+#define VFS_SAVED_MAX  8
+
+static int vfs_std_target[3] = { -1, -1, -1 };
+static int vfs_std_alias[3]  = { 0, 0, 0 };   /* 2>&1: shares, does not own */
+
+typedef struct {
+    int used;
+    int target;
+    int alias;
+} VfsSaved;
+
+static VfsSaved vfs_saved[VFS_SAVED_MAX];
+
+int fs_is_file_fd(int fd);
+int fs_close_fd(int fd);
+
+/* Where should a write to `fd` actually go? -1 means the console. */
+int vfs_std_of(int fd) {
+    if (fd < 0 || fd > 2) return -1;
+    return vfs_std_target[fd];
+}
+
+/* Is this descriptor currently standing in for a standard one? Then a
+ * `close` on it is the shell tidying up after `dup2`, not a request to
+ * drop the redirect. */
+int vfs_is_std_target(int fd) {
+    int i;
+    if (fd < 0) return 0;
+    for (i = 0; i < 3; i++) if (vfs_std_target[i] == fd) return 1;
+    for (i = 0; i < VFS_SAVED_MAX; i++)
+        if (vfs_saved[i].used && vfs_saved[i].target == fd) return 1;
+    return 0;
+}
+
+static int vfs_is_std_target_except(int fd, int skip);
+
+static void vfs_std_release(int stdfd) {
+    int t = vfs_std_target[stdfd];
+    if (t >= 0 && !vfs_std_alias[stdfd] && !vfs_is_std_target_except(t, stdfd))
+        (void)fs_close_fd(t);
+    vfs_std_target[stdfd] = -1;
+    vfs_std_alias[stdfd] = 0;
+}
+
+static int vfs_is_std_target_except(int fd, int skip) {
+    int i;
+    if (fd < 0) return 0;
+    for (i = 0; i < 3; i++) if (i != skip && vfs_std_target[i] == fd) return 1;
+    for (i = 0; i < VFS_SAVED_MAX; i++)
+        if (vfs_saved[i].used && vfs_saved[i].target == fd) return 1;
+    return 0;
+}
+
+int dup2(int oldfd, int newfd) {
+    if (newfd < 0 || newfd > 2) { nl_errno_slot = 9 /* EBADF */; return -1; }
+    if (oldfd >= VFS_SAVED_BASE && oldfd < VFS_SAVED_BASE + VFS_SAVED_MAX) {
+        /* Restoring a saved descriptor. */
+        VfsSaved *sv = &vfs_saved[oldfd - VFS_SAVED_BASE];
+        if (!sv->used) { nl_errno_slot = 9; return -1; }
+        vfs_std_release(newfd);
+        vfs_std_target[newfd] = sv->target;
+        vfs_std_alias[newfd] = sv->alias;
+        return newfd;
+    }
+    if (oldfd >= 0 && oldfd < 3) {           /* `2>&1` */
+        int t = vfs_std_target[oldfd];
+        vfs_std_release(newfd);
+        vfs_std_target[newfd] = t;
+        vfs_std_alias[newfd] = 1;
+        return newfd;
+    }
+    if (!fs_is_file_fd(oldfd)) { nl_errno_slot = 9; return -1; }
+    vfs_std_release(newfd);
+    vfs_std_target[newfd] = oldfd;
+    vfs_std_alias[newfd] = 0;
+    return newfd;
+}
+
+int dup(int fd) {
+    int i;
+    if (fd < 0 || fd > 2) { nl_errno_slot = 9; return -1; }
+    for (i = 0; i < VFS_SAVED_MAX; i++) {
+        if (vfs_saved[i].used) continue;
+        vfs_saved[i].used = 1;
+        vfs_saved[i].target = vfs_std_target[fd];
+        /* The save carries the OWNERSHIP with it. Recording it as a
+         * borrow instead loses track of who closes the file: restoring
+         * the descriptor would then leave the redirected file open and
+         * unflushed, which is how a `$(cmd | cmd)` came back empty —
+         * the capture file was still buffered when it was read. */
+        vfs_saved[i].alias = vfs_std_alias[fd];
+        return VFS_SAVED_BASE + i;
+    }
+    nl_errno_slot = 24 /* EMFILE */;
+    return -1;
+}
+
+/* fcntl(2), the F_DUPFD form only — which is how a shell saves a
+ * descriptor before redirecting it. Everything else is refused. */
+int fcntl(int fd, int cmd, long arg) {
+    (void)arg;
+    if (cmd != 0 /* F_DUPFD */) { nl_errno_slot = 38 /* ENOSYS */; return -1; }
+    return dup(fd);
+}
+
+/* Close a saved slot; ordinary descriptors go to fs_close_fd. */
+int vfs_close_saved(int fd) {
+    if (fd < VFS_SAVED_BASE || fd >= VFS_SAVED_BASE + VFS_SAVED_MAX) return 0;
+    vfs_saved[fd - VFS_SAVED_BASE].used = 0;
+    return 1;
+}
+
+/* ── the working directory ───────────────────────────────────────
+ *
+ * The guest has one namespace, and until now it had no cursor into it:
+ * every path was resolved from the root, so `cd` could not work and a
+ * shell script that changed directory and then opened a relative name
+ * opened the wrong thing — or nothing.
+ *
+ * One string, and one resolution step in front of every path-taking
+ * entry point. `..` and `.` are folded by the archive's own normaliser
+ * (initfs.c), so this only has to decide whether a path is absolute and
+ * prefix the cursor when it is not.
+ */
+#define VFS_CWD_MAX 512
+static char vfs_cwd[VFS_CWD_MAX] = "/";
+
+/* Make `path` absolute against the working directory AND fold away `.`
+ * and `..`. Both halves matter: the layers underneath — the archive's
+ * lookup and the FAT driver — walk the path component by component, and
+ * neither has a kernel in front of it to tidy `./tmp.abcdef` or
+ * `a/../b` first. `mkstemp` producing `./tmp.XXXXXX` is exactly how
+ * that showed up: a name the disk could not open, reported as "nowhere
+ * writable" on a machine with a perfectly good disk. */
+static const char *vfs_resolve(const char *path, char *buf, unsigned long cap) {
+    unsigned long n = 0, i = 0, out = 0;
+    static char tmp[VFS_CWD_MAX * 2];
+    const char *src;
+
+    if (!path) return path;
+    if (path[0] == '/') {
+        src = path;
+    } else {
+        while (vfs_cwd[n] && n + 2 < sizeof tmp) { tmp[n] = vfs_cwd[n]; n++; }
+        if (n == 0 || tmp[n - 1] != '/') tmp[n++] = '/';
+        while (path[i] && n + 1 < sizeof tmp) tmp[n++] = path[i++];
+        tmp[n] = 0;
+        src = tmp;
+    }
+
+    /* Fold the components. `..` at the root stays at the root, which is
+     * what every kernel does with `/..`. */
+    i = 0;
+    buf[out++] = '/';
+    for (;;) {
+        unsigned long start, len;
+        while (src[i] == '/') i++;
+        if (!src[i]) break;
+        start = i;
+        while (src[i] && src[i] != '/') i++;
+        len = i - start;
+        if (len == 1 && src[start] == '.') continue;
+        if (len == 2 && src[start] == '.' && src[start + 1] == '.') {
+            while (out > 1 && buf[out - 1] != '/') out--;
+            if (out > 1) out--;
+            continue;
+        }
+        if (out > 1 && out + 1 < cap) buf[out++] = '/';
+        {
+            unsigned long k = 0;
+            while (k < len && out + 1 < cap) buf[out++] = src[start + k++];
+        }
+    }
+    buf[out] = 0;
+    return buf;
+}
+
+char *getcwd(char *buf, unsigned long size) {
+    unsigned long n = 0;
+    if (!buf) { nl_errno_slot = 22 /* EINVAL */; return 0; }
+    while (vfs_cwd[n]) n++;
+    if (size < n + 1) { nl_errno_slot = 34 /* ERANGE */; return 0; }
+    for (n = 0; vfs_cwd[n]; n++) buf[n] = vfs_cwd[n];
+    buf[n] = 0;
+    return buf;
+}
+
+int chdir(const char *path) {
+    char tmp[VFS_CWD_MAX];
+    const char *full;
+    unsigned long n = 0;
+    if (!path) { nl_errno_slot = 22; return -1; }
+    full = vfs_resolve(path, tmp, sizeof tmp);
+    /* It has to BE a directory. A `cd` that succeeded onto a file would
+     * make every relative path after it fail for no visible reason. */
+    if (ifs_kind(full, 0) != 2) {
+        if (!(disk_live() && nurl_disk_is_dir && nurl_disk_is_dir(full) == 1)) {
+            nl_errno_slot = 2 /* ENOENT */;
+            return -1;
+        }
+    }
+    (void)n;
+    {
+        unsigned long i = 0, o = (full[0] == '/') ? 0 : 1;
+        if (o == 1) vfs_cwd[0] = '/';
+        while (full[i] && o + 1 < VFS_CWD_MAX) vfs_cwd[o++] = full[i++];
+        /* Strip a trailing slash so `cd /etc/` and `cd /etc` agree. */
+        while (o > 1 && vfs_cwd[o - 1] == '/') o--;
+        vfs_cwd[o] = 0;
+    }
+    return 0;
+}
+
+int nl_open(const char *path0, int flags, int mode) {
+    char rbuf[VFS_CWD_MAX];
+    const char *path;
+    if (!path0) { nl_errno_slot = 22 /* EINVAL */; return -1; }
+    path = vfs_resolve(path0, rbuf, sizeof rbuf);
 
     int wants_write = (flags & VFS_O_ACCMODE) != 0 || (flags & VFS_O_CREAT) != 0;
 
@@ -309,8 +544,11 @@ void *vfs_map_file(int fd, unsigned long len, long off) {
     return (void *)m;
 }
 
-int fs_exists(const char *path) {
-    if (!path) return 0;
+int fs_exists(const char *path0) {
+    char rbuf[VFS_CWD_MAX];
+    const char *path;
+    if (!path0) return 0;
+    path = vfs_resolve(path0, rbuf, sizeof rbuf);
     /* A directory exists as surely as a file does; `ifs_exists` only
      * answers about regular entries, which made `access` say no about
      * every directory in the image. */
@@ -368,21 +606,29 @@ long long pwrite(int fd, const void *buf, unsigned long n, long long off) {
  * reachable is a caller whose success path is now wrong.
  */
 
-int unlink(const char *p) {
+int unlink(const char *p0) {
+    char rbuf[VFS_CWD_MAX];
+    const char *p = vfs_resolve(p0, rbuf, sizeof rbuf);
     if (!p) { nl_errno_slot = 22; return -1; }
     if (disk_live() && nurl_disk_unlink) return posix_ret(nurl_disk_unlink(p));
     nl_errno_slot = ifs_exists(p) ? 30 /* EROFS */ : 2 /* ENOENT */;
     return -1;
 }
 
-int rename(const char *a, const char *b) {
+int rename(const char *a0, const char *b0) {
+    char rbuf_a[VFS_CWD_MAX];
+    char rbuf_b[VFS_CWD_MAX];
+    const char *a = vfs_resolve(a0, rbuf_a, sizeof rbuf_a);
+    const char *b = vfs_resolve(b0, rbuf_b, sizeof rbuf_b);
     if (!a || !b) { nl_errno_slot = 22; return -1; }
     if (disk_live() && nurl_disk_rename) return posix_ret(nurl_disk_rename(a, b));
     nl_errno_slot = 30;
     return -1;
 }
 
-int mkdir(const char *p, int mode) {
+int mkdir(const char *p0, int mode) {
+    char rbuf[VFS_CWD_MAX];
+    const char *p = vfs_resolve(p0, rbuf, sizeof rbuf);
     (void)mode;
     if (!p) { nl_errno_slot = 22; return -1; }
     if (disk_live() && nurl_disk_mkdir) return posix_ret(nurl_disk_mkdir(p));
@@ -390,14 +636,18 @@ int mkdir(const char *p, int mode) {
     return -1;
 }
 
-int rmdir(const char *p) {
+int rmdir(const char *p0) {
+    char rbuf[VFS_CWD_MAX];
+    const char *p = vfs_resolve(p0, rbuf, sizeof rbuf);
     if (!p) { nl_errno_slot = 22; return -1; }
     if (disk_live() && nurl_disk_rmdir) return posix_ret(nurl_disk_rmdir(p));
     nl_errno_slot = 30;
     return -1;
 }
 
-int truncate(const char *p, long long len) {
+int truncate(const char *p0, long long len) {
+    char rbuf[VFS_CWD_MAX];
+    const char *p = vfs_resolve(p0, rbuf, sizeof rbuf);
     if (!p) { nl_errno_slot = 22; return -1; }
     if (disk_live() && nurl_disk_truncate) return posix_ret(nurl_disk_truncate(p, len));
     nl_errno_slot = 30;
@@ -590,10 +840,13 @@ static void vfs_fill_stat(void *st, int is_dir, long long size) {
     vfs_put_u64(p + 64, (unsigned long long)((size + 511) / 512)); /* st_blocks */
 }
 
-static long vfs_stat_path(const char *path, void *st) {
+static long vfs_stat_path(const char *path0, void *st) {
+    char rbuf[VFS_CWD_MAX];
+    const char *path;
     vfs_size_t size = 0;
     int kind;
-    if (!path || !st) return -14 /* EFAULT */;
+    if (!path0 || !st) return -14 /* EFAULT */;
+    path = vfs_resolve(path0, rbuf, sizeof rbuf);
     kind = ifs_kind(path, &size);
     /* The archive's ROOT is a directory only when the archive has
      * something in it; an empty image must not shadow the disk's `/`. */

--- a/unikernel/nolibc/misc.c
+++ b/unikernel/nolibc/misc.c
@@ -328,6 +328,16 @@ char *realpath(const char *path, char *resolved) {
     }
 }
 
+/* statvfs(3) — a freestanding target has no filesystem statistics to
+ * report. The archive is a fixed span of the text segment and the FAT
+ * layer does not surface free-cluster counts, so `df` there must say
+ * "not supported" rather than print an empty disk. */
+int statvfs(const char *path, void *buf) {
+    (void)path; (void)buf;
+    errno = 38 /* ENOSYS */;
+    return -1;
+}
+
 /* localtime_r(3) — there is no zone database on a machine whose whole
  * filesystem may be its own text segment, and a -nostdlib Linux build
  * has no /etc/localtime reader either. The honest answer is "no local


### PR DESCRIPTION
The second half of the userland. `packages/nurlbox` goes from 69 applets
to **100**, and the one that matters most is **`sh`**.

| | |
|---|---|
| shell | `sh` |
| text | `fold` `expand` `unexpand` `paste` `comm` `shuf` `dos2unix` `unix2dos` |
| binary | `od` `hexdump` `xxd` `cmp` `dd` `strings` `split` |
| archives | `tar` `gzip` `gunzip` `zcat` |
| digests | `cksum` `sum` |
| processes | `ps` `kill` `killall` `pidof` `free` `uptime` `mount` `df` |
| misc | `factor`, and `nurlbox --install [-s] DIR` |

## The shell

A real one, not a dispatcher with an `if`:

- per-byte quote tracking, so `"$@"`, `echo "a b"` and `set "a b" c` are
  all right — anything less than a per-byte answer gets one of them wrong
- `$VAR` · `${VAR}` · `${VAR:-…}` · `${VAR:=…}` · `${VAR:+…}` ·
  `${VAR#pat}` · `${VAR##pat}` · `${VAR%pat}` · `${VAR%%pat}` · `${#VAR}`
- `$(…)`, backticks, `$((…))` with the full comparison/logic ladder
- globbing, field splitting on `IFS`, tilde expansion
- pipelines, redirections (`<` `>` `>>` `2>` `2>&1` `<<` `<<-`),
  `&&` / `||` / `!`, `;` and `&`
- `if` / `elif` / `while` / `until` / `for` / `case` / `{ }` / `( )`,
  functions, and the builtins (`cd export unset shift set read eval
  . source return break continue local type`)

**349 differential cases** — 49 of them through `sh` — run the same
command line through nurlbox and through busybox and require agreement on
stdout, on the bytes, and on the exit status.

## One decision shapes it: an applet runs in-process

When a command names one of nurlbox's own, the shell calls it directly
instead of exec'ing itself. That is busybox's standalone-shell trick, and
here it is what makes the shell work on a machine with **no `fork` at
all**.

Which is the other half of this PR. A unikernel guest now has:

- **`stat(2)` and directory listing** over the baked-in archive, as a
  **union** with the disk — read resolution is archive-first, so the
  listing is too;
- **a working directory**, with every path-taking entry point resolving
  against it and folding `.` / `..` — which is what `cd` is, and what
  made `mkstemp`'s `./tmp.XXXXXX` openable;
- **a redirection table** for descriptors 0–2 behind `dup` / `dup2` /
  `fcntl(F_DUPFD)`.

```
$ NURL_APPEND='args="sh hello.sh"' unikernel/run_qemu.sh nurlbox.elf …
nurlbox sh on a unikernel
file: etc/lines.txt
3 etc/lines.txt
count 1
count 2
count 3
found bravo
hello, world
running on NURL          ← case "$(uname -s)" in NURL) …
```

That is globbing, a `for` loop, `$((…))`, a function, `grep -q`, a
`case`, and a command substitution, inside a machine with one address
space and no processes. A pipeline there runs stage by stage through a
temporary file and **says so** — a machine that cannot run two things at
once should not pretend to — and says so again when it has nowhere
writable to put that file.

## Where the language was short, again fixed at the source

| | |
|---|---|
| `stdlib/std/fs.nu` | `FsStat` + `fs_statfs` — `df`'s question, through a new `statvfs` thunk. And `fs_tempfile "/"` stopped emitting `//tmp.XXXXXX` |
| `stdlib/std/path.nu` | `path_join "/" "x"` answered `"//x"` |
| `compiler/nurlc.nu` | an owned temporary handed to a **copying** consumer was not dropped: `( string_from ( nurl_str_slice … ) )` leaked its inner buffer, in every program that wrote it |
| `docs/MEMORY.md` | §7.4 gains the seam that cost an afternoon: a **capturing** closure passed straight to a generic callee is not proven invoke-only, so its env is the caller's to free |
| `unikernel/nolibc` | `realpath`, `fdopen`, `statvfs` and the rest of the surface the userland asked for |

The compiler change is worth a second look, because it is the one with
reach beyond this package. `mem_consumer_copy_safe` now covers
`string_from`, the `path_*` family, the string inspectors and
`nurl_eprint` — audited one at a time, with **`string_from_take`
deliberately excluded**: it has `string_from`'s shape exactly and
*adopts* the buffer instead of copying it, which is why that list is
hand-audited rather than derived from a signature.

## Gates

| | |
|---|---|
| hosted corpus | green — the bootstrap fixed point held across the compiler change |
| unikernel guest | 29/29 |
| nolibc corpus | 516 PASS / 0 FAIL |
| `nurlbox` suite | 348 PASS / 0 FAIL |
| ASan + LSan | clean across every applet and every shell construct |
| `tools/check_*` | package imports, version strings, stdlib symbols, builtins doc, nolibc symbols, strict arity — all green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyDDy4qzKJRsJd91x9e57P