### PR TITLE
dev: a container with the whole toolchain, not just clang

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "nurl-lang dev",
+
+  // The image is defined once, in containers/dev/Dockerfile, and shared
+  // by this file and containers/dev/run.sh. VS Code / GitHub Codespaces
+  // read this; the script is the plain-docker path. Neither is the
+  // source of truth for what is installed — the Dockerfile is.
+  "build": {
+    "dockerfile": "../containers/dev/Dockerfile",
+    "context": "../containers/dev"
+  },
+
+  "workspaceFolder": "/work",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/work,type=bind,consistency=cached",
+
+  "remoteUser": "dev",
+  "updateRemoteUserUID": true,
+
+  "runArgs": [
+    // gdb / strace / valgrind on a build inside the container. Narrower
+    // than --privileged: the debugger capability and the syscall surface
+    // those tools need, nothing more.
+    "--cap-add=SYS_PTRACE",
+    "--security-opt", "seccomp=unconfined"
+  ],
+
+  "mounts": [
+    // State that must outlive the container. Same volume names as
+    // containers/dev/run.sh, so a login done through either is visible
+    // to the other.
+    "source=nurl-dev-claude,target=/home/dev/.claude,type=volume",
+    "source=nurl-dev-state,target=/home/dev/.local/state,type=volume",
+    "source=nurl-dev-cache,target=/home/dev/.cache,type=volume",
+    "source=nurl-dev-nurl,target=/home/dev/.nurl,type=volume"
+  ],
+
+  // Credentials are forwarded, never baked into the image.
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "timonwong.shellcheck",
+        "ms-python.python"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "files.eol": "\n"
+      }
+    }
+  },
+
+  // The bind mount lands with the host's ownership; git refuses a repo
+  // it cannot vouch for, and every gate in this tree shells out to git.
+  // The image marks all directories safe system-wide, this is the
+  // belt-and-braces for a remapped uid.
+  "postCreateCommand": "git config --global --add safe.directory /work"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A development container** —
+  [`containers/dev/`](containers/dev/README.md), with a
+  `.devcontainer/` wired to the same image. `./containers/dev/run.sh`
+  drops you into a shell with the whole toolchain and the repo
+  bind-mounted at `/work`.
+
+  The compiler itself asks for very little: clang, and the committed
+  bootstrap IR does the rest. Everything *around* it does not. The
+  unikernel wants QEMU, GRUB, xorriso and mtools; the cross targets want
+  zig; the Workers under `registry/`, `webdocs/` and `nurlweb/` want Node,
+  pnpm and wrangler; the benchmark comparisons want Rust; the metamorph
+  and reference gates want Python with numpy. That is a long afternoon of
+  installing before the first interesting failure.
+
+  It is deliberately NOT `containers/ci`, which stays the union of the
+  three Linux jobs' package lists and nothing else — a convenience
+  package added for a human must never change what CI tests. This image
+  starts from that same set and adds the rest of a working day, including
+  `gh`, a debugger and Claude Code.
+
+  Verified by running the real gates inside it against a real checkout:
+  `build.sh` (bootstrap fixed point + corpus), `run_nolibc_tests.sh`,
+  the nolibc unit gates, and the QEMU guest suites on x86 (29/29) and
+  AArch64 (19/19). 3.6 GB; three build ARGs (`INCLUDE_RUST`,
+  `INCLUDE_QEMU_CROSS`, `INCLUDE_WRANGLER`) trade capability for size.
+
+  Two of the three defects in it were only visible from running it.
+  `corepack`'s pnpm downloads itself on first use into `~/.cache`, which
+  the launcher then hides behind a named volume — so every fresh
+  container would have re-fetched it and an offline one would have had no
+  pnpm at all. And `busybox` was missing: `packages/nurlbox` uses it as
+  its differential oracle and *skips* when it is absent, which reads
+  exactly like a suite that passed.
+
 ## [0.53.0] — 2026-08-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,19 @@ directly into a working boot compiler. Windows users have `build.bat`;
 macOS builds with Homebrew LLVM (`brew install llvm`) but is not covered
 by CI.
 
