### PR TITLE
k8s: a NURL server on a cluster, and the three bugs the cluster found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A NURL server on Kubernetes, with and without a machine under it** —
+  [`unikernel/k8s/`](unikernel/k8s/README.md). One `server.nu` builds two
+  ways and not a line of it differs between them: `build_image.sh` makes
+  it a 616 KB bootable PVH kernel with a hypervisor in the container,
+  `build_static_image.sh` makes it a 1.5 MB static binary in a `FROM
+  scratch` container of 1.56 MB. Both run as ordinary pods —
+  `runAsNonRoot`, all capabilities dropped, no privileged flag, no
+  `/dev/kvm`, no `runtimeClass` — because QEMU's user-mode network stack
+  is userspace code and needs no tap device.
+
+  Three defects, none of which a "does it answer" test could see, and
+  all three found by deploying rather than by testing:
+
+  * `dhcp_handle` moved SELECTING → REQUESTING on an OFFER and set
+    `next_send_ms = now + dhcp_retry_base_ms`, so the REQUEST — the
+    answer to an offer already in hand — went out four seconds later.
+    Sixty-eight state-machine assertions passed the whole time: the
+    client bound, with the right address, lease and timers. Nothing
+    asserted *when*. `compiler/tests/net_dhcp.nu` now does.
+  * The first frame to an unresolved next hop is never the frame:
+    `stack_tx_ip4` sends the ARP request in its place and leaves the
+    retry to the caller, "which for TCP is free, because a segment that
+    did not go out is exactly what its retransmit timer is already
+    for". Free only when someone is already waiting — for a server that
+    segment is the SYN-ACK of the first connection it ever accepts, and
+    a machine that had been listening for 40 ms answered its first
+    client 1000 ms later. New `stack_arp_prime` resolves a hop with
+    nothing pending; the guest primes its gateway at the end of DHCP.
+  * `server_run` serves one connection at a time, keep-alive, to a 30 s
+    idle timeout. A pod has two clients before it has any users — the
+    readiness probe and the liveness probe — and one idle `curl` was
+    enough to time the kubelet out and get the pod replaced. Both
+    builds now use `server_run_async`, which needed
+    `nurl_fiber_spawn_owned` in `unikernel/runtime_bare.c`: without it
+    the freestanding target could not link the async server at all.
+
+  Together the first two took the cold start from 5.1 s to a first
+  answer down to 66 ms. `unikernel/k8s/smoke.sh` asserts the budget and
+  the held-open connection rather than printing them.
+
+  Also here: the TSC frequency under TCG is the *host's*, not QEMU's
+  documented 1 GHz, so `entrypoint.sh` derives it — passing 1000000 on a
+  3.5 GHz host made every guest timer run 3.5× fast, which is what made
+  the DHCP delay look like a working boot.
+
 - **A development container** —
   [`containers/dev/`](containers/dev/README.md), with a
   `.devcontainer/` wired to the same image. `./containers/dev/run.sh`

--- a/compiler/tests/net_dhcp.nu
+++ b/compiler/tests/net_dhcp.nu
@@ -115,6 +115,14 @@ $ `stdlib/net/dhcp.nu`
     ( pb `offer accepted: ` ( dhcp_handle c om 13000 ) )
     ( pb `now requesting: ` == . c state ( dhcp_state_requesting ) )
     ( pb `not bound yet: ` ! ( dhcp_bound c ) )
+    // The REQUEST is the answer to an OFFER already in hand, so it goes
+    // out on the next turn — the retransmit timer starts after we have
+    // asked, not before. Charging it a backoff here is invisible to a
+    // state-machine assertion (the client still binds, still with the
+    // right address) and costs a full `dhcp_retry_base_ms` of every
+    // boot; it did, for four seconds, until this line existed.
+    ( pb `request goes out at once: ` == ( dhcp_tick c 13000 ) ( dhcp_msg_request ) )
+    ( pb `then quiet until the timer: ` == ( dhcp_tick c 16999 ) 0 )
     ( pb `request retransmits: ` == ( dhcp_tick c 17000 ) ( dhcp_msg_request ) )
 
     // ── ACK → BOUND ──────────────────────────────────────────────

--- a/compiler/tests/outputs/net_dhcp.txt
+++ b/compiler/tests/outputs/net_dhcp.txt
@@ -25,6 +25,8 @@ offer server id: YES
 offer accepted: YES
 now requesting: YES
 not bound yet: YES
+request goes out at once: YES
+then quiet until the timer: YES
 request retransmits: YES
 ack accepted: YES
 bound: YES

--- a/stdlib/net/dhcp.nu
+++ b/stdlib/net/dhcp.nu
@@ -321,8 +321,22 @@ $ `stdlib/net/udp4.nu`
         ^ ( dhcp_msg_request )
     } {}
     ? < now . c next_send_ms { ^ 0 } {}
-    // Retransmit whatever this state sends.
-    = . c backoff_ms ? >= * . c backoff_ms 2 ( dhcp_retry_max_ms ) ( dhcp_retry_max_ms ) * . c backoff_ms 2
+    // First transmission of a state, or a retransmission of one.
+    //
+    // `sends == 0` means nothing has gone out for the state we are in,
+    // which happens when the state was entered by a REPLY rather than
+    // by this function: `dhcp_handle` moves SELECTING → REQUESTING on
+    // an OFFER and leaves the sending to us. That first REQUEST is not
+    // a retransmission and must not be charged a backoff — RFC 2131
+    // sends it immediately and starts the timer afterwards. Doubling
+    // here instead put a full `dhcp_retry_base_ms` between the OFFER
+    // and the REQUEST, which is four seconds of a boot spent waiting
+    // for a server that had already answered.
+    ? == . c sends 0 {
+        = . c backoff_ms ( dhcp_retry_base_ms )
+    } {
+        = . c backoff_ms ? >= * . c backoff_ms 2 ( dhcp_retry_max_ms ) ( dhcp_retry_max_ms ) * . c backoff_ms 2
+    }
     = . c next_send_ms + now . c backoff_ms
     = . c sends + . c sends 1
     ? == . c state ( dhcp_state_selecting ) { ^ ( dhcp_msg_discover ) } {}
@@ -356,8 +370,11 @@ $ `stdlib/net/udp4.nu`
         = . c server_id . m server_id
         = . c state ( dhcp_state_requesting )
         = . c backoff_ms ( dhcp_retry_base_ms )
