### PR TITLE
net: learn a peer's MAC from the frames it sends us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The machine learns who is talking to it** — `stack_arp_prime` in
+  [PR #1018](https://github.com/nurl-lang/nurl/pull/1018) resolved the
+  gateway before anyone needed it, which covers every peer that arrives
+  through a router. It does nothing for a peer on the machine's own
+  subnet, and that case was measured rather than reasoned about:
+  Firecracker, a tap, three static addresses in one /24, `ip=` on the
+  kernel command line so no DHCP server answers on the stack's behalf,
+  and tcpdump timestamping both ends of the exchange
+  (`unikernel/tests/arp_learn_exp.sh`, manual — it needs root).
+
+  The first client cost nothing: Linux ARPs for the guest before it
+  sends anything, and the ARP handler already learns a sender that
+  asks for us — RFC 826's receive side, long since implemented. The
+  **second** client cost 858–1000 ms, because by then the host's
+  neighbour entry was valid, no second ARP went out, and the guest had
+  never heard of that address.
+
+  The wire says the interesting part. The ARP the guest sent in the
+  SYN-ACK's place was answered in 0.3 ms; the SYN-ACK itself left
+  856 ms after that, when TCP's retransmit timer fired. Resolution was
+  never the cost — the wait was entirely the timer.
+
+  `__learn_sender` now takes the sender's hardware address from any IP
+  frame addressed to us, under three guards: unicast sender MAC only,
+  on-subnet sender IP only (off-subnet, the Ethernet source is the
+  *router's* MAC and binding it to a host behind it records a next hop
+  that is not one), and never our own address. Second client: 3.7–7.9 ms,
+  and no ARP request for it at all.
+
+  `compiler/tests/net_frames.nu` keeps `(Δt, frame)` rather than the
+  frame: a golden that records only what came back passes whether the
+  answer left at once or a second later, which is exactly how this hid.
+  The new assertions report `NO` against the old code.
+
+- **`ip=A.B.C.D/prefix` and `gw=` on the kernel command line** — a guest
+  told what it is instead of asking. With `ip=` the DHCP client does not
+  run at all. Needed by any network with no DHCP server, and by any
+  measurement of the stack that wants nothing else answering for it.
+
+
 - **A NURL server on Kubernetes, with and without a machine under it** —
   [`unikernel/k8s/`](unikernel/k8s/README.md). One `server.nu` builds two
   ways and not a line of it differs between them: `build_image.sh` makes
@@ -88,6 +128,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pnpm at all. And `busybox` was missing: `packages/nurlbox` uses it as
   its differential oracle and *skips* when it is absent, which reads
   exactly like a suite that passed.
+
+
+### Fixed
+
+- **`unikernel/tests/hypervisor_gate.sh` could not actually boot
+  Firecracker.** From v1.16 the one-shot JSON config requires a `drives`
+  field even when it is empty, and without it Firecracker refuses the
+  config — which the gate reported as a failed boot of a perfectly good
+  image. Nothing noticed, because the gate SKIPs when firecracker is not
+  installed and CI does not install it. With the field present it now
+  says `PASS firecracker booted the unchanged image`, which is the first
+  time anything in this repository has watched a hypervisor other than
+  QEMU boot the image rather than only checking the PVH note.
 
 ## [0.53.0] — 2026-08-26
 

--- a/compiler/tests/net_frames.nu
+++ b/compiler/tests/net_frames.nu
@@ -19,6 +19,8 @@ $ `stdlib/net/ipv4.nu`
 $ `stdlib/net/arp.nu`
 $ `stdlib/net/icmp.nu`
 $ `stdlib/net/udp4.nu`
+$ `stdlib/net/pktbuf.nu`
+$ `stdlib/net/stack.nu`
 
 @ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
 
@@ -29,6 +31,65 @@ $ `stdlib/net/udp4.nu`
 @ our_ip → i { ^ ( ipv4_make 10 0 2 15 ) }
 
 @ peer_ip → i { ^ ( ipv4_make 10 0 2 2 ) }
+
+// A second peer on our own subnet that we have never exchanged a
+// packet with, and a host beyond the router that we have not either.
+@ stranger_ip → i { ^ ( ipv4_make 10 0 2 77 ) }
+
+@ stranger_mac → i { ^ 2199023255629 }  // 02:00:00:00:00:4d
+
+@ far_ip → i { ^ ( ipv4_make 198 51 100 9 ) }
+
+@ router_mac → i { ^ 2199023255551 }  // 02:00:00:00:00:ff
+
+@ our_mask → i { ^ ( ipv4_mask_from_prefix 24 ) }
+
+@ our_gw → i { ^ ( ipv4_make 10 0 2 1 ) }
+
+// Build an Ethernet+IPv4 frame from an arbitrary sender — the sender's
+// MAC and IP separately, because the whole question below is whether
+// the two get bound together.
+@ mk_udp_frame_from i src_mac i src_ip → ( Vec u ) {
+    : ( Vec u ) pay ( vec_new [u] )
+    ( vec_push [u] pay # u 1 )
+    : ( Vec u ) dg ( vec_new [u] )
+    ( udp4_push dg src_ip ( our_ip ) 4243 53 pay 0 1 )
+    : ( Vec u ) f ( vec_new [u] )
+    ( eth_push_header f ( our_mac ) src_mac ( ethertype_ipv4 ) )
+    ( ip4_push_header f src_ip ( our_ip ) ( ip_proto_udp ) ( vec_len [u] dg ) 4661 64 T )
+    ( vec_extend [u] f dg )
+    ~ < ( vec_len [u] f ) 60 { ( vec_push [u] f # u 0 ) }
+    ( vec_free [u] dg )
+    ( vec_free [u] pay )
+    ^ f
+}
+
+// How long the stack takes to put an answer to `dst` on the wire,
+// measured the way the wire measures it: the caller is TCP, so a
+// datagram that did not go out is retried when the retransmit timer
+// fires and not before. Answers the simulated milliseconds between the
+// request arriving and the answer leaving, or -1 if it never left.
+//
+// This is the (delta-t, frame) shape the golden keeps. Recording only
+// the frame passes whether the answer left at once or a second later,
+// which is exactly the bug that hid here: the ARP resolved in 0.3 ms
+// and the SYN-ACK it displaced left 856 ms after that, measured on a
+// Firecracker tap with no DHCP and no slirp in the picture.
+@ answer_delay_ms * NetStack st i dst i t0 → i {
+    : ( Vec u ) dg ( vec_new [u] )
+    ( vec_push [u] dg # u 7 )
+    : ~ i now t0
+    : ~ i sent_at -1
+    : *PktBuf out ( pktbuf_new )
+    ~ && == sent_at -1 <= now + t0 4000 {
+        ( pktbuf_clear out )
+        : TxResult t ( stack_tx_ip4 st 0 dst ( ip_proto_udp ) dg 0 1 now out )
+        ? == . t status ( tx_sent ) { = sent_at now } { = now + now 1000 }
+    }
+    ( pktbuf_free out )
+    ( vec_free [u] dg )
+    ^ ? == sent_at -1 -1 - sent_at t0
+}
 
 // Build a full Ethernet+IPv4 frame carrying `payload`, as a peer would.
 @ mk_ip_frame i proto ( Vec u ) payload i pad_to → ( Vec u ) {
@@ -255,6 +316,64 @@ $ `stdlib/net/udp4.nu`
     ( pb `cache stays bounded at max: ` == ( vec_len [ArpEntry] . c entries ) 4 )
     ( pb `most recent insert survived: ` ?? ( arp_cache_lookup c ( ipv4_make 10 0 9 19 ) 80000 ) { T m → == m 1019 F → F } )
     ( arp_cache_free c )
+
+    // ── (delta-t, frame): WHEN the answer goes out ───────────────
+    //
+    // A peer on our own subnet that the cache has never heard of sends
+    // us a datagram, and we answer it. The frame that comes back is
+    // the same frame either way; the question the golden has to keep
+    // is how long it took, because the whole defect was invisible to a
+    // golden that kept only the frame.
+
+    : *NetStack ls ( stack_new ( our_mac ) ( our_ip ) ( our_mask ) ( our_gw ) )
+    : ( Vec u ) from_stranger ( mk_udp_frame_from ( stranger_mac ) ( stranger_ip ) )
+    : *PktBuf lout ( pktbuf_new )
+    : RxResult lr ( stack_rx ls from_stranger 1000 lout )
+    ( pb `stranger's datagram accepted: ` == . lr kind ( rx_udp ) )
+    ( pktbuf_clear lout )
+    ( pb `answer to the stranger leaves at once (delta-t 0 ms): `
+    == ( answer_delay_ms ls ( stranger_ip ) 1000 ) 0 )
+
+    // The same measurement against a peer that has said nothing, so the
+    // assertion above cannot pass for the wrong reason. Here the first
+    // attempt emits an ARP request in the datagram's place; the peer
+    // answers it three milliseconds later; and the datagram itself does
+    // not leave until the caller retries, which for TCP is a
+    // retransmit timer away. Delta-t 1000, for a resolution that took 3.
+    : *NetStack qs ( stack_new ( our_mac ) ( our_ip ) ( our_mask ) ( our_gw ) )
+    : i silent ( ipv4_make 10 0 2 88 )
+    : ( Vec u ) qdg ( vec_new [u] )
+    ( vec_push [u] qdg # u 7 )
+    : *PktBuf qout ( pktbuf_new )
+    : TxResult q1 ( stack_tx_ip4 qs 0 silent ( ip_proto_udp ) qdg 0 1 1000 qout )
+    ( pb `a silent peer displaces the datagram with an ARP request: `
+    == . q1 status ( tx_arp_pending ) )
+    ( pktbuf_clear qout )
+    : ( Vec u ) qrep ( vec_new [u] )
+    ( arp_push_frame qrep ( arp_op_reply ) ( our_mac ) 2199023255630 silent ( our_mac ) ( our_ip ) )
+    : RxResult qr ( stack_rx qs qrep 1003 qout )
+    ( pb `the ARP reply lands 3 ms later: ` == . qr kind ( rx_arp_handled ) )
+    ( pktbuf_clear qout )
+    : TxResult q2 ( stack_tx_ip4 qs 0 silent ( ip_proto_udp ) qdg 0 1 2000 qout )
+    ( pb `and the datagram waits for the retry, not for the ARP (delta-t 1000 ms): `
+    == . q2 status ( tx_sent ) )
+    ( pktbuf_free qout )
+    ( vec_free [u] qdg ) ( vec_free [u] qrep )
+    ( stack_free qs )
+
+    // And the lie we must not learn: a datagram from beyond the router
+    // arrives with the ROUTER's MAC in the Ethernet header. Binding the
+    // far host's IP to it records a next hop that is not one.
+    : ( Vec u ) from_far ( mk_udp_frame_from ( router_mac ) ( far_ip ) )
+    : RxResult fr ( stack_rx ls from_far 1000 lout )
+    ( pb `off-subnet datagram accepted: ` == . fr kind ( rx_udp ) )
+    ( pktbuf_clear lout )
+    ( pb `off-subnet sender is NOT learned: `
+    ?? ( arp_cache_lookup . ls arp ( far_ip ) 1000 ) { T m → F F → T } )
+
+    ( pktbuf_free lout )
+    ( vec_free [u] from_stranger ) ( vec_free [u] from_far )
+    ( stack_free ls )
 
     // Vec is a manually-managed handle (docs/MEMORY.md §7.4).
     ( vec_free [u] small ) ( vec_free [u] runt ) ( vec_free [u] udp_pay )

--- a/compiler/tests/outputs/net_frames.txt
+++ b/compiler/tests/outputs/net_frames.txt
@@ -77,3 +77,10 @@ expire reclaims 1: YES
 expire again reclaims 0: YES
 cache stays bounded at max: YES
 most recent insert survived: YES
+stranger's datagram accepted: YES
+answer to the stranger leaves at once (delta-t 0 ms): YES
+a silent peer displaces the datagram with an ARP request: YES
+the ARP reply lands 3 ms later: YES
+and the datagram waits for the retry, not for the ARP (delta-t 1000 ms): YES
+off-subnet datagram accepted: YES
+off-subnet sender is NOT learned: YES

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -253,6 +253,41 @@ $ `stdlib/net/pktbuf.nu`
     ^ @ RxResult { ( rx_icmp_echo ) 0 . ih src . ih dst . im id . im seq . im payload_off . im payload_len - ( pktbuf_total out ) before }
 }
 
+// Learn a peer's hardware address from a frame it sent us.
+//
+// RFC 826's receive side, one step further than the ARP handler takes
+// it: a frame that reached this machine already carries its sender's
+// hardware address in the header we just parsed, so a peer that talks
+// to us never has to be asked who it is. Without this the machine
+// answers an unknown on-subnet peer's SYN by ARPing for it — and the
+// ARP is not the cost. Measured on a tap, with Firecracker and no
+// DHCP: the ARP request went out 12 ms after the SYN, the reply came
+// back 0.3 ms later, and the SYN-ACK that had been dropped in the
+// request's place left 856 ms after that, when TCP's retransmit timer
+// fired. Resolution was instant; the wait was entirely the timer.
+//
+// Three guards, and each is the difference between learning and being
+// told a lie:
+//   * only from a frame addressed to us — the caller checks that
+//     before calling this;
+//   * only a unicast sender MAC, because a broadcast or multicast
+//     address is not one anybody can be reached at;
+//   * only an on-subnet sender IP. Off-subnet, the Ethernet source is
+//     the ROUTER's MAC and the IP source is a host behind it: binding
+//     those two together records a next hop that is not one, and the
+//     entry outlives whatever made it look right.
+@ __learn_sender * NetStack st i src_ip i src_mac i now → v {
+    ? == . st our_ip 0 { ^ v } {}
+    ? == . st netmask 0 { ^ v } {}
+    ? ( mac_is_broadcast src_mac ) { ^ v } {}
+    ? ( mac_is_multicast src_mac ) { ^ v } {}
+    ? == src_mac 0 { ^ v } {}
+    ? ! ( ipv4_is_assignable src_ip ) { ^ v } {}
+    ? == src_ip . st our_ip { ^ v } {}
+    ? ! ( ipv4_in_subnet src_ip . st our_ip . st netmask ) { ^ v } {}
+    ( arp_cache_insert . st arp src_ip src_mac now )
+}
+
 // Feed one received frame. Any reply is appended to `out`; the caller
 // transmits whatever `out` gained.
 @ stack_rx * NetStack st ( Vec u ) frame i now * PktBuf out → RxResult {
@@ -291,6 +326,7 @@ $ `stdlib/net/pktbuf.nu`
         ( __count_drop st ( drop_not_our_ip ) )
         ^ ( __rx_drop ( drop_not_our_ip ) )
     } {}
+    ( __learn_sender st . ih src . eh src now )
     ? == . ih proto ( ip_proto_icmp ) { ^ ( __rx_icmp st frame ih now out ) } {}
     ? == . ih proto ( ip_proto_tcp ) {
         ^ @ RxResult {

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -263,6 +263,8 @@ rather than guessed:
 | `wallclock=N` | the boot epoch, seconds | whenever X.509 validity is checked: TLS client verification, and a server whose certificate has dates |
 | `virtio_mmio.device=…` | where the devices are | appended by the hypervisor; the guest parses it, and a guest with no match reports "no device" rather than probing blindly |
 | `args="…"` | the program's argv | when the program takes arguments. ONE key, quoted, because QEMU appends its own entries after `-append` and a program that read the tail of the line would be handed them |
+| `ip=A.B.C.D/prefix` | the machine's own address | on a network with no DHCP server — a tap with static addresses, for instance. Told beats asked: with this key the guest does not run the DHCP client at all. Stated-but-unparseable exits 127 |
+| `gw=A.B.C.D` | the default route | with `ip=`, when peers are off-subnet. Optional: a machine whose peers are all on its own subnet needs none, and an invented gateway is a first packet sent to a host that is not there |
 | `dns=ip[:port]` | the resolver | when a name must resolve and DHCP's option 6 is absent or wrong; stated-but-unparseable exits 127 rather than resolving against a guessed server |
 | `disk=rw\|ro\|format\|off` | what to do with the block device | only to say something other than `rw`. `ro` refuses every write with EROFS; `format` writes a filesystem **only onto a device that does not mount**, so it is not a reformat-on-every-boot switch; `off` makes the machine behave exactly as one with no disk. A guest with no virtio-blk device ignores the key |
 

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -163,7 +163,11 @@ $ `stdlib/net/dnsclient.nu`
     // before the first bind: a listener with a source address of
     // 0.0.0.0 checksums every segment against the wrong pseudo-header
     // and goes unanswered.
-    ? != have 0 { ( __dhcp_configure sh ) } {}
+    // Told, or asked — in that order. `ip=` is the host stating a fact,
+    // and a machine that was told does not then go and ask.
+    ? != have 0 {
+        ? ( __ip_cmdline sh ) {} { ( __dhcp_configure sh ) }
+    } {}
     // `dns=ip[:port]` on the kernel command line overrides whatever
     // DHCP said — the same contract as wallclock=: the host states a
     // fact the guest cannot discover. Stated but unparseable is a
@@ -298,6 +302,71 @@ $ `stdlib/net/dnsclient.nu`
         } {}
     }
     ( pktbuf_free out )
+}
+
+// `ip=A.B.C.D/prefix` (with optional `gw=A.B.C.D`) on the kernel
+// command line: a machine told what it is, instead of asking. Answers T
+// when it configured the stack, F when the key is absent.
+//
+// This is not a convenience alternative to DHCP. It is what a machine
+// needs on a network that has no DHCP server — a Firecracker tap with
+// three static addresses on it, for instance — and it exists because
+// measuring the stack's own behaviour means removing everything that
+// answers on its behalf. Stated but unparseable panics like a bad
+// `dns=` does, rather than quietly falling back to asking.
+@ __ip_cmdline * Shim sh → b {
+    : s v ( getenv `ip` )
+    ? == # i v 0 { ^ F } {}
+    : i n ( nurl_str_len v )
+    : ~ i slash -1
+    : ~ i k 0
+    ~ < k n { ? == ( nurl_str_get v k ) 47 { = slash k } {} = k + k 1 }
+    : ~ i ok 0
+    : ~ i addr 0
+    : ~ i mask 0
+    ? >= slash 0 {
+        : s ipbuf ( nurl_alloc + slash 1 )
+        ( nurl_memcpy ipbuf v slash )
+        : *u zp # *u + # i ipbuf slash
+        = . zp 0 # u 0
+        : i bits ( nurl_str_to_int # s + # i v + slash 1 )
+        ?? ( ipv4_parse ipbuf ) {
+            T a → {
+                ? && && > bits 0 <= bits 32 ( ipv4_is_assignable a ) {
+                    = addr a
+                    = mask ( ipv4_mask_from_prefix bits )
+                    = ok 1
+                } {}
+            }
+            F → {}
+        }
+        ( nurl_free ipbuf )
+    } {}
+    ? == ok 0 {
+        ( nurl_print `nurl: ip= on the kernel command line is not A.B.C.D/prefix\n` )
+        ( nurl_flush_stdout )
+        ( nurl_exit 127 )
+    } {}
+    // A gateway is optional: a machine whose peers are all on its own
+    // subnet needs none, and inventing one would send its first
+    // off-subnet packet to a host that is not there.
+    : ~ i gw 0
+    : s gv ( getenv `gw` )
+    ? != # i gv 0 {
+        ?? ( ipv4_parse gv ) {
+            T g → = gw g
+            F → {
+                ( nurl_print `nurl: gw= on the kernel command line is not A.B.C.D\n` )
+                ( nurl_flush_stdout )
+                ( nurl_exit 127 )
+            }
+        }
+    } {}
+    ( stack_set_address . sh net addr mask gw )
+    ( sock_set_our_ip . sh st addr )
+    ( sock_seed_addr . sh st addr ( __ms ) )
+    ? != gw 0 { ( __arp_warm sh ) } {}
+    ^ T
 }
 
 // Run the DHCP client — the same state machine `net/dhcp.nu` covers

--- a/unikernel/tests/arp_learn_exp.sh
+++ b/unikernel/tests/arp_learn_exp.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/tests/arp_learn_exp.sh — how long does a freshly booted
+#  machine take to answer the FIRST connection from an on-subnet peer
+#  it has never heard of?
+#
+#  MANUAL. Not part of any suite and not run by CI, because it needs
+#  root (a tap device), a Firecracker binary, and tcpdump. It is here
+#  because it is the evidence behind `__learn_sender` in
+#  stdlib/net/stack.nu, and a claim about microseconds on a wire should
+#  be re-runnable by whoever doubts it.
+#
+#  Usage:
+#      NURL_FIRECRACKER=/path/to/firecracker \
+#      unikernel/tests/arp_learn_exp.sh [image.elf] [tag]
+#
+#  Every variable that could answer on the stack's behalf is removed:
+#
+#    no QEMU      — Firecracker boots the same PVH image, so the
+#                   hypervisor is not part of what is being measured
+#    no slirp     — a real tap; frames are frames
+#    no DHCP      — `ip=` on the kernel command line (the guest does not
+#                   run a DHCP client at all when it is told)
+#    no guessing  — tcpdump on the tap timestamps the inbound SYN and
+#                   the outbound SYN-ACK. Neither endpoint is asked.
+#
+#  Three addresses in one /24 on the tap: .1 is the host's primary
+#  (the address Linux ARPs from), .2 is clientA, .3 is clientB, and the
+#  guest is .10. clientA is cheap either way — Linux's own ARP request
+#  for the guest teaches the guest who .2 is, which is RFC 826's
+#  receive side and was already implemented. clientB is the question:
+#  by then the host's neighbour entry is valid, so no second ARP goes
+#  out, and the guest has never heard of .3.
+#
+#  Measured before `__learn_sender` (2026-08-27), across runs:
+#      client .2   SYN -> SYN-ACK       0.9-1.0 ms
+#      client .3   SYN -> SYN-ACK   858.0-999.6 ms
+#  and on the wire the reason, which is not the one the number suggests:
+#      0.029  IP   .3 > .10:8080  SYN
+#      0.041  ARP  who-has .3 tell .10        <- the SYN-ACK's place
+#      0.041  ARP  reply .3 is-at ...         <- resolved in 0.3 ms
+#      0.897  IP   .10:8080 > .3  SYN-ACK     <- 856 ms of retransmit timer
+#  After: 0.9-1.0 ms and 3.7-7.9 ms, and no ARP request for .3 at all.
+# ============================================================
+set -uo pipefail
+
+# awk's %f and its arithmetic follow the locale: on a Finnish desktop
+# the decimal separator is a comma, the subtraction below yields 0, and
+# every measurement prints as 0.0 ms — a harness that reports a perfect
+# result because it cannot do arithmetic. hypervisor_gate.sh carries the
+# same scar for readelf. CI never sees it; the fix belongs here.
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FC="${NURL_FIRECRACKER:-firecracker}"
+IMG="${1:-$ROOT/build/unikernel/k8sd.elf}"
+tag="${2:-arp}"
+OUT="${NURL_EXP_OUT:-$(mktemp -d)}"
+TAP="${NURL_EXP_TAP:-nurl0}"
+NET="${NURL_EXP_NET:-172.31.7}"
+GUEST_MAC=02:00:00:00:77:10
+
+command -v "$FC" >/dev/null 2>&1 || { echo "no firecracker (set NURL_FIRECRACKER)" >&2; exit 3; }
+command -v tcpdump >/dev/null 2>&1 || { echo "no tcpdump" >&2; exit 3; }
+[ -f "$IMG" ] || { echo "no image at $IMG" >&2; exit 2; }
+[ -w /dev/kvm ] || { echo "no /dev/kvm — Firecracker does not emulate" >&2; exit 3; }
+sudo -n true 2>/dev/null || { echo "needs sudo for the tap and tcpdump" >&2; exit 3; }
+
+cleanup() {
+    [ -n "${fcpid:-}" ] && kill "$fcpid" 2>/dev/null
+    sudo ip link del "$TAP" 2>/dev/null
+}
+trap cleanup EXIT
+
+sudo ip link del "$TAP" 2>/dev/null
+sudo ip tuntap add dev "$TAP" mode tap user "$USER"
+for a in 1 2 3; do sudo ip addr add "$NET.$a/24" dev "$TAP"; done
+sudo ip link set "$TAP" up
+
+# Under TCG the guest's rdtsc is the host's; under KVM the leaf answers
+# and this is ignored. Firecracker is KVM-only, so this is belt and
+# braces — and the wrong value here is what once made a four-second
+# DHCP delay look like a working boot.
+TSC=$(sed -n 's/^model name.*@ *\([0-9.]*\)GHz.*/\1/p' /proc/cpuinfo | head -1 |
+      awk '{printf "%d", $1 * 1000000}')
+[ -n "$TSC" ] || TSC=1000000
+
+cat > "$OUT/fc.json" <<JSON
+{
+  "boot-source": {
+    "kernel_image_path": "$IMG",
+    "boot_args": "tsc_khz=$TSC wallclock=$(date +%s) ip=$NET.10/24 port=8080 pod=exp platform=unikernel"
+  },
+  "drives": [],
+  "network-interfaces": [
+    { "iface_id": "eth0", "host_dev_name": "$TAP", "guest_mac": "$GUEST_MAC" }
+  ],
+  "machine-config": { "vcpu_count": 1, "mem_size_mib": 256 }
+}
+JSON
+
+sudo tcpdump -i "$TAP" -nn -tt -s 128 -w "$OUT/$tag.pcap" -U > "$OUT/tcpdump.log" 2>&1 &
+for _ in $(seq 1 100); do grep -q "listening on" "$OUT/tcpdump.log" 2>/dev/null && break; sleep 0.05; done
+grep -q "listening on" "$OUT/tcpdump.log" || { echo "tcpdump did not start:"; cat "$OUT/tcpdump.log"; exit 1; }
+
+"$FC" --no-api --config-file "$OUT/fc.json" > "$OUT/$tag.console" 2>&1 &
+fcpid=$!
+for _ in $(seq 1 500); do grep -q 'serving on' "$OUT/$tag.console" 2>/dev/null && break; sleep 0.02; done
+grep -q 'serving on' "$OUT/$tag.console" || { echo "guest never listened:"; cat "$OUT/$tag.console"; exit 1; }
+
+for c in 2 3; do
+    code=$(curl -sS -o /dev/null -m 10 -w '%{http_code}' --interface "$NET.$c" \
+           "http://$NET.10:8080/healthz" 2>/dev/null)
+    echo "client $NET.$c: http=$code"
+done
+
+sleep 2
+# SIGINT, and to tcpdump itself rather than to the sudo that started
+# it: a SIGTERM to the parent leaves the capture unflushed, and a run
+# whose capture was never flushed looks exactly like a run in which
+# nothing happened. That cost an hour once.
+td=$(pgrep -f "tcpdump -i $TAP" | tail -1)
+[ -n "$td" ] && sudo kill -INT "$td"
+sleep 1
+sudo chmod a+r "$OUT/$tag.pcap" 2>/dev/null
+
+echo
+echo "--- $OUT/$tag.pcap ---"
+tcpdump -r "$OUT/$tag.pcap" -nn -tt -q 2>/dev/null |
+awk -v net="$NET" '
+    NR == 1 { t0 = $1 }
+    { printf "%8.3f  %s\n", $1 - t0, substr($0, index($0, $2)) }
+    $2 == "IP" {
+        split($3, s, "."); split($5, d, ".")
+        src = s[1]"."s[2]"."s[3]"."s[4]; sport = s[5]
+        dst = d[1]"."d[2]"."d[3]"."d[4]; dport = d[5]
+        sub(":", "", dport)
+        if (dport == "8080" && !(src in syn)) syn[src] = $1
+        if (sport == "8080" && (dst in syn) && !(dst in done)) {
+            ans[dst] = ($1 - syn[dst]) * 1000; done[dst] = 1
+        }
+    }
+    END {
+        printf "\n"
+        for (c in ans) printf "%16s: first SYN -> first packet back = %8.1f ms\n", c, ans[c]
+    }
+'

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -250,6 +250,11 @@ boot_ch() {
 boot_fc() {
     command -v "$FC" >/dev/null 2>&1 || { skipped="$skipped firecracker"; return 0; }
     # Firecracker is API-driven; the one-shot form takes a JSON config.
+    # `drives` is required even when empty from v1.16 on — without it a
+    # modern Firecracker refuses the config with "missing field `drives`"
+    # and the gate reports a boot failure against a perfectly good image.
+    # Nothing here noticed, because the gate SKIPS when firecracker is
+    # not installed and CI does not install it.
     cfg=$(mktemp); log=$(mktemp)
     cat > "$cfg" <<EOF
 {
@@ -257,6 +262,7 @@ boot_fc() {
     "kernel_image_path": "$IMG",
     "boot_args": "tsc_khz=1000000 wallclock=$(date +%s)"
   },
+  "drives": [],
   "machine-config": { "vcpu_count": 1, "mem_size_mib": 64 }
 }
 EOF


### PR DESCRIPTION
`stack_arp_prime` (#1018) resolves the gateway before anything needs it.
That covers every peer arriving through a router and nothing at all for
a peer on the machine's own subnet — so this one was **measured**, with
everything that could answer on the stack's behalf taken out of the
picture:

* **Firecracker**, not QEMU — the hypervisor is not part of what is
  being measured
* **a tap**, not slirp — frames are frames
* **`ip=` on the kernel command line**, not DHCP — the guest is told
  what it is, and does not run a DHCP client at all
* **tcpdump on the tap** — neither endpoint's opinion is asked

Three addresses in one /24: `.1` is the host's primary (the address
Linux ARPs from), `.2` and `.3` are the two clients, the guest is `.10`.
Harness: `unikernel/tests/arp_learn_exp.sh` — manual, since it needs
root, a tap and a firecracker binary.

## What the wire said

The first client cost nothing, which was the first surprise. Linux ARPs
for the guest before it sends anything, and `__rx_arp` already learns a
sender that asks for us — **RFC 826's receive side has been there all
along**. The *second* client cost 858–1000 ms: by then the host's
neighbour entry was valid, no second ARP went out, and the guest had
never heard of that address.

```
0.029  IP   .3 > .10:8080   SYN
0.041  ARP  who-has .3 tell .10      <- sent in the SYN-ACK's place
0.041  ARP  reply .3 is-at ...       <- resolved in 0.3 ms
0.897  IP   .10:8080 > .3   SYN-ACK  <- 856 ms of retransmit timer
```

**Resolution was never the cost.** The ARP completed in 0.3 ms and the
displaced SYN-ACK then sat for 856 ms waiting for TCP's retransmit
timer. No amount of making ARP faster would have moved that number.

| | before | after |
|---|---|---|
| client `.2` SYN → SYN-ACK | 0.9–1.0 ms | 0.9–1.0 ms |
| client `.3` SYN → SYN-ACK | **858–1000 ms** | **3.7–7.9 ms** |
| guest ARP requests for `.3` | 1 | 0 |

## The fix

`__learn_sender` takes the sender's hardware address from any IP frame
addressed to us, under three guards — each the difference between
learning and being told a lie:

* **unicast sender MAC only** — a broadcast or multicast address is not
  one anybody can be reached at;
* **on-subnet sender IP only** — off-subnet the Ethernet source is the
  *router's* MAC and the IP source is a host behind it; binding those
  together records a next hop that is not one, and the entry outlives
  whatever made it look right;
* **never our own address.**

## The gate: (Δt, frame), not frame

`compiler/tests/net_frames.nu` now records **when** the answer leaves,
because a golden that keeps only what came back passes whether it left
at once or a second later — which is precisely how this hid. The test
drives the stack with a caller that retries on TCP's schedule:

* a peer that just sent us a datagram is answered at **Δt 0 ms**;
* a silent peer, whose ARP reply lands 3 ms in, is not answered until
  **Δt 1000 ms** — the negative control, so the first assertion cannot
  pass for the wrong reason;
* an off-subnet sender is **not** learned.

Run against the old code, the first of those reports `NO`.

## Two prerequisites the measurement dragged in

**`ip=A.B.C.D/prefix` and `gw=`** on the kernel command line — a guest
told what it is instead of asking. With `ip=` the DHCP client does not
run at all. Needed by any network with no DHCP server, and by any
measurement that wants nothing else answering for the stack.

**`hypervisor_gate.sh` could not actually boot Firecracker.** From v1.16
the one-shot JSON config requires a `drives` field even when it is
empty; without it Firecracker refuses the config, which the gate
reported as a failed boot of a perfectly good image. Nothing noticed,
because the gate SKIPs when firecracker is absent and CI does not
install it. It now says `PASS firecracker booted the unchanged image` —
the first time anything in this repository has watched a hypervisor
other than QEMU boot the image rather than only checking the PVH note.

The harness also carries an `LC_ALL=C` of its own: awk's arithmetic
follows the locale, and on a comma-decimal desktop every measurement
printed as `0.0 ms` — a harness reporting a perfect result because it
could not subtract. `hypervisor_gate.sh` has the same scar for
`readelf`.

## What this does not fix

A guest that *initiates* a connection to an on-subnet peer it has never
heard from still pays the retransmit timer: nothing has spoken to it
yet, so there is nothing to learn from. Closing that needs a queue for
the pending datagram or a retry driven by the ARP reply, which is a
change to `stack_tx_ip4`'s ownership story and belongs in its own PR.

## Gates

`./build.sh` (bootstrap fixed point + corpus) green · QEMU guest suite
**29/29** · nolibc corpus **517/0** · nolibc unit gates all pass ·
`hypervisor_gate` PASS under Firecracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x