+Work beyond the compiler proper — the unikernel (QEMU, GRUB, xorriso),
+the cross-compiled targets (zig), the Cloudflare Workers (Node, pnpm,
+wrangler), the benchmark comparisons (Rust) — needs more than clang. If
+you would rather not install all of that on your machine, there is a
+prepared container:
+
+```sh
+./containers/dev/run.sh          # shell with the whole toolchain
+```
+
+See [`containers/dev/README.md`](containers/dev/README.md); VS Code and
+Codespaces users can "Reopen in Container" instead.
+
 Compile and run a single program:
 
 ```sh

--- a/containers/dev/Dockerfile
+++ b/containers/dev/Dockerfile
@@ -1,0 +1,383 @@
+# containers/dev/Dockerfile — the full development environment, in a box.
+#
+# Why this exists, and how it differs from containers/ci/Dockerfile:
+#
+#   containers/ci  is the CI environment: the UNION of the three Linux
+#                  jobs' package lists and nothing else. It is pinned by
+#                  dated tag in ci.yml, it runs as root, and every byte
+#                  in it is there because a workflow step needs it.
+#
+#   containers/dev (this file) is a WORKBENCH. It is what a human — or a
+#                  coding agent — needs to sit down in a clean checkout
+#                  and do a day's work without hitting a "command not
+#                  found" every twenty minutes: the CI set, plus the
+#                  ecosystem toolchains (Node/pnpm for the Cloudflare
+#                  Workers under registry/, webdocs/, nurlweb/; Rust and
+#                  Node for the bench comparison programs; Python with
+#                  numpy for the metamorph / fuzz / reference gates),
+#                  plus git, gh, an editor, a debugger and a shell that
+#                  is pleasant to be in.
+#
+# The two are deliberately NOT the same image. CI wants a small, audited,
+# reproducible surface; a dev box wants coverage. Keeping them separate
+# means a convenience package added here can never change what CI tests.
+#
+# Size budget: ~5 GB. The three optional blocks below (Rust, the
+# non-x86 QEMU system emulators, the global wrangler) are what you trim
+# first if you need to go smaller — see the ARGs.
+#
+# Build (from the repo root or anywhere; the build context is tiny):
+#
+#   docker build -t nurllang/dev:latest containers/dev
+#
+# Run — see containers/dev/run.sh, which mounts the repo, forwards your
+# git/gh/Claude credentials and keeps agent state in named volumes.
+#
+# ubuntu:24.04 to match containers/ci and the ubuntu-latest runners, so
+# a failure reproduced here is a failure CI will also see. clang 18 and
+# glibc 2.39 are the versions the compiler's IR output is tuned against.
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH=amd64
+
+# ── Optional blocks ────────────────────────────────────────────────────
+# Flip any of these to 0 to trade a capability for image size.
+#   INCLUDE_RUST       ~700 MB — bench/*.rs comparison programs (bench.sh
+#                      builds them with rustc/cargo). Nothing in the
+#                      compiler or stdlib needs it.
+#   INCLUDE_QEMU_CROSS ~900 MB — qemu-system-arm + qemu-system-misc, for
+#                      booting the aarch64 / riscv64 unikernel targets.
+#                      qemu-system-x86 is NOT optional: the unikernel
+#                      test path and unikernel/bench_boot.sh need it.
+#   INCLUDE_WRANGLER   ~150 MB — the Cloudflare CLI, preinstalled so the
+#                      Worker directories do not each npx-fetch their own
+#                      copy on first use.
+ARG INCLUDE_RUST=1
+ARG INCLUDE_QEMU_CROSS=1
+ARG INCLUDE_WRANGLER=1
+
+# Versions that are fetched rather than apt-installed. Pinned so a
+# rebuild is a reviewed diff, not a moving target.
+ARG ZIG_VERSION=0.16.0
+ARG NODE_MAJOR=24
+ARG RUST_VERSION=1.97.1
+
+# The container user. Match your host uid/gid (the default 1000:1000 is
+# the first interactive user on Debian/Ubuntu/Fedora) so that files the
+# container writes into the bind-mounted work-tree stay yours, and the
+# ones your host editor writes stay writable in here. run.sh passes the
+# real values through.
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# ── 1. The CI package set ──────────────────────────────────────────────
+# Everything containers/ci installs, so anything that reproduces in CI
+# reproduces here. Two notes carried over from that file because they
+# cost real debugging time to learn:
+#
+#   libclang-rt-dev — Ubuntu 24 splits the sanitizer runtimes out of the
+#   `clang` package. Without it `build.sh --san` dies with "cannot find
+#   libclang_rt.asan-x86_64.a".
+#
+#   The grub/mtools/xorriso trio is what unikernel/build_bootable_image.sh
+#   shells out to; it checks for each by name and refuses early.
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        bash \
+        binutils \
+        ca-certificates \
+        clang \
+        curl \
+        gdb \
+        git \
+        grub-common \
+        grub-efi-amd64-bin \
+        grub-pc-bin \
+        jq \
+        libclang-rt-dev \
+        libcurl4-openssl-dev \
+        libpq-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libzstd-dev \
+        llvm \
+        mtools \
+        openssl \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-xxhash \
+        qemu-system-x86 \
+        sudo \
+        xorriso \
+        xz-utils \
+        zlib1g-dev \
+        zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 2. What a workbench adds on top ────────────────────────────────────
+# build-essential: gcc/make. The compiler itself needs clang (nurlc emits
+#   LLVM IR, which gcc cannot consume — nurl.sh says so explicitly), but
+#   bench/*.c, node-gyp and any pip source build want a working cc.
+# lld: the LTO link path, and the linker zig would otherwise shadow.
+# clang-format/clang-tidy: stdlib/*.c and unikernel/**.c hygiene.
+# valgrind/strace/ltrace: the leak + syscall gates under tools/ reach for
+#   these when ASan is not the right instrument.
+# shellcheck: there are ~60 .sh files in this repo driving the gates.
+# python3-numpy: the reference implementations under packages/*/tests
+#   (gguf, tensor, nurllama) and bench/genacc/score.py. python3-venv +
+#   python3-dev so the heavier optional deps (torch, tiktoken — several
+#   GB, deliberately NOT baked in) can be added on demand in a venv.
+# postgresql-client / redis-tools / sqlite3: NURL speaks these protocols
+#   in pure NURL, but debugging a wire-format mismatch means having the
+#   reference client to compare against.
+# busybox-static: the DIFFERENTIAL ORACLE for packages/nurlbox — its
+#   test suite runs each applet against busybox and compares stdout and
+#   exit status, and where busybox is absent it SKIPS. A suite whose
+#   default state is "skipped" reads exactly like a suite that passed,
+#   so this is not a convenience package.
+# minisign: tools/ package-signing gates.
+# dosfstools: mkfs.vfat for the unikernel FAT image path.
+# qemu-utils: qemu-img, for the virtio-blk disk images.
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        bsdextrautils \
+        build-essential \
+        busybox-static \
+        clang-format \
+        clang-tidy \
+        cmake \
+        diffutils \
+        dnsutils \
+        dosfstools \
+        fd-find \
+        file \
+        git-lfs \
+        gnupg \
+        htop \
+        iproute2 \
+        iputils-ping \
+        less \
+        libncurses-dev \
+        lld \
+        locales \
+        ltrace \
+        make \
+        man-db \
+        minisign \
+        nano \
+        netcat-openbsd \
+        ninja-build \
+        openssh-client \
+        patch \
+        postgresql-client \
+        procps \
+        psmisc \
+        python3-dev \
+        python3-numpy \
+        python3-venv \
+        qemu-utils \
+        redis-tools \
+        ripgrep \
+        rsync \
+        shellcheck \
+        socat \
+        sqlite3 \
+        strace \
+        time \
+        tmux \
+        tree \
+        tzdata \
+        unzip \
+        uuid-runtime \
+        valgrind \
+        vim \
+        wget \
+        xxd \
+        zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && ln -sf /bin/busybox /usr/local/bin/busybox
+
+# Non-x86 system emulators for the cross-compiled unikernel targets.
+# Separate layer so INCLUDE_QEMU_CROSS=0 drops ~900 MB cleanly instead of
+# poisoning the big layer above.
+RUN if [ "${INCLUDE_QEMU_CROSS}" = "1" ]; then \
+        apt-get update -qq && apt-get install -y --no-install-recommends \
+            qemu-system-arm \
+            qemu-system-misc \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# UTF-8 everywhere. nurlc's diagnostics draw carets under multi-byte
+# source, the test goldens contain UTF-8, and a C locale turns both into
+# mojibake that reads like a real diff.
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# ── 3. GitHub CLI ──────────────────────────────────────────────────────
+# From GitHub's own apt repo rather than Ubuntu's, which ships a `gh` old
+# enough to be missing subcommands the release/PR flows use.
+RUN curl -fsSL --retry 5 https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update -qq \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 3b. cloud-hypervisor ───────────────────────────────────────────────
+# The OTHER PVH loader. unikernel/tests/run_unit_tests.sh's
+# hypervisor_gate boots the SAME ELF QEMU boots — both read the PVH note
+# — which is the cheapest check that the image is not secretly a QEMU
+# image. Without the binary the gate SKIPS, and a skip that is the
+# default reads like a pass. ci.yml curls it per run; 4.5 MB is cheaper
+# baked in. amd64 only: upstream ships no aarch64 static build.
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -fsSL --retry 5 -o /usr/local/bin/cloud-hypervisor \
+            https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v46.0/cloud-hypervisor-static \
+        && chmod +x /usr/local/bin/cloud-hypervisor; \
+    fi
+
+# ── 4. Node + pnpm ─────────────────────────────────────────────────────
+# The workflows use both actions/setup-node (node 22 and 24) and
+# pnpm/action-setup. The Cloudflare Workers under registry/, webdocs/,
+# nurlweb/ and cloudflare/ are the consumers, together with the .mjs
+# generators in tools/ (gen-bench-table, gen-contributors).
+# NodeSource because Ubuntu 24.04's own nodejs is v18.
+#
+# pnpm comes from npm, NOT from corepack. `corepack prepare` installs a
+# shim that downloads the real pnpm into ~/.cache/node/corepack on first
+# use — which run.sh then hides behind a named cache volume, so every
+# fresh container re-downloads it and an offline one has no pnpm at all.
+# A global npm install lands in /usr/lib/node_modules and is immune.
+RUN curl -fsSL --retry 5 https://deb.nodesource.com/setup_${NODE_MAJOR}.x -o /tmp/nodesource_setup.sh \
+    && bash /tmp/nodesource_setup.sh \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -f /tmp/nodesource_setup.sh \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm config set fund false --global \
+    && npm config set update-notifier false --global \
+    && npm install -g pnpm \
+    && npm cache clean --force \
+    && pnpm --version
+
+# Preinstalled so each Worker directory does not npx-fetch its own copy
+# into a throwaway cache the first time it is touched.
+RUN if [ "${INCLUDE_WRANGLER}" = "1" ]; then \
+        npm install -g wrangler && npm cache clean --force; \
+    fi
+
+# ── 5. Zig ─────────────────────────────────────────────────────────────
+# The same version and the same path as containers/ci and the ecosystem
+# installers (install.sh, the playground image), so NURL_ZIG=/opt/zig/zig
+# means the same thing in all of them. Zig is the cross-compiler: the
+# aarch64/riscv64 targets and the Windows MinGW runtime object are built
+# with `zig cc -target ...`, which is how the whole Windows link path is
+# diagnosed from Linux.
+#
+# Deliberately NO global ENV NURL_ZIG — the same trap containers/ci
+# documents: nurl.sh prefers a bundled zig when it sees one, and zig's
+# ASan runtime is a different LLVM generation from system clang 18's
+# instrumentation, so a sanitizer build links against a runtime_san.o it
+# cannot resolve ("undefined symbol: __asan_unregister_elf_globals").
+# Set NURL_ZIG per-command when you want zig; leave it unset otherwise.
+RUN case "${TARGETARCH}" in \
+        amd64) ZIG_ARCH=x86_64 ;; \
+        arm64) ZIG_ARCH=aarch64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL --retry 5 -o /tmp/zig.tar.xz \
+        "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz" \
+    && mkdir -p /opt/zig \
+    && tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1 \
+    && rm /tmp/zig.tar.xz \
+    && /opt/zig/zig version
+ENV PATH="/opt/zig:${PATH}"
+
+# ── 6. The user ────────────────────────────────────────────────────────
+# ubuntu:24.04 already ships a uid-1000 `ubuntu` account, which collides
+# with the common host uid. Rename it into ours rather than fighting it.
+RUN if getent group ${USER_GID} >/dev/null; then \
+        groupmod -n ${USERNAME} "$(getent group ${USER_GID} | cut -d: -f1)"; \
+    else \
+        groupadd -g ${USER_GID} ${USERNAME}; \
+    fi \
+    && if getent passwd ${USER_UID} >/dev/null; then \
+        usermod -l ${USERNAME} -d /home/${USERNAME} -m -s /bin/bash \
+            "$(getent passwd ${USER_UID} | cut -d: -f1)"; \
+    else \
+        useradd -u ${USER_UID} -g ${USER_GID} -m -s /bin/bash ${USERNAME}; \
+    fi \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# The work-tree arrives as a bind mount owned by the host uid. Even when
+# that matches, git refuses a repo whose owner it cannot vouch for after
+# any uid remap, and every gate in this repo shells out to git.
+RUN git config --system --add safe.directory '*'
+
+# ── 7. Rust ────────────────────────────────────────────────────────────
+# bench/*.rs — the comparison half of every benchmark in bench/RESULTS.md.
+# Installed as the user (rustup is per-user by design) with the minimal
+# profile: rustc, cargo, rust-std. No docs, no rust-analyzer component.
+USER ${USERNAME}
+ENV HOME=/home/${USERNAME}
+ENV CARGO_HOME=${HOME}/.cargo \
+    RUSTUP_HOME=${HOME}/.rustup
+RUN if [ "${INCLUDE_RUST}" = "1" ]; then \
+        curl -fsSL --retry 5 https://sh.rustup.rs -o /tmp/rustup.sh \
+        && sh /tmp/rustup.sh -y --no-modify-path --profile minimal \
+            --default-toolchain ${RUST_VERSION} \
+        && rm -f /tmp/rustup.sh \
+        && ${CARGO_HOME}/bin/rustc --version; \
+    fi
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+
+# ── 8. Claude Code ─────────────────────────────────────────────────────
+# The agent this box is for. Installs to ~/.local/bin/claude.
+#
+# Last layer on purpose: it is the fastest-moving piece, and putting it
+# here means a `claude` bump rebuilds one small layer instead of the
+# 4 GB of toolchain above it.
+#
+# No credentials are baked in — the install only places the binary.
+# Authentication lives in ~/.claude, which run.sh keeps in a named volume
+# so a `claude /login` survives the container.
+ENV PATH="${HOME}/.local/bin:${PATH}"
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && claude --version
+
+# ── 9. Shell environment ───────────────────────────────────────────────
+# NURL_HOME is where tools/install-toolchain.sh puts an installed
+# toolchain; putting its bin/ on PATH up front means `nurlpkg install
+# <tool>` produces something runnable without a re-login.
+ENV NURL_HOME=${HOME}/.nurl
+ENV PATH="${NURL_HOME}/bin:${PATH}"
+
+# Non-login, non-interactive shells (`docker exec ... bash -c`, and every
+# tool that spawns `sh -c`) do not read .bashrc, so the PATH above is set
+# as ENV and this file only carries the interactive niceties.
+RUN printf '%s\n' \
+    '# nurl-lang dev container' \
+    'export HISTSIZE=100000 HISTFILESIZE=100000 HISTCONTROL=ignoreboth' \
+    'shopt -s histappend checkwinsize' \
+    "PS1='\\[\\e[38;5;39m\\]nurl\\[\\e[0m\\]:\\[\\e[38;5;114m\\]\\w\\[\\e[0m\\]\\$ '" \
+    'alias ll="ls -alF"' \
+    '# The repo drives everything through these; keep them one keystroke away.' \
+    'alias b="./build.sh"' \
+    'alias c="./check.sh"' \
+    >> ${HOME}/.bashrc
+
+# Keep the shell history in the state volume run.sh mounts, so it
+# survives `docker rm`.
+RUN mkdir -p ${HOME}/.local/state ${HOME}/.claude ${HOME}/.config
+ENV HISTFILE=${HOME}/.local/state/bash_history
+
+WORKDIR /work
+CMD ["/bin/bash", "-l"]