-        = . c next_send_ms + now ( dhcp_retry_base_ms )
-        = . c sends 1
+        // Send the REQUEST on the next turn, not one backoff from now.
+        // The offer is in hand; the timer exists for the case where the
+        // server does not answer, and it starts once we have asked.
+        = . c next_send_ms now
+        = . c sends 0
         ^ T
     } {}
     ? == . m msg_type ( dhcp_msg_ack ) {

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -340,6 +340,33 @@ $ `stdlib/net/pktbuf.nu`
 // talk to itself over loopback at all, and nothing anywhere reported a
 // drop, because a TCP segment failing its checksum is not a frame-level
 // drop. Zero means "whatever this interface's address is".
+// Resolve a next hop before anything needs it. Answers T when the MAC
+// is already known, F when a request has just gone out (or one is
+// still in flight) and the caller should ask again.
+//
+// `stack_tx_ip4` already does this on the way past — but by then a
+// datagram exists that will not be sent, because on a miss the ARP
+// request goes out in its place and the retry is the caller's. For a
+// server the first such datagram is the SYN-ACK of the first
+// connection ever accepted, and the caller that retries it is TCP's
+// retransmit timer: one second, paid by a machine that had been
+// listening for forty milliseconds. Priming a hop while nobody is
+// waiting moves that round trip somewhere it costs nothing.
+@ stack_arp_prime * NetStack st i dst_ip i now * PktBuf out → b {
+    : i hop ( __next_hop st dst_ip )
+    ? || ( ipv4_is_broadcast hop ) ( ipv4_is_multicast hop ) { ^ T } {}
+    : ?i found ( arp_cache_lookup . st arp hop now )
+    : ~ b known F
+    ?? found { T _m → { = known T } F → {} }
+    ? known { ^ T } {}
+    ? ( arp_cache_should_request . st arp hop now ) {
+        ( arp_push_request . out bytes . st our_mac . st our_ip hop )
+        ( pktbuf_mark out )
+        = . st tx_frames + . st tx_frames 1
+    } {}
+    ^ F
+}
+
 @ stack_tx_ip4 * NetStack st i src_ip i dst_ip i proto ( Vec u ) dg i dg_off i dg_len i now * PktBuf out → TxResult {
     : i src ? != src_ip 0 src_ip . st our_ip
     ? == src 0 { ^ @ TxResult { ( tx_no_address ) 0 } } {}

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -36,6 +36,7 @@ Decided by coupling, not convenience:
 | `run_qemu_arm64.sh` · `run_qemu_arm64_tests.sh` | the AArch64 twins of those two |
 | `compile_nu.sh` | compile one program, pulling in `net/sockets.nu` when (and only when) it calls the socket ABI |
 | `demos/` | the programs that only make sense in the guest: devices, DHCP, a filesystem, a server, an MCP endpoint, TLS — and the two that are about failure, `fault.nu` and `soak.nu` |
+| `k8s/` | the guest as an ordinary Kubernetes workload: an HTTP server, a container that carries a hypervisor and the image, and the manifests — unprivileged, no `/dev/kvm`, [its own README](k8s/README.md) |
 | `tests/` | the unit gates — differentials against glibc for strings, float formatting and libm; two allocator fuzzers; the scheduler's schedule and its deadlock detector |
 | `build_nolibc.sh` | build one `.nu` program against nolibc with `-nostdlib` |
 | `run_nolibc_tests.sh` | build and run the **whole corpus** that way |

--- a/unikernel/k8s/Dockerfile
+++ b/unikernel/k8s/Dockerfile
@@ -1,0 +1,29 @@
+# unikernel/k8s/Dockerfile — a container whose payload is a machine.
+#
+# The image carries two things: a hypervisor, and a ~610 KB bootable
+# ELF that contains an HTTP server and everything under it. There is no
+# base OS for the payload to run on, because the payload does not run
+# on an OS.
+#
+# The build context is the staging directory that `build_image.sh`
+# assembles (server.elf + entrypoint.sh), not the repository — the
+# repository's .dockerignore excludes build/, and a context of two
+# files is the honest description of what goes in anyway.
+#
+# Build:  unikernel/k8s/build_image.sh
+FROM alpine:3.22
+
+# qemu-system-x86_64 only. Nothing here is for the guest — the guest
+# brought its own everything.
+RUN apk add --no-cache qemu-system-x86_64
+
+COPY server.elf /srv/server.elf
+COPY entrypoint.sh /srv/entrypoint.sh
+
+# QEMU's user-mode network stack needs no privileges, no tap device and
+# no CAP_NET_ADMIN, so the container runs as an ordinary unprivileged
+# user. Without /dev/kvm it emulates instead of virtualising; the guest
+# cannot tell, and the boot is still under two seconds.
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/srv/entrypoint.sh"]

--- a/unikernel/k8s/Dockerfile.static
+++ b/unikernel/k8s/Dockerfile.static
@@ -1,0 +1,12 @@
+# unikernel/k8s/Dockerfile.static — the whole image is one file.
+#
+# No base layer, no shell, no package manager, no entrypoint script:
+# a statically linked binary and the metadata that names it. There is
+# nothing in here to shell into, and nothing to keep up to date.
+#
+# Build: unikernel/k8s/build_static_image.sh
+FROM scratch
+COPY server /server
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/unikernel/k8s/README.md
+++ b/unikernel/k8s/README.md
@@ -1,0 +1,246 @@
+# A NURL server, with and without a machine under it
+
+`server.nu` is an HTTP server. It builds two ways, and not one line of
+it changes between them:
+
+* **As a machine.** `build_unikernel.sh` turns it into a 616 KB
+  bootable PVH kernel, and `Dockerfile` puts that kernel next to a
+  hypervisor. Under the program there is no operating system: the
+  router, the HTTP parser, the TCP stack, the ARP cache, the DHCP
+  client, the scheduler and the allocator are all NURL from this
+  repository, and the bottom edge is a virtio-net device and a CPU.
+* **As a process.** `build_static_image.sh` links it into a 1.5 MB
+  static Linux binary in a `FROM scratch` container, where the node's
+  kernel answers the socket calls instead.
+
+Both run as ordinary, unprivileged Kubernetes workloads.
+[Measured numbers](#measured) and [what the exercise
+found](#two-things-this-exercise-found) are below; the fastest way to
+believe any of it is to run it.
+
+## Run it, in order of how much you have to install
+
+You need `clang`, `qemu-system-x86_64`, and `./build.sh` run once (for
+`build/nurlc`). Docker and a cluster are optional and come later.
+
+### 1. No container, no Kubernetes
+
+```sh
+unikernel/build_unikernel.sh unikernel/k8s/server.nu -o build/unikernel/k8sd.elf
+unikernel/k8s/smoke.sh
+```
+
+`smoke.sh` boots the image, waits for the guest to say it is
+listening, asks it all four routes, and asserts two things a working
+server has to do and a broken one still looks fine without: answer
+inside a cold-start budget, and answer a second client while a first
+holds a connection open. Expect seven `PASS` lines.
+
+To poke at it by hand instead, this is the whole invocation — no
+initrd, no bootloader, no disk, and `-netdev user` so it needs no
+privileges:
+
+```sh
+qemu-system-x86_64 -M microvm,acpi=off,rtc=off \
+    -accel kvm -cpu max -m 256 \
+    -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
+    -kernel build/unikernel/k8sd.elf \
+    -append "tsc_khz=3500000 wallclock=$(date +%s) pod=laptop port=8080 platform=unikernel" \
+    -device virtio-net-device,netdev=n0 \
+    -netdev user,id=n0,hostfwd=tcp:127.0.0.1:8080-:8080 \
+    -serial stdio -display none
+# then, in another terminal:
+curl localhost:8080/ ; curl localhost:8080/info
+```
+
+`-accel kvm` needs `/dev/kvm`; drop to `-accel tcg` without it and set
+`tsc_khz` to your host's nominal TSC frequency — see [the
+clock](#the-clock-which-the-guest-refuses-to-invent), which is the one
+thing about this target that will surprise you.
+
+### 2. As a container
+
+```sh
+unikernel/k8s/build_image.sh                      # 86 MB: alpine + qemu + the guest
+docker run --rm -p 8080:8080 -e POD_NAME=laptop nurl-unikernel-httpd:0.1.0
+curl localhost:8080/
+
+unikernel/k8s/build_static_image.sh               # 1.56 MB: the binary, and nothing
+docker run --rm -p 8081:8080 -e pod=laptop -e platform=linux nurl-static-httpd:0.1.0
+curl localhost:8081/
+```
+
+### 3. On Kubernetes
+
+The manifests reference bare local tags, so a local cluster needs the
+image loaded rather than pulled:
+
+```sh
+kind create cluster                               # or: minikube start
+kind load docker-image nurl-unikernel-httpd:0.1.0 # or: minikube image load ...
+kubectl apply -f unikernel/k8s/deploy.yaml
+kubectl -n nurl-unikernel port-forward svc/nurl-unikernel 8080:80
+curl localhost:8080/info
+```
+
+`deploy-static.yaml` is the same for the other build, in the
+`nurl-static` namespace. `ingress.yaml` is an example, and says which
+two lines you have to change.
+
+For a real cluster: retag to your registry (`build_image.sh -t
+registry.example.com/you/nurl-unikernel-httpd:0.1.0 --push`), put that
+reference in the manifest's `image:`, and add an `imagePullSecrets:`
+entry if the registry needs one. Nothing else in the manifests is
+site-specific.
+
+Routes: `/` (text), `/healthz` (probes), `/info` (JSON), `/metrics`
+(Prometheus).
+
+## What the pod is allowed to do: nothing in particular
+
+QEMU's user-mode network stack is ordinary userspace code, so the
+forwarded port needs no tap device, no `CAP_NET_ADMIN` and no
+`NET_RAW`. The pod therefore runs `runAsNonRoot`,
+`readOnlyRootFilesystem`, all capabilities dropped, `RuntimeDefault`
+seccomp, no privileged flag, no `/dev/kvm`, no `runtimeClass`. It is as
+unprivileged as a static file server, and what it serves is a machine.
+
+`/dev/kvm` is used *if the node hands it over* — `entrypoint.sh` checks
+and falls back to TCG — but the manifest does not ask for it, because
+asking means either a privileged container or a device plugin, and the
+measurements below are the ones without it.
+
+The one hard constraint is `nodeSelector: kubernetes.io/arch: amd64`.
+PVH is an x86 boot protocol; on AArch64 the same build emits a flat
+`Image` instead (see `unikernel/README.md`), which is a different
+container-image build, not a different manifest.
+
+## Measured
+
+On a 6-core x86_64 desktop (nominal TSC 3.5 GHz), 2026-08-27. The
+cluster row is a two-node amd64 k3s, with `kubectl top` after the
+traffic stopped — the kubelet's own probes are in that figure.
+
+| | unikernel + QEMU | static binary |
+|---|---|---|
+| artifact | 616 KB bootable ELF | 1.5 MB static binary, stripped |
+| container image | 86 MB (alpine + `qemu-system-x86_64`) | **1.56 MB** (`FROM scratch`) |
+| start → listening | 38 ms (KVM), 63 ms (TCG) | — |
+| start → first request answered | 66 ms (KVM), 90 ms (TCG) | **11 ms** |
+| container start → probe-Ready | 1–2 s, and that is the probe's period | 1–2 s, likewise |
+| idle in the cluster | 22–40 millicores, 15–17 MiB | **1 millicore, under 1 MiB** |
+| memory handed to it | 256 MB; it touches ~16 MB | 64 MB limit; it touches ~1 MB |
+| pod privileges | none | none |
+| what is under it | a virtio-net device and a CPU | the node's Linux kernel |
+
+The unikernel's idle figure is what makes it a resident rather than a
+demo: the guest halts on `hlt` between poller ticks (tickless idle off
+the LAPIC timer), so an idle machine is not a spinning host core.
+
+## Three things this exercise found
+
+None of them was visible to a test that asked "does it answer". Two
+cost every boot a fixed, clock-scaled delay; the third cost the pod its
+life.
+
+**The first DHCPREQUEST waited a full retransmit backoff.**
+`dhcp_handle` moved SELECTING → REQUESTING on an OFFER and set
+`next_send_ms = now + dhcp_retry_base_ms`, so the REQUEST — the answer
+to an offer already in hand — went out four seconds later. Sixty-eight
+state-machine assertions passed the whole time: the client bound, with
+the right address, the right lease and the right timers. Nothing
+asserted *when*. `compiler/tests/net_dhcp.nu` now does, and the
+assertion fails against the old code.
+
+**The first frame to an unresolved next hop is never the frame.**
+`stack_tx_ip4` owns no queues by design: on an ARP miss it sends the
+request and returns `tx_arp_pending`, leaving the retry to the caller —
+"which for TCP is free, because a segment that did not go out is
+exactly what its retransmit timer is already for". It is free only when
+someone is already waiting. For a server the first such segment is the
+SYN-ACK of the first connection it ever accepts, and the retransmit
+timer is one second: a machine that had been listening for 40 ms
+answered its first client 1000 ms later. `stack_arp_prime` resolves a
+hop with nothing pending, and the guest primes its gateway at the end
+of DHCP — every client arriving through a hypervisor's user-mode
+network is off-subnet and routes via that gateway.
+
+Together: 5.1 s to a first answer became 66 ms.
+
+**One connection at a time is one connection too few.** `server_run`
+accepts, serves keep-alive until the peer leaves or the 30 s idle
+timeout fires, and only then accepts again. A pod has two clients
+before it has any users — the readiness probe and the liveness probe —
+and one `curl` left open is enough to make the kubelet's probes time
+out and the pod get replaced. It happened here, in the cluster, and the
+event log is how it was found rather than any test. Both builds now
+call `server_run_async`, which gives each connection a fiber: on the
+guest those fibers are the whole concurrency story anyway (one vCPU,
+cooperative, the device poller is already one of them); hosted, the M:N
+scheduler spreads them over worker threads.
+
+That change needed one thing the freestanding runtime did not have:
+`nurl_fiber_spawn_owned`, the spawn that frees the closure environment
+its fiber captured. `runtime_bare.c` has it now — without it the guest
+could not link the async server at all, which is a fair description of
+how much the async path had been exercised there.
+
+`smoke.sh` asserts both the cold-start budget and the held-open
+connection rather than printing them, because all three bugs passed
+every does-it-answer test in the repository.
+
+## The clock, which the guest refuses to invent
+
+Under KVM the guest reads the TSC frequency from CPUID leaf
+0x40000010. Under TCG there is no such leaf, and QEMU's `rdtsc` is the
+*host's* `rdtsc` — so the honest `tsc_khz=` is the host's nominal TSC
+frequency, not QEMU's documented 1 GHz. `entrypoint.sh` derives it
+(the kernel's own figure, else Intel's nominal frequency out of
+`/proc/cpuinfo`'s model name, else the current core frequency) and the
+guest's clock then tracks the host's to within 0.2 %.
+
+Passing 1000000 on a 3.5 GHz host made every guest timer — including
+DHCP's — run 3.5× fast, which is the kind of error that makes a timing
+bug look like a working system.
+
+## Configuration
+
+Everything the launcher says reaches the guest as a kernel command line
+key, which `boot/cmdenv.c` presents as an environment variable. The
+static build reads the same keys straight from the environment.
+
+| key | set by | meaning |
+|---|---|---|
+| `pod` | `POD_NAME` (downward API) | printed by `/` and `/info` |
+| `port` | `GUEST_PORT` | the port the server binds |
+| `platform` | the launcher | `unikernel`, `linux`, or `unknown` |
+| `tsc_khz` | derived by `entrypoint.sh` | TSC frequency (guest only) |
+| `wallclock` | `date +%s` | boot epoch — without it the guest thinks it is 1980 |
+
+`platform` is something the launcher states rather than something the
+program asserts. A program cannot find out what is beneath it, and a
+binary that says "no operating system" while running as a Linux process
+is a claim its reader cannot check — so the launcher says
+(`platform=unikernel` on the kernel command line, `platform: linux` in
+the static manifest) and the program repeats it.
+
+## Before the static build stops being a proof of concept
+
+* **Static glibc and NSS.** The link warns about `getaddrinfo`,
+  `getpwuid` and `getgrgid`: they resolve through `dlopen`'d NSS
+  modules that a static binary has no loader for. This server calls
+  none of them, so the warning is accurate and harmless *here* — a
+  program that resolves a name would fail at runtime, not at link time.
+  Building against musl (`zig cc -target x86_64-linux-musl`) removes
+  the trap instead of dodging it.
+* **The link bypasses `nurl.sh`.** There is no hook for link flags, so
+  `build_static_image.sh` spells the link out itself and thereby skips
+  nurl.sh's ThinLTO configuration and feature-library probing. A
+  `NURL_LDFLAGS` hook would be the smaller, more honest fix.
+* **What the static build gives up** is the machine — the TCP stack,
+  ARP, DHCP, the scheduler and the allocator become the node's, and the
+  pure-NURL network stack, the thing that surfaced both bugs above, no
+  longer runs in production — and the isolation boundary, which is the
+  only reason left to pay for a hypervisor once a workload is
+  stateless.

--- a/unikernel/k8s/build_image.sh
+++ b/unikernel/k8s/build_image.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/k8s/build_image.sh — build the unikernel, then wrap it in
+#  a container image.
+#
+#  Usage: unikernel/k8s/build_image.sh [-t repo:tag] [--push]
+#
+#  The default tag is unqualified on purpose: it stays on the local
+#  Docker daemon, which is what `docker run` and `kind load
+#  docker-image` want. Pushing anywhere means naming a registry:
+#      build_image.sh -t registry.example.com/you/nurl-unikernel-httpd:0.1.0 --push
+#
+#  Two steps, in order, because the second one has nothing to do with
+#  NURL: build_unikernel.sh turns server.nu into a bootable ELF, and
+#  docker puts that ELF next to a hypervisor. Skipping the first is how
+#  you ship yesterday's guest, so this script always does both.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERE="$ROOT/unikernel/k8s"
+TAG="${TAG:-nurl-unikernel-httpd:0.1.0}"
+PUSH=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t) TAG="$2"; shift 2 ;;
+        --push) PUSH=1; shift ;;
+        *) echo "usage: build_image.sh [-t repo:tag] [--push]" >&2; exit 2 ;;
+    esac
+done
+
+ELF="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}/k8sd.elf"
+"$ROOT/unikernel/build_unikernel.sh" "$HERE/server.nu" -o "$ELF"
+
+# A context of exactly the two files that go into the image. The
+# repository's .dockerignore excludes build/, and a two-file context
+# is also a faster and more truthful build than sending the tree.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp "$ELF" "$STAGE/server.elf"
+cp "$HERE/entrypoint.sh" "$STAGE/entrypoint.sh"
+chmod 0755 "$STAGE/entrypoint.sh"
+
+docker build --platform linux/amd64 -f "$HERE/Dockerfile" -t "$TAG" "$STAGE"
+echo "built $TAG ($(du -h "$ELF" | cut -f1) guest)"
+
+if [ -n "$PUSH" ]; then
+    docker push "$TAG"
+fi

--- a/unikernel/k8s/build_static_image.sh
+++ b/unikernel/k8s/build_static_image.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/k8s/build_static_image.sh — the same server, with the
+#  node's kernel underneath it instead of a machine of its own.
+#
+#  Usage: build_static_image.sh [-t repo:tag] [--push]
+#
+#  Default tag is unqualified — local daemon only. Name a registry to
+#  push:  -t registry.example.com/you/nurl-static-httpd:0.1.0 --push
+#
+#  `build_image.sh` produces a bootable image and a container that
+#  carries a hypervisor to boot it. This produces a static Linux binary
+#  and a container that carries nothing else at all. The NURL source is
+#  byte-identical; what changes is what answers the socket calls — the
+#  pure-NURL TCP stack over virtio-net there, the node's kernel here.
+#
+#  The link is spelled out rather than delegated to `nurl.sh`, which
+#  has no hook for link flags. The cost of that is real and worth
+#  knowing: this bypasses nurl.sh's ThinLTO setup and its feature-lib
+#  probing, so the binary is a plain -O2 static link.
+#
+#  GLIBC STATIC + NSS: the link warns about `getaddrinfo`, `getpwuid`
+#  and `getgrgid` — those resolve through dlopen'd NSS modules, which a
+#  static binary has no loader for. This server calls none of them, so
+#  the warning is accurate and harmless HERE; a program that resolves a
+#  name would fail at runtime rather than at link time. Building
+#  against musl (`zig cc -target x86_64-linux-musl`) removes the trap
+#  rather than dodging it, and is the right move if this stops being a
+#  proof of concept.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERE="$ROOT/unikernel/k8s"
+CC="${CC:-clang}"
+TAG="${TAG:-nurl-static-httpd:0.1.0}"
+PUSH=""
+OUTDIR="${NURL_STATIC_OUT:-$ROOT/build/k8s-static}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t) TAG="$2"; shift 2 ;;
+        --push) PUSH=1; shift ;;
+        *) echo "usage: build_static_image.sh [-t repo:tag] [--push]" >&2; exit 2 ;;
+    esac
+done
+
+[ -x "$ROOT/build/nurlc" ] || { echo "build_static_image.sh: no build/nurlc — run ./build.sh" >&2; exit 2; }
+mkdir -p "$OUTDIR"
+
+# nurlc writes IR to stdout; the redirect is the output file.
+"$ROOT/build/nurlc" "$HERE/server.nu" > "$OUTDIR/server.ll"
+# stderr kept: the NSS warnings above are the ones worth reading.
+"$CC" -O2 -static -o "$OUTDIR/server.dbg" "$OUTDIR/server.ll" \
+      "$ROOT/stdlib/runtime.c" -lm -lpthread
+strip -s "$OUTDIR/server.dbg" -o "$OUTDIR/server"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp "$OUTDIR/server" "$STAGE/server"
+cp "$HERE/Dockerfile.static" "$STAGE/Dockerfile"
+
+docker build --platform linux/amd64 -t "$TAG" "$STAGE"
+echo "built $TAG ($(du -h "$OUTDIR/server" | cut -f1) binary, and the image is that plus nothing)"
+
+[ -n "$PUSH" ] && docker push "$TAG"
+exit 0