--- a/containers/dev/README.md
+++ b/containers/dev/README.md
@@ -1,0 +1,143 @@
+# The NURL dev container
+
+A workbench in a box: everything needed to build the compiler, run the
+gates, boot the unikernel, deploy the Workers and drive a coding agent —
+without installing any of it on the host.
+
+```bash
+./containers/dev/run.sh            # builds on first use, then drops you in a shell
+./containers/dev/run.sh claude     # straight into the agent
+./containers/dev/run.sh ./build.sh # one-shot command, then exit
+```
+
+The repo is bind-mounted at `/work`, owned by your host uid, so edits go
+both ways and nothing in the container can leave a root-owned file behind.
+
+## Why this is not `containers/ci`
+
+`containers/ci/Dockerfile` is the CI environment: the union of the three
+Linux jobs' package lists and nothing more, pinned by dated tag in
+`ci.yml`. Every byte in it is there because a workflow step needs it, and
+it should stay that way — a convenience package added for a human must
+never change what CI tests.
+
+This image starts from that same set and adds the rest of a working day:
+the ecosystem toolchains, the debuggers, an editor, `git`, `gh`, and
+Claude Code.
+
+## What is in it
+
+| Area | Tools |
+|---|---|
+| Compiler | `clang` 18, `llvm`, `lld`, `libclang-rt-dev` (ASan/UBSan), `gdb`, `valgrind`, `strace`, `ltrace` |
+| Cross / freestanding | `zig` 0.16 at `/opt/zig`, `qemu-system-{x86,arm,misc}`, `cloud-hypervisor`, `grub-{pc,efi-amd64}-bin`, `xorriso`, `mtools`, `dosfstools`, `qemu-utils` |
+| FFI dev libs | `libssl`, `libcurl`, `libsqlite3`, `libpq`, `libzstd`, `zlib` |
+| Ecosystem web | Node 24, `pnpm` (corepack), `wrangler` |
+| Scripting / gates | Python 3.12 + `numpy` + `xxhash` + `venv`, `shellcheck`, `jq`, `openssl`, `minisign` |
+| Benchmarks | Rust 1.97 (`rustc`/`cargo`), Node, Python — the comparison half of `bench/` |
+| Protocol debugging | `psql`, `redis-cli`, `sqlite3`, `socat`, `nc`, `dig` |
+| Differential oracles | `busybox` (for `packages/nurlbox`), GNU coreutils, `openssl`, `zstd` |
+| Everyday | `git`, `git-lfs`, `gh`, `ripgrep`, `fd`, `tmux`, `vim`, `nano`, `htop`, `tree`, `rsync`, `less`, `xxd`, `column`, `uuidgen` |
+| Agent | Claude Code (`claude`) |
+
+Deliberately **not** in it:
+
+* **A GPU stack.** No CUDA, no ROCm, no `nvidia-container-toolkit`. The
+  GPU packages (`packages/gpukit`, `packages/onnx`, …) are developed
+  against a real device on the host.
+* **PyTorch / tiktoken / onnxruntime.** Several GB for reference tests
+  that a handful of packages run occasionally. `python3-venv` is
+  installed so they are one command away when you need them:
+
+  ```bash
+  python3 -m venv ~/.cache/venv-ml && ~/.cache/venv-ml/bin/pip install torch numpy
+  ```
+
+* **The Docker CLI.** `dockerpush.sh` and the playground image build on
+  the host; mount `/var/run/docker.sock` yourself if you want that here.
+
+## Size, and how to shrink it
+
+The image lands around 4–5 GB. Three blocks are the bulk of the
+discretionary part and each is a build ARG:
+
+```bash
+docker build \
+    --build-arg INCLUDE_RUST=0 \
+    --build-arg INCLUDE_QEMU_CROSS=0 \
+    --build-arg INCLUDE_WRANGLER=0 \
+    -t nurllang/dev:slim containers/dev
+```
+
+| ARG | Cost | What you lose |
+|---|---|---|
+| `INCLUDE_RUST` | ~700 MB | the `bench/*.rs` comparison programs |
+| `INCLUDE_QEMU_CROSS` | ~900 MB | booting the aarch64 / riscv64 unikernel targets (x86 still works) |
+| `INCLUDE_WRANGLER` | ~150 MB | a preinstalled Cloudflare CLI (`npx wrangler` still works, online) |
+
+## State, credentials and the agent
+
+Nothing secret is baked into the image. `run.sh` forwards what it finds
+on the host and keeps mutable state in named volumes, so `docker rm` is
+never destructive:
+
+| Volume | Mounted at | Holds |
+|---|---|---|
+| `nurl-dev-claude` | `~/.claude` | agent auth + session state |
+| `nurl-dev-state` | `~/.local/state` | shell history |
+| `nurl-dev-cache` | `~/.cache` | npm / pip / cargo download caches |
+| `nurl-dev-nurl` | `~/.nurl` | an installed NURL toolchain |
+
+Forwarded from the host when present: `~/.gitconfig` (read-only),
+`~/.ssh` (read-only), `$SSH_AUTH_SOCK`, `$ANTHROPIC_API_KEY`, and a
+GitHub token taken from `$GH_TOKEN`, `$GITHUB_TOKEN` or `gh auth token`.
+
+Claude Code starts logged out. Either run `claude` and `/login` once —
+the volume keeps it — or copy the host's credentials in on first run:
+
+```bash
+./containers/dev/run.sh --seed-claude claude
+```
+
+`/dev/kvm` is passed through when the host exposes it, which is the
+difference between a unikernel boot test taking a second and taking a
+minute. Without it QEMU falls back to TCG and everything still works.
+
+## First run inside
+
+```bash
+./build.sh                 # bootstrap the compiler + run the corpus
+./check.sh stdlib/std/fs.nu # ~0.2 s per-file syntax/type check
+```
+
+`build.sh` is the gate; `check.sh` is the loop. Note that `build.sh` does
+*not* run `tools/check_stdlib_symbols.sh`, `tools/check_nolibc_symbols.sh`
+or `tools/check_examples.sh` — run those before pushing.
+
+Sanitizer builds work out of the box (`./build.sh --san`), but leave
+`NURL_ZIG` unset for them. The image ships zig at `/opt/zig/zig` and
+deliberately does not export `NURL_ZIG`: `nurl.sh` prefers a bundled zig
+when it sees one, and zig's ASan runtime is a different LLVM generation
+from system clang 18's instrumentation — mixing them fails to link with
+`undefined symbol: __asan_unregister_elf_globals`. Point `NURL_ZIG` at it
+per-command when you want the cross-compiler:
+
+```bash
+NURL_ZIG=/opt/zig/zig ./unikernel/build_bootable_image.sh
+```
+
+## VS Code / Codespaces
+
+`.devcontainer/devcontainer.json` builds this same Dockerfile and mounts
+the same volumes, so a login done through either path is visible to the
+other. "Reopen in Container" is all it takes.
+
+## Rebuilding
+
+```bash
+./containers/dev/run.sh --build     # rebuild, reusing layers
+./containers/dev/run.sh --rebuild   # --no-cache
+```
+
+Claude Code is the last layer on purpose: bumping it rebuilds one small
+layer instead of the toolchain above it.