--- a/unikernel/k8s/deploy-static.yaml
+++ b/unikernel/k8s/deploy-static.yaml
@@ -1,0 +1,96 @@
+# unikernel/k8s/deploy-static.yaml — the same server with the node's
+# kernel underneath it, deployed beside the one that brings its own.
+#
+# Proof of concept: it exists to be compared with `deploy.yaml`, not to
+# replace it. Everything the other manifest needs and this one does not
+# is the point — no hypervisor in the image, no architecture pin (once
+# an arm64 image exists), no TSC frequency to derive, no boot to wait
+# for.
+#
+# Same image-reference note as deploy.yaml: bare local tag, load it
+# into a local cluster or retag for a registry.
+#
+#   kubectl apply -f unikernel/k8s/deploy-static.yaml
+#   kubectl -n nurl-static port-forward svc/nurl-static 8080:80
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nurl-static
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nurl-static
+  namespace: nurl-static
+  labels:
+    app: nurl-static
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nurl-static
+  template:
+    metadata:
+      labels:
+        app: nurl-static
+    spec:
+      # Still amd64-only, and for a duller reason than the other
+      # manifest's: the image holds whatever binary the build host
+      # linked. An arm64 build needs a cross-compiler (zig, as in
+      # containers/dev) — and unlike the unikernel, nothing about this
+      # one is architecture-bound in principle.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: server
+          image: nurl-static-httpd:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # Same keys the guest reads off the kernel command line —
+            # here they are just environment, because here there is a
+            # kernel that has one.
+            - name: pod
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: platform
+              value: linux
+          startupProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 20
+          # Measured idle: 0.4–1.4 MB resident, no measurable CPU.
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits:   { cpu: "1", memory: 64Mi }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nurl-static
+  namespace: nurl-static
+spec:
+  selector:
+    app: nurl-static
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/unikernel/k8s/deploy.yaml
+++ b/unikernel/k8s/deploy.yaml
@@ -1,0 +1,99 @@
+# unikernel/k8s/deploy.yaml — an ordinary Kubernetes workload whose
+# process happens to be a hypervisor.
+#
+# Nothing in this manifest is special-cased for virtual machines: no
+# privileged flag, no /dev/kvm device, no CAP_NET_ADMIN, no runtimeClass.
+# QEMU's user-mode network stack lives entirely in userspace, so the pod
+# is as unprivileged as a static file server — and the thing it serves
+# is a machine with no operating system.
+#
+# The image reference is a bare local tag, which is what a local
+# cluster wants: build it, load it (`kind load docker-image
+# nurl-unikernel-httpd:0.1.0`, or `minikube image load ...`), apply.
+# For a real cluster, retag and push to your registry, put that
+# reference here, and add an `imagePullSecrets:` entry if it needs one.
+#
+#   kubectl apply -f unikernel/k8s/deploy.yaml
+#   kubectl -n nurl-unikernel port-forward svc/nurl-unikernel 8080:80
+#   curl localhost:8080/info
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nurl-unikernel
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nurl-unikernel
+  namespace: nurl-unikernel
+  labels:
+    app: nurl-unikernel
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nurl-unikernel
+  template:
+    metadata:
+      labels:
+        app: nurl-unikernel
+    spec:
+      # The guest is an x86_64 PVH kernel — the boot protocol is x86
+      # only, so this is a hard constraint and not a preference. On a
+      # single-architecture cluster the selector is a no-op; on a mixed
+      # one it is the difference between running and CrashLoopBackOff.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: qemu
+          image: nurl-unikernel-httpd:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # Becomes a kernel command line key, which cmdenv.c presents
+            # to the guest as an environment variable. The guest prints
+            # it; that is how you tell the two replicas apart.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          # The guest boots to a served request in well under two
+          # seconds, so the readiness gate is short and honest rather
+          # than a generous guess.
+          startupProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 1
+            failureThreshold: 30
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 20
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits:   { cpu: "1",  memory: 512Mi }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nurl-unikernel
+  namespace: nurl-unikernel
+spec:
+  selector:
+    app: nurl-unikernel
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/unikernel/k8s/entrypoint.sh
+++ b/unikernel/k8s/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# unikernel/k8s/entrypoint.sh — the container's only job is to point a
+# CPU at the image and forward a port.
+#
+# Nothing here is Kubernetes-specific: the same command runs the image
+# on a laptop. What Kubernetes contributes is the environment —
+# POD_NAME from the downward API, PORT from the container spec — and
+# those become kernel command line keys, which `cmdenv.c` presents to
+# the guest as its environment.
+set -eu
+
+IMAGE="${IMAGE:-/srv/server.elf}"
+PORT="${PORT:-8080}"
+GUEST_PORT="${GUEST_PORT:-8080}"
+MEM="${MEM:-256}"
+POD="${POD_NAME:-$(hostname)}"
+
+# KVM when the node gave us the device, TCG when it did not. The
+# difference is speed and the clock, not behaviour: this image boots to
+# a served request in under two seconds either way.
+if [ -w /dev/kvm ]; then
+    ACCEL=kvm
+else
+    ACCEL=tcg
+fi
+
+# The TSC frequency, which the guest refuses to invent.
+#
+# Under KVM the guest reads it from CPUID leaf 0x40000010 and ignores
+# what we say here. Under TCG QEMU's rdtsc IS the host's rdtsc, so the
+# honest value is the host's nominal TSC frequency — not QEMU's
+# documented 1 GHz, which would make the guest's clock run at whatever
+# ratio the host's TSC happens to have to it. Sources, best first:
+# the kernel's own figure, then Intel's nominal frequency out of the
+# model name, then the current (boost/idle-dependent) core frequency.
+tsc_khz() {
+    if [ -r /sys/devices/system/cpu/cpu0/tsc_freq_khz ]; then
+        cat /sys/devices/system/cpu/cpu0/tsc_freq_khz
+        return
+    fi
+    ghz=$(sed -n 's/^model name.*@ *\([0-9.]*\)GHz.*/\1/p' /proc/cpuinfo | head -1)
+    if [ -n "$ghz" ]; then
+        awk -v g="$ghz" 'BEGIN { printf "%d\n", g * 1000000 }'
+        return
+    fi
+    mhz=$(sed -n 's/^cpu MHz[^0-9]*\([0-9.]*\).*/\1/p' /proc/cpuinfo | head -1)
+    if [ -n "$mhz" ]; then
+        echo "entrypoint: no nominal TSC frequency; using the current core frequency" >&2
+        awk -v m="$mhz" 'BEGIN { printf "%d\n", m * 1000 }'
+        return
+    fi
+    echo "entrypoint: no TSC frequency anywhere; the guest clock will be wrong" >&2
+    echo 1000000
+}
+
+# `platform` is the launcher telling the guest what is underneath it.
+# The program cannot find that out, and a program that asserts it
+# anyway is one whose banner stops being checkable the day the same
+# source is built the other way — which it now is.
+APPEND="tsc_khz=$(tsc_khz) wallclock=$(date +%s) pod=${POD} port=${GUEST_PORT} platform=unikernel"
+echo "entrypoint: accel=${ACCEL} append=[${APPEND}] forwarding :${PORT} -> guest:${GUEST_PORT}" >&2
+
+# exec, so QEMU is PID 1 and Kubernetes' SIGTERM reaches the hypervisor
+# rather than a shell that would outlive it.
+exec qemu-system-x86_64 \
+    -M microvm,acpi=off,rtc=off \
+    -accel "${ACCEL}" -cpu max -m "${MEM}" \
+    -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
+    -kernel "${IMAGE}" \
+    -append "${APPEND}" \
+    -device virtio-net-device,netdev=n0 \
+    -netdev "user,id=n0,hostfwd=tcp::${PORT}-:${GUEST_PORT}" \
+    -serial stdio -display none

--- a/unikernel/k8s/ingress.yaml
+++ b/unikernel/k8s/ingress.yaml
@@ -1,0 +1,36 @@
+# unikernel/k8s/ingress.yaml — an EXAMPLE front door, kept separate
+# from deploy.yaml because putting a machine with no operating system
+# on a network is a deliberate act, and because an Ingress is the one
+# object here that cannot be written portably.
+#
+# Two edits before this applies anywhere:
+#   1. `ingressClassName` — whatever your cluster runs (`nginx`,
+#      `traefik`, `alb`, …). `kubectl get ingressclass` tells you.
+#   2. `host` — a name that resolves to your ingress controller.
+#      Locally, `*.localtest.me` resolves to 127.0.0.1 without any
+#      /etc/hosts editing, which is why it is the default here.
+#
+# TLS is left out rather than guessed: it depends on whether you run
+# cert-manager, a wildcard secret, or terminate somewhere else. Add
+# a `tls:` block naming your own secret if you need one.
+#
+# You do not need this to try the server — `kubectl port-forward` is
+# the shorter path and the README leads with it.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nurl-unikernel
+  namespace: nurl-unikernel
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: unikernel.localtest.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nurl-unikernel
+                port:
+                  number: 80

--- a/unikernel/k8s/server.nu
+++ b/unikernel/k8s/server.nu
@@ -1,0 +1,204 @@
+// unikernel/k8s/server.nu — one program, two bottom edges.
+//
+// Built by `build_image.sh` it is a machine: `build_unikernel.sh`
+// turns it into a bootable PVH kernel and a hypervisor in the
+// container boots it. Built by `build_static_image.sh` it is a 1.5 MB
+// static Linux binary in a `FROM scratch` container. Not one line
+// below differs between them — what differs is what is underneath,
+// which is why `platform` is something the launcher says rather than
+// something this file claims.
+//
+// A Kubernetes container normally holds a process on a shared Linux
+// kernel. This one holds a hypervisor holding a machine whose entire
+// software stack — scheduler, allocator, TCP/IP, HTTP parser, router —
+// is the NURL in this repository. There is no kernel under it, no libc
+// beside it, and no init before it: `main` runs because the CPU was
+// pointed at it.
+//
+// Config arrives on the kernel command line, which `cmdenv.c` turns
+// into the guest's environment, so the deployment can say `pod=$(POD)`
+// the same way it would set an env var on a container.
+//
+// Routes:
+//   GET /         plain text, for a human
+//   GET /healthz  liveness/readiness — 200 the moment the loop runs
+//   GET /info     JSON, for a machine
+//   GET /metrics  Prometheus text
+$ `stdlib/std/async.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/http_router.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/env.nu`
+
+// ── shared counters ──────────────────────────────────────────────────
+//
+// Slot 0 = requests served. A `Vec` is a boxed handle onto a shared
+// control block, so every closure that captured it mutates the SAME
+// counter — a scalar binding would be captured by value and each
+// handler would count its own private zero.
+
+@ stat_get ( Vec i ) c i idx → i {
+    ?? ( vec_get [i] c idx ) {
+        T n → ^ n
+        F → ^ 0
+    }
+    ^ 0
+}
+
+@ stat_bump ( Vec i ) c i idx → i {
+    : i n + 1 ( stat_get c idx )
+    ( vec_set [i] c idx n )
+    ^ n
+}
+
+@ uptime_ms i boot_ns → i {
+    ^ / - ( monotonic_ns ) boot_ns 1000000
+}
+
+// ── handlers ─────────────────────────────────────────────────────────
+
+@ h_root ( Vec i ) c i boot_ns String pod String platform → HttpResponse {
+    : i n ( stat_bump c 0 )
+    : String b ( string_with_cap 512 )
+    ( string_push_str b `NURL HTTP server\n\n` )
+    // The same program has two bottom edges, and only one of them gets
+    // to make the interesting claim. A build that says "no operating
+    // system" while running as a Linux process is a lie the reader
+    // cannot check, so the launcher states which one this is and the
+    // program says nothing it does not know.
+    ? != 0 ( nurl_str_eq ( string_data platform ) `unikernel` ) {
+        ( string_push_str b `This reply was assembled by a machine with no operating\n` )
+        ( string_push_str b `system. The TCP stack, the HTTP parser and the router are\n` )
+        ( string_push_str b `NURL; under them is a virtio-net device and a CPU.\n\n` )
+    } {
+        ( string_push_str b `Same program, ordinary bottom edge: a Linux process, whose\n` )
+        ( string_push_str b `router and HTTP parser are still NURL and whose TCP stack\n` )
+        ( string_push_str b `is the node's kernel.\n\n` )
+    }
+    ( string_push_str b `platform: ` )
+    ( string_push_str b ( string_data platform ) )
+    ( string_push_str b `\npod:      ` )
+    ( string_push_str b ( string_data pod ) )
+    ( string_push_str b `\nuptime:   ` )
+    ( string_push_str b ( nurl_str_int ( uptime_ms boot_ns ) ) )
+    ( string_push_str b ` ms\nrequests: ` )
+    ( string_push_str b ( nurl_str_int n ) )
+    ( string_push_str b `\n\ntry /healthz, /info, /metrics\n` )
+    : HttpResponse r ( response_text 200 ( string_data b ) )
+    ( string_free b )
+    ^ r
+}
+
+@ h_health ( Vec i ) c → HttpResponse {
+    ( stat_bump c 0 )
+    ^ ( response_text 200 `ok\n` )
+}
+
+@ h_info ( Vec i ) c i boot_ns String pod String platform → HttpResponse {
+    : i n ( stat_bump c 0 )
+    : Json j ( json_obj_new )
+    ( json_obj_set j `server` ( json_str_lit `nurl-http` ) )
+    ( json_obj_set j `pod` ( json_str_lit ( string_data pod ) ) )
+    // What is under this program is not something it can find out, so
+    // it reports what it was told rather than what it would like to be
+    // true: `unikernel` when a hypervisor booted the image, `linux`
+    // when the node's kernel exec'd the binary, `unknown` when nobody
+    // said.
+    ( json_obj_set j `platform` ( json_str_lit ( string_data platform ) ) )
+    ( json_obj_set j `uptime_ms` ( json_int ( uptime_ms boot_ns ) ) )
+    ( json_obj_set j `requests` ( json_int n ) )
+    ( json_obj_set j `unix_time` ( json_int ( now_seconds ) ) )
+    : HttpResponse r ( response_json 200 j )
+    ( json_free j )
+    ^ r
+}
+
+@ h_metrics ( Vec i ) c i boot_ns → HttpResponse {
+    : i n ( stat_bump c 0 )
+    : String b ( string_with_cap 256 )
+    ( string_push_str b `# HELP nurl_requests_total Requests served since boot.\n` )
+    ( string_push_str b `# TYPE nurl_requests_total counter\nnurl_requests_total ` )
+    ( string_push_str b ( nurl_str_int n ) )
+    ( string_push_str b `\n# HELP nurl_uptime_ms Milliseconds since the guest entered main.\n` )
+    ( string_push_str b `# TYPE nurl_uptime_ms gauge\nnurl_uptime_ms ` )
+    ( string_push_str b ( nurl_str_int ( uptime_ms boot_ns ) ) )
+    ( string_push_str b `\n` )
+    : HttpResponse r ( response_text 200 ( string_data b ) )
+    ( string_free b )
+    ^ r
+}
+
+// ── main ─────────────────────────────────────────────────────────────
+
+@ main → i {
+    : i boot_ns ( monotonic_ns )
+    // One connection at a time is one connection too few.
+    //
+    // `server_run` accepts, serves keep-alive until the peer goes away
+    // or the 30 s idle timeout fires, and only then accepts again. A
+    // Kubernetes pod has at least two clients before it has any users
+    // — the readiness probe and the liveness probe — and a held-open
+    // connection makes every other one wait. That is not a load
+    // problem discovered under load: one idle `curl` was enough to
+    // time out the kubelet's probes and get the pod replaced.
+    //
+    // `server_run_async` gives each connection a fiber. On the guest
+    // those fibers are the whole concurrency story anyway (one vCPU,
+    // cooperative, the device poller is already one of them); hosted,
+    // the M:N scheduler spreads them over worker threads. 0 = pick the
+    // worker count from the machine.
+    ( runtime_init 0 )
+    : String pod ( env_var_or `pod` `unnamed` )
+    : String platform ( env_var_or `platform` `unknown` )
+    : i port ?? ( env_get `port` ) {
+        T p → ?? ( string_to_int p ) { T v → v F _ → 8080 }
+        F → 8080
+    }
+
+    : ( Vec i ) counters ( vec_new [i] )
+    ( vec_push [i] counters 0 )
+
+    ?? ( tcp_listen `0.0.0.0` port ) {
+        F e → {
+            ( nurl_print `listen failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+            ^ 1
+        }
+        T listener → {
+            : Router rt ( router_new )
+            ( router_get rt `/`
+            \ HttpRequest req Params ps → HttpResponse { ^ ( h_root counters boot_ns pod platform ) } )
+            ( router_get rt `/healthz`
+            \ HttpRequest req Params ps → HttpResponse { ^ ( h_health counters ) } )
+            ( router_get rt `/info`
+            \ HttpRequest req Params ps → HttpResponse { ^ ( h_info counters boot_ns pod platform ) } )
+            ( router_get rt `/metrics`
+            \ HttpRequest req Params ps → HttpResponse { ^ ( h_metrics counters boot_ns ) } )
+
+            : ( @ HttpResponse HttpRequest ) app
+            \ HttpRequest req → HttpResponse { ^ ( router_handle rt req ) }
+            : HttpServer srv ( server_new listener app )
+
+            ( nurl_print `nurl unikernel serving on 0.0.0.0:` )
+            ( nurl_print ( nurl_str_int port ) )
+            ( nurl_print `\n` )
+
+            : !v NetErr rr ( server_run_async srv )
+            ?? rr {
+                T _ → { ( nurl_print `server stopped\n` ) }
+                F e → {
+                    ( nurl_print `server error: ` )
+                    ( nurl_print ( net_err_name e ) )
+                    ( nurl_print `\n` )
+                }
+            }
+            ( runtime_shutdown )
+            ( router_free rt )
+        }
+    }
+    ( string_free pod )
+    ( string_free platform )
+    ( vec_free [i] counters )
+    ^ 0
+}

--- a/unikernel/k8s/smoke.sh
+++ b/unikernel/k8s/smoke.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/k8s/smoke.sh — boot the server the deployment ships and
+#  ask it the four questions the deployment asks it.
+#
+#  Usage: unikernel/k8s/smoke.sh [image.elf]
+#
+#  The interesting assertions are the last two, and neither is about
+#  whether the server answers. A machine that boots and serves is not
+#  news; one that boots and serves QUICKLY, to more than one client at
+#  a time, is the whole claim — and all three bugs this directory's
+#  README describes were invisible to every "does it answer" test in
+#  the repository. So the budget is asserted, not printed:
+#  from the hypervisor's first instruction to a client holding a
+#  response, one second — against 63 ms measured, which leaves room for
+#  a loaded CI box and none for a regression.
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMG="${1:-${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}/k8sd.elf}"
+QEMU="${QEMU:-qemu-system-x86_64}"
+PORT="${SMOKE_PORT:-18771}"
+BUDGET_MS="${SMOKE_BUDGET_MS:-1000}"
+LOG="$(mktemp)"
+fails=0
+
+[ -f "$IMG" ] || { echo "smoke.sh: no image at $IMG — run build_image.sh or build_unikernel.sh" >&2; exit 2; }
+command -v "$QEMU" >/dev/null 2>&1 || { echo "smoke.sh: $QEMU not found" >&2; exit 3; }
+command -v curl >/dev/null 2>&1 || { echo "smoke.sh: curl not found" >&2; exit 3; }
+
+ACCEL=tcg
+[ -w /dev/kvm ] && ACCEL=kvm
+
+# The host's nominal TSC frequency, for the same reason entrypoint.sh
+# derives it: under TCG the guest's rdtsc IS the host's, so 1 GHz would
+# make every guest timer run at the host's TSC ratio to it.
+TSC_KHZ="$(sed -n 's/^model name.*@ *\([0-9.]*\)GHz.*/\1/p' /proc/cpuinfo | head -1 |
+           awk '{ printf "%d", $1 * 1000000 }')"
+[ -n "$TSC_KHZ" ] || TSC_KHZ=1000000
+
+start_ns=$(date +%s%N)
+"$QEMU" -M microvm,acpi=off,rtc=off \
+    -accel "$ACCEL" -cpu max -m 256 \
+    -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
+    -kernel "$IMG" \
+    -append "tsc_khz=${TSC_KHZ} wallclock=$(date +%s) pod=smoke port=8080 platform=unikernel" \
+    -device virtio-net-device,netdev=n0 \
+    -netdev "user,id=n0,hostfwd=tcp:127.0.0.1:${PORT}-:8080" \
+    -serial stdio -display none > "$LOG" 2>&1 &
+qemu_pid=$!
+cleanup() { kill "$qemu_pid" 2>/dev/null; wait "$qemu_pid" 2>/dev/null; rm -f "$LOG"; }
+trap cleanup EXIT
+
+# Wait for the guest to SAY it is listening rather than for the port to
+# accept: the hypervisor's forwarded port accepts on the host side
+# before the guest exists, so polling it would time the host.
+for _ in $(seq 1 600); do
+    grep -q 'serving on' "$LOG" && break
+    kill -0 "$qemu_pid" 2>/dev/null || break
+    sleep 0.02
+done
+if ! grep -q 'serving on' "$LOG"; then
+    echo "FAIL: guest never listened. Console:" >&2
+    sed 's/\r$//' "$LOG" >&2
+    exit 1
+fi
+
+body="$(curl -sS --max-time 10 "http://127.0.0.1:${PORT}/healthz")"
+answered_ns=$(date +%s%N)
+elapsed_ms=$(( (answered_ns - start_ns) / 1000000 ))
+
+check() {  # name expected-substring actual
+    if printf '%s' "$3" | grep -q -- "$2"; then
+        echo "PASS $1"
+    else
+        echo "FAIL $1: expected to find [$2] in [$3]"
+        fails=$((fails + 1))
+    fi
+}
+
+check "healthz"  "ok"                 "$body"
+check "root"     "no operating"       "$(curl -sS --max-time 10 "http://127.0.0.1:${PORT}/")"
+check "info"     '"pod":"smoke"'      "$(curl -sS --max-time 10 "http://127.0.0.1:${PORT}/info")"
+check "metrics"  "nurl_requests_total" "$(curl -sS --max-time 10 "http://127.0.0.1:${PORT}/metrics")"
+check "404"      "404"                "$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:${PORT}/nope")"
+
+# A second client, while a first one is holding a keep-alive connection
+# open and saying nothing.
+#
+# This is not a load test — it is one idle connection, which is what a
+# Kubernetes pod has before it has any users at all (a readiness probe
+# and a liveness probe are two clients). A sequentially-serving loop
+# answers the holder, waits out its 30 s idle timeout, and only then
+# accepts anyone else; the kubelet times out and replaces the pod. That
+# happened, in a real cluster, before this check existed.
+exec 9<>"/dev/tcp/127.0.0.1/${PORT}" 2>/dev/null || { echo "FAIL concurrency: cannot open a holding connection"; fails=$((fails + 1)); }
+if [ -e /proc/self/fd/9 ]; then
+    printf 'GET /healthz HTTP/1.1\r\nHost: smoke\r\nConnection: keep-alive\r\n\r\n' >&9
+    head -c 32 <&9 >/dev/null
+    second="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${PORT}/healthz")"
+    exec 9<&-
+    if [ "$second" = "200" ]; then
+        echo "PASS concurrency (a held-open connection does not block the next client)"
+    else
+        echo "FAIL concurrency: second client got [$second] while one connection was held open"
+        fails=$((fails + 1))
+    fi
+fi
+
+if [ "$elapsed_ms" -le "$BUDGET_MS" ]; then
+    echo "PASS cold start (${elapsed_ms} ms, budget ${BUDGET_MS} ms, accel ${ACCEL})"
+else
+    echo "FAIL cold start: ${elapsed_ms} ms > ${BUDGET_MS} ms budget (accel ${ACCEL})"
+    fails=$((fails + 1))
+fi
+
+[ "$fails" -eq 0 ] && echo "smoke: all checks passed" || echo "smoke: ${fails} check(s) failed"
+exit $(( fails == 0 ? 0 : 1 ))

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -246,6 +246,60 @@ $ `stdlib/net/dnsclient.nu`
     : i _f ( nurl_fiber_spawn fnp env )
 }
 
+// Put every frame the stack built onto the wire, then empty the buffer.
+@ __flush_frames * PktBuf out → v {
+    : i n ( pktbuf_count out )
+    : ~ i k 0
+    ~ < k n {
+        : ( Vec u ) f ( vec_new [u] )
+        ( pktbuf_copy_to f out k )
+        : i _t ( netdev_tx # s ( vec_data [u] f ) ( vec_len [u] f ) )
+        ( vec_free [u] f )
+        = k + k 1
+    }
+    ( pktbuf_clear out )
+}
+
+// Ask for the gateway's MAC while the boot is still in `main`.
+//
+// The machine's first outbound frame to an unresolved next hop is not
+// the frame — it is an ARP request, and the frame is the caller's to
+// send again. For a server the first one is the SYN-ACK of the first
+// connection it ever accepts, and the caller that sends it again is
+// TCP's retransmit timer: the first client of a freshly booted machine
+// waited a full second to be answered by a machine that had been
+// listening for forty milliseconds. Off-subnet clients — which through
+// a hypervisor's user-mode network is all of them — all route via the
+// gateway, so one resolution covers them.
+//
+// Bounded and best-effort: a network with no gateway, or one that does
+// not answer, costs the deadline once and nothing afterwards. The
+// address still works; the first client just pays the second again.
+@ __arp_warm * Shim sh → v {
+    : *NetStack net . sh net
+    : i gw . net gateway
+    ? == gw 0 { ^ v } {}
+    : *PktBuf out ( pktbuf_new )
+    : i deadline + ( __ms ) 250
+    : ~ b done F
+    ~ && ! done < ( __ms ) deadline {
+        = done ( stack_arp_prime net gw ( __ms ) out )
+        ? ! done {
+            ( __flush_frames out )
+            : ( Vec u ) in ( vec_with_cap [u] 2048 )
+            ( vec_set_len [u] in 2048 )
+            : i len ( netdev_rx # s ( vec_data [u] in ) 2048 )
+            ? > len 0 {
+                ( vec_set_len [u] in len )
+                : RxResult _r ( stack_rx net in ( __ms ) out )
+                ( __flush_frames out )
+            } {}
+            ( vec_free [u] in )
+        } {}
+    }
+    ( pktbuf_free out )
+}
+
 // Run the DHCP client — the same state machine `net/dhcp.nu` covers
 // with 62 host assertions — until it holds a lease or the deadline
 // passes. Bounded by the CLOCK, not by a round count: the retransmit
@@ -266,6 +320,7 @@ $ `stdlib/net/dnsclient.nu`
         // the shim: name resolution is a socket-layer service here,
         // exactly where getaddrinfo keeps it on a hosted machine.
         = . sh dns_ip . c dns
+        ( __arp_warm sh )
     } {}
     ( dhcp_client_free c )
 }
@@ -281,16 +336,7 @@ $ `stdlib/net/dnsclient.nu`
         : i _n ( stack_tx_udp_broadcast . sh net ( dhcp_src_ip c ) ( dhcp_client_port )
         ( dhcp_server_port ) ( dhcp_dest_ip c ) msg 0 ( vec_len [u] msg ) out )
         ( vec_free [u] msg )
-        : i n ( pktbuf_count out )
-        : ~ i k 0
-        ~ < k n {
-            : ( Vec u ) f ( vec_new [u] )
-            ( pktbuf_copy_to f out k )
-            : i _t ( netdev_tx # s ( vec_data [u] f ) ( vec_len [u] f ) )
-            ( vec_free [u] f )
-            = k + k 1
-        }
-        ( pktbuf_clear out )
+        ( __flush_frames out )
     } {}
     : ~ b more T
     ~ more {

--- a/unikernel/runtime_bare.c
+++ b/unikernel/runtime_bare.c
@@ -178,7 +178,13 @@ struct NbCoro {
     int          last_park_result;
     int          wake_pending;    /* an unpark that arrived before the
                                    * park — consumed by the next park   */
+    int          owns_env;        /* free env after the body returns    */
 };
+
+/* The NURL allocator, not free(): an owned closure environment came out
+ * of nurl_alloc and its header is not malloc's. Declared rather than
+ * included because this file has no libc to include it from. */
+extern void nurl_free(char *p);
 
 /* Defined in §8 — named here because §7's scheduler step performs the
  * parked-with-mutex handoff. A forward declaration, not an `extern`
@@ -338,6 +344,12 @@ static void nb_entry(void *arg) {
     nurl_ctx_asan_finish_switch(0, &nb_loop_lo, &nb_loop_size);
 #endif
     if (c->fn) c->fn(c->env);
+    /* Same point in the lifecycle as runtime_ffi.c's fiber body: after
+     * the body returns and before anything can observe the coroutine as
+     * done. A fiber spawned per connection captures its connection in a
+     * heap environment nobody else holds, so "nobody frees it" is one
+     * leak per request. */
+    if (c->owns_env && c->env) { nurl_free((char *)c->env); c->env = 0; }
     c->finished = 1;
     c->state = NB_DONE;
 #ifdef NURL_BARE_ASAN
@@ -885,6 +897,23 @@ long long nurl_fiber_spawn(void *fn, void *env) {
     if (!nb_initialized) nurl_runtime_init(0);
     NbCoro *c = nb_coro_new(fn, env, 0);
     if (!c) nb_spawn_failed();
+    nb_live++;
+    nb_rq_push(c);
+    return (long long)(unsigned long)c;
+}
+
+/* Spawn a fiber that owns its closure environment. `server_run_async`
+ * and every other per-item `spawn` in std/async.nu builds a closure
+ * whose env exists only for that fiber; without this entry point a
+ * freestanding program links against the hosted runtime's name and
+ * fails, which is how it was found — the guest simply could not run
+ * the async server at all. */
+long long nurl_fiber_spawn_owned(void *fn, void *env) {
+    if (!fn) return 0;
+    if (!nb_initialized) nurl_runtime_init(0);
+    NbCoro *c = nb_coro_new(fn, env, 0);
+    if (!c) nb_spawn_failed();
+    c->owns_env = 1;
     nb_live++;
     nb_rq_push(c);
     return (long long)(unsigned long)c;

--- a/unikernel/tests/pthread_layout.c
+++ b/unikernel/tests/pthread_layout.c
@@ -21,10 +21,24 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 extern const unsigned long nurl__bare_sizeof_mutex;
 extern const unsigned long nurl__bare_sizeof_cond;
 extern const unsigned long nurl__bare_sizeof_coro;
+
+/* Same reason as sched_gate.c: runtime_bare frees an owned closure
+ * environment through the NURL allocator, and this gate links the bare
+ * runtime without runtime_core.c. Nothing here spawns an owned fiber,
+ * so the definition exists to satisfy the link and aborts if that ever
+ * stops being true. */
+void nurl_free(char *p);
+void nurl_free(char *p) {
+    (void)p;
+    fprintf(stderr, "pthread_layout: nurl_free reached — this gate links "
+                    "no allocator\n");
+    abort();
+}
 
 int main(void) {
     int bad = 0;

--- a/unikernel/tests/sched_gate.c
+++ b/unikernel/tests/sched_gate.c
@@ -46,6 +46,22 @@ int  pthread_create(void *t, void *attr, void *start, void *arg);
 int  nurl_pthread_join_ptr(void *t);
 void nurl_pthread_detach_ptr(void *t);
 
+/* runtime_bare frees an owned closure environment through the NURL
+ * allocator, which lives in runtime_core.c — a file this gate
+ * deliberately does not link, because the scheduler is what is under
+ * test and the allocator is not. Nothing here spawns an owned fiber,
+ * so the symbol exists only to satisfy the link. It aborts rather than
+ * no-ops: a gate that grows an owned spawn should fail loudly here
+ * instead of quietly leaking whatever it captured.
+ */
+void nurl_free(char *p);
+void nurl_free(char *p) {
+    (void)p;
+    fprintf(stderr, "sched_gate: nurl_free reached — this gate links no "
+                    "allocator; link runtime_core.o if it now needs one\n");
+    abort();
+}
+
 long long nurl_fiber_spawn(void *fn, void *env);
 long long nurl_fiber_spawn_joinable(void *fn, void *env);
 void      nurl_fiber_join(long long h);


### PR DESCRIPTION
`unikernel/k8s/` deploys one `server.nu` two ways, and not a line of the
NURL differs between them:

* **As a machine** — `build_image.sh` turns it into a 616 KB bootable PVH
  kernel and puts a hypervisor in the container beside it. Under the
  program there is no operating system: router, HTTP parser, TCP stack,
  ARP cache, DHCP client, scheduler and allocator are all NURL from this
  repository, and the bottom edge is a virtio-net device and a CPU.
* **As a process** — `build_static_image.sh` links it into a 1.5 MB
  static Linux binary in a `FROM scratch` container of 1.56 MB, where
  the node's kernel answers the socket calls instead.

Both run as ordinary, unprivileged pods: `runAsNonRoot`,
`readOnlyRootFilesystem`, all capabilities dropped, `RuntimeDefault`
seccomp, no privileged flag, no `/dev/kvm`, no `runtimeClass`. QEMU's
user-mode network stack is userspace code, so the forwarded port needs
no tap device and no `CAP_NET_ADMIN`.

## The three bugs, none of which a test could see

All three were found by deploying rather than by testing, and each one
passed every "does it answer" assertion in the repository while it was
happening.

**The first DHCPREQUEST waited a full retransmit backoff.**
`dhcp_handle` moved SELECTING → REQUESTING on an OFFER and set
`next_send_ms = now + dhcp_retry_base_ms`, so the REQUEST — the answer to
an offer already in hand — went out four seconds later. RFC 2131 sends it
immediately and starts the timer afterwards. Sixty-eight state-machine
assertions passed the whole time: the client bound, with the right
address, the right lease and the right timers. Nothing asserted *when*.
`compiler/tests/net_dhcp.nu` now does, and the new assertion reports `NO`
against the old code (negative control run).

**The first frame to an unresolved next hop is never the frame.**
`stack_tx_ip4` owns no queues by design: on an ARP miss the request goes
out in the datagram's place and the retry is the caller's — *"which for
TCP is free, because a segment that did not go out is exactly what its
retransmit timer is already for"*. It is free only when someone is
already waiting. For a server the first such segment is the SYN-ACK of
the first connection it ever accepts, and the retransmit timer is one
second: a machine that had been listening for 40 ms answered its first
client 1000 ms later. New `stack_arp_prime` resolves a hop with nothing
pending, and the guest primes its gateway at the end of DHCP — through a
hypervisor's user-mode network every client is off-subnet and routes via
it.

**One connection at a time is one connection too few.** `server_run`
serves keep-alive until the peer leaves or the 30 s idle timeout fires,
and only then accepts again. A pod has two clients before it has any
users — the readiness probe and the liveness probe — and one idle `curl`
was enough to time the kubelet out and get the pod replaced. That
happened in a real cluster; the event log found it. Both builds now call
`server_run_async`, one fiber per connection.

That last fix needed `nurl_fiber_spawn_owned` in `runtime_bare.c` — the
spawn that frees the closure environment its fiber captured. Without it
the freestanding target could not link the async server **at all**, which
is a fair description of how much that path had been exercised there. Two
C gates link `runtime_bare.o` without an allocator, so they now carry a
loudly aborting stub rather than a silent no-op.

## Measured

6-core x86_64 desktop; the cluster row is a two-node amd64 k3s with
`kubectl top` after traffic stopped (kubelet probes included).

| | unikernel + QEMU | static binary |
|---|---|---|
| artifact | 616 KB bootable ELF | 1.5 MB static binary, stripped |
| container image | 86 MB | **1.56 MB** |
| start → listening | 38 ms (KVM), 63 ms (TCG) | — |
| start → first request answered | 66 ms (KVM), 90 ms (TCG) | **11 ms** |
| idle in the cluster | 22–40 millicores, 15–17 MiB | 1 millicore, under 1 MiB |

Before the first two fixes, that cold start was **5.1 s**.

## The clock, which is worth reading before trusting a measurement

Under KVM the guest reads its TSC frequency from CPUID leaf
0x40000010. Under TCG there is no such leaf and QEMU's `rdtsc` **is the
host's** `rdtsc`, so the honest `tsc_khz=` is the host's nominal TSC
frequency, not QEMU's documented 1 GHz. `entrypoint.sh` derives it, and
the guest's clock then tracks the host's to within 0.2 %. Passing
1000000 on a 3.5 GHz host made every guest timer run 3.5× fast — which
is what made the four-second DHCP delay look like a working boot.

## `platform` is stated, not asserted

The same source now runs with two different things underneath it, and a
program cannot find out which. A binary that says "no operating system"
while running as a Linux process is a claim its reader cannot check, so
the launcher says (`platform=unikernel` on the kernel command line,
`platform: linux` in the static manifest) and the program repeats it —
`unknown` when nobody did.

## Gates

* QEMU guest suite **29/29** (one clean run; an earlier 28/29 was a flake
  from running it alongside the 517-program nolibc corpus build — the
  `httpsd` TLS handshake missed its window and passed first try when
  re-run alone)
* nolibc corpus **517 / 0 FAIL**
* nolibc unit gates: all pass, including `sched_gate` and `pthread_layout`
* `./build.sh` — bootstrap fixed point + compiler corpus, green
* `net_dhcp` / `net_stack` / `net_socket` / `net_tcpstack` / `net_frames`
  / `net_loopback` goldens unmoved except `net_dhcp`'s two new lines
* `unikernel/k8s/smoke.sh` — 7/7, and it asserts the cold-start budget and
  the held-open connection rather than printing them

## Trying it

Nothing here is site-specific: image references are bare local tags, so
`kind load docker-image` / `minikube image load` works with no edits, and
`ingress.yaml` is an example that names the two lines you have to change.
The README leads with the path that needs no container and no cluster at
all — `unikernel/k8s/smoke.sh` and the full `qemu-system-x86_64`
invocation, spelled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x