--- a/containers/dev/run.sh
+++ b/containers/dev/run.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  containers/dev/run.sh — open a shell in the dev container.
+#
+#  The image (containers/dev/Dockerfile) carries the toolchain;
+#  this script carries the *wiring*: which host directories are
+#  visible inside, which credentials are forwarded, and what
+#  state survives the container being thrown away.
+#
+#  Usage:
+#    ./containers/dev/run.sh                # interactive shell
+#    ./containers/dev/run.sh claude         # straight into the agent
+#    ./containers/dev/run.sh ./build.sh     # one-shot command
+#
+#  Flags (before the command):
+#    --build          (re)build the image first
+#    --rebuild        build with --no-cache
+#    --name NAME      container name (default: nurl-dev)
+#    --fresh          remove the existing container first
+#    --seed-claude    copy the host's ~/.claude credentials in on
+#                     first run, so the agent starts logged in
+#    --root           run as root inside (package installs etc.)
+#
+#  What persists across runs (docker named volumes, so `docker rm`
+#  does not lose them):
+#    nurl-dev-claude   ~/.claude          agent auth + session state
+#    nurl-dev-state    ~/.local/state     shell history
+#    nurl-dev-cache    ~/.cache           npm/pip/cargo download caches
+#    nurl-dev-nurl     ~/.nurl            installed NURL toolchain
+#
+#  What is NOT baked into the image and is forwarded from the host
+#  instead, because it is a secret: the git identity, the gh token,
+#  the ssh agent socket.
+# ============================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="${NURL_DEV_IMAGE:-nurllang/dev:latest}"
+NAME="nurl-dev"
+DO_BUILD=0
+NO_CACHE=0
+FRESH=0
+SEED_CLAUDE=0
+AS_ROOT=0
+
+usage() { sed -n '4,36p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,\} \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build)       DO_BUILD=1; shift ;;
+        --rebuild)     DO_BUILD=1; NO_CACHE=1; shift ;;
+        --name)        NAME="$2"; shift 2 ;;
+        --fresh)       FRESH=1; shift ;;
+        --seed-claude) SEED_CLAUDE=1; shift ;;
+        --root)        AS_ROOT=1; shift ;;
+        --help|-h)     usage; exit 0 ;;
+        --)            shift; break ;;
+        *)             break ;;
+    esac
+done
+
+command -v docker >/dev/null 2>&1 || {
+    echo "ERROR: docker not found on PATH." >&2
+    exit 127
+}
+
+if [[ $DO_BUILD -eq 1 ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo ">> building $IMAGE (this takes a few minutes the first time)"
+    build_args=(--build-arg "USER_UID=$(id -u)" --build-arg "USER_GID=$(id -g)")
+    [[ $NO_CACHE -eq 1 ]] && build_args+=(--no-cache)
+    docker build "${build_args[@]}" -t "$IMAGE" "$REPO_ROOT/containers/dev"
+fi
+
+# The command to run inside. Default is a login shell.
+if [[ $# -eq 0 ]]; then
+    CMD=(bash -l)
+else
+    CMD=("$@")
+fi
+
+if [[ $FRESH -eq 1 ]]; then
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+fi
+
+# `docker run -it` without a terminal dies with "the input device is not
+# a TTY", which is exactly how this script gets called from another
+# script or an agent. Allocate a TTY only when there is one to allocate.
+TTY_ARGS=(-i)
+[[ -t 0 && -t 1 ]] && TTY_ARGS=(-it)
+
+# An already-running container: attach a second shell to it rather than
+# starting a rival one on the same bind mount.
+if docker ps --format '{{.Names}}' | grep -qx "$NAME"; then
+    echo ">> attaching to running container '$NAME'"
+    exec_args=("${TTY_ARGS[@]}" -w /work)
+    [[ $AS_ROOT -eq 1 ]] && exec_args+=(-u root)
+    exec docker exec "${exec_args[@]}" "$NAME" "${CMD[@]}"
+fi
+# A stopped leftover of the same name would block `docker run`.
+if docker ps -a --format '{{.Names}}' | grep -qx "$NAME"; then
+    docker rm -f "$NAME" >/dev/null
+fi
+
+# Named volumes for the state that must outlive the container.
+for v in claude state cache nurl; do
+    docker volume create "nurl-dev-$v" >/dev/null
+done
+
+HOME_IN=/home/dev
+[[ $AS_ROOT -eq 1 ]] && HOME_IN=/root
+
+args=(
+    --name "$NAME"
+    --rm
+    "${TTY_ARGS[@]}"
+    --hostname nurl-dev
+    -v "$REPO_ROOT:/work"
+    -w /work
+    -v "nurl-dev-claude:${HOME_IN}/.claude"
+    -v "nurl-dev-state:${HOME_IN}/.local/state"
+    -v "nurl-dev-cache:${HOME_IN}/.cache"
+    -v "nurl-dev-nurl:${HOME_IN}/.nurl"
+)
+
+[[ $AS_ROOT -eq 1 ]] && args+=(-u root)
+
+# ── Credentials, forwarded rather than baked ───────────────────────────
+
+# git identity: read-only, so an accidental `git config --global` inside
+# the container cannot rewrite the host's file.
+[[ -f "$HOME/.gitconfig" ]] && args+=(-v "$HOME/.gitconfig:${HOME_IN}/.gitconfig:ro")
+
+# gh: a token in the environment is the container-friendly form and beats
+# mounting the host's credential store, which gh rewrites in place.
+if [[ -n "${GH_TOKEN:-}" ]]; then
+    args+=(-e "GH_TOKEN=${GH_TOKEN}")
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    args+=(-e "GH_TOKEN=${GITHUB_TOKEN}")
+elif command -v gh >/dev/null 2>&1 && tok="$(gh auth token 2>/dev/null)" && [[ -n "$tok" ]]; then
+    args+=(-e "GH_TOKEN=${tok}")
+fi
+
+# ssh-agent, for git-over-ssh and signed commits. Forwarding the socket
+# keeps the private key itself on the host.
+if [[ -n "${SSH_AUTH_SOCK:-}" && -S "${SSH_AUTH_SOCK}" ]]; then
+    args+=(-v "${SSH_AUTH_SOCK}:/ssh-agent" -e "SSH_AUTH_SOCK=/ssh-agent")
+fi
+[[ -d "$HOME/.ssh" ]] && args+=(-v "$HOME/.ssh:${HOME_IN}/.ssh:ro")
+
+# An API key in the environment is honoured by Claude Code as-is; a
+# subscription login instead lives in the ~/.claude volume.
+[[ -n "${ANTHROPIC_API_KEY:-}" ]] && args+=(-e "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
+
+# --seed-claude mounts the host's credentials at /seed and copies them in
+# without clobbering (`cp -n`), so it is a no-op on later runs.
+if [[ $SEED_CLAUDE -eq 1 && -d "$HOME/.claude" ]]; then
+    echo ">> seeding ~/.claude from the host (existing files are kept)"
+    args+=(-v "$HOME/.claude:/seed/.claude:ro")
+    printf -v inner '%q ' "${CMD[@]}"
+    CMD=(bash -lc "cp -rn /seed/.claude/. \"\$HOME/.claude/\" 2>/dev/null || true; exec ${inner}")
+fi
+
+# ── QEMU acceleration ──────────────────────────────────────────────────
+# The unikernel boot tests run far faster with KVM. Only offered when the
+# host actually exposes /dev/kvm; without it QEMU falls back to TCG and
+# everything still works, just slower.
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    args+=(--device /dev/kvm)
+fi
+
+# ptrace, for gdb/strace/valgrind on a build inside the container.
+# Narrower than --privileged: it grants the debugger capability and the
+# syscall surface those tools need, and nothing else.
+args+=(--cap-add=SYS_PTRACE --security-opt seccomp=unconfined)
+
+exec docker run "${args[@]}" "$IMAGE" "${CMD[@]}"


### PR DESCRIPTION
`./containers/dev/run.sh` drops you into a shell with everything this repo actually needs, and the work-tree bind-mounted at `/work`.

## Why

The compiler asks for very little — clang, plus the committed bootstrap IR. Everything around it does not. The unikernel wants QEMU, GRUB, xorriso and mtools; the cross targets want zig; the Workers under `registry/`, `webdocs/` and `nurlweb/` want Node, pnpm and wrangler; the benchmark comparisons want Rust; the metamorph and reference gates want Python with numpy. `CONTRIBUTING.md` says "clang/LLVM 15+. Nothing else", which is true of `./build.sh` and of nothing past it.

## Why not `containers/ci`

That image is the union of the three Linux jobs' package lists and nothing more, pinned by dated tag in `ci.yml`, and it should stay that way — a convenience package added for a human must never change what CI tests.

This one starts from that same set and adds the rest of a working day: `gh`, a debugger, an editor, the ecosystem toolchains, and Claude Code as the last layer so bumping it rebuilds one small layer instead of the 3 GB below it.

## Verification

Ran the real gates inside the image against a real checkout, rather than reading package lists:

| Gate | Result |
|---|---|
| `./build.sh` (bootstrap fixed point + corpus) | BUILD SUCCESS & TESTS PASSED |
| `zig cc` for all six playground cross targets (2× Mach-O) | 6/6 |
| `./unikernel/run_nolibc_tests.sh` | FAIL 0 |
| `./unikernel/tests/run_unit_tests.sh` | all, incl. `hypervisor_gate` + `baremetal_gate` (a real BIOS boot through the grub/xorriso/mtools chain) |
| `./unikernel/run_qemu_tests.sh` (x86) | 29/29, incl. `nurlc.wasm` compiling in the guest and virtio-blk |
| `./unikernel/run_qemu_arm64_tests.sh` | 19/19 |
| `run.sh` end to end | uid 1000, `gh` authenticated, `claude` 2.1.247 |

3.6 GB. `INCLUDE_RUST` (~700 MB), `INCLUDE_QEMU_CROSS` (~900 MB) and `INCLUDE_WRANGLER` (~150 MB) trade capability for size.

## What running it found

Two of the three defects here were invisible until the image ran:

1. **`corepack`'s pnpm downloads itself on first use** into `~/.cache` — which `run.sh` then hides behind a named volume. Every fresh container would have re-fetched it, and an offline one would have had no pnpm at all. It now comes from npm, into `/usr/lib/node_modules`.
2. **`busybox` was missing.** `packages/nurlbox` uses it as its differential oracle and *skips* when it is absent — and a suite whose default state is "skipped" reads exactly like a suite that passed.
3. `run.sh` died with "the input device is not a TTY" when called from a script, which is how an agent calls it. `-t` is now conditional.

## Scope

No GPU stack, no PyTorch/tiktoken/onnxruntime, no Docker CLI. `python3-venv` is there for the ML reference tests when a package needs them.

`.devcontainer/devcontainer.json` builds the same Dockerfile and mounts the same volumes, so a login done through either path is visible to the other. Nothing in CI builds this image, same as `containers/ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU