### PR TITLE
k8s: give the guest /dev/kvm without giving its pod the node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`unikernel/k8s/kvm-device-plugin.yaml`** — a device plugin so the
+  guest can be given `/dev/kvm` without giving its pod the node. A
+  workload adds `devic.es/kvm: 1` to its limits and stays exactly as
+  unprivileged as it was; the scheduler, not a hand-maintained
+  nodeSelector, knows which nodes have the device.
+
+  Measured on one node, same image and same pod spec with and without
+  it — 2000 sequential requests, CPU read from the container's own
+  cgroup rather than sampled: **276–306 µs of CPU per request against
+  940–991 µs**, idle 5 millicores against 22, boot 35–45 ms against
+  53–97 ms. The wall-clock difference (1.15 ms against 1.48–1.82 ms) is
+  the least interesting number of the set.
+
+  Two things the README says out loud because both fail quietly. The
+  device arrives owned by `root:kvm 0660`, so a container running as a
+  non-root user needs `supplementalGroups` with that node's gid — and
+  without it QEMU simply emulates: the pod comes up, passes its probes,
+  serves correct answers, and is slower. And requesting the resource
+  collapses a deployment onto the nodes that have it, trading
+  availability for speed in a one-line diff.
+
 - **The machine learns who is talking to it** — `stack_arp_prime` in
   [PR #1018](https://github.com/nurl-lang/nurl/pull/1018) resolved the
   gateway before anyone needed it, which covers every peer that arrives

--- a/unikernel/k8s/README.md
+++ b/unikernel/k8s/README.md
@@ -107,9 +107,11 @@ seccomp, no privileged flag, no `/dev/kvm`, no `runtimeClass`. It is as
 unprivileged as a static file server, and what it serves is a machine.
 
 `/dev/kvm` is used *if the node hands it over* — `entrypoint.sh` checks
-and falls back to TCG — but the manifest does not ask for it, because
-asking means either a privileged container or a device plugin, and the
-measurements below are the ones without it.
+and falls back to TCG — but `deploy.yaml` does not ask for it, because
+asking means either a privileged container or a device plugin. The
+measurements below are the ones without it;
+[**giving the guest KVM**](#optional-giving-the-guest-kvm) is a section
+of its own, with the numbers it buys and the two things that bite.
 
 The one hard constraint is `nodeSelector: kubernetes.io/arch: amd64`.
 PVH is an x86 boot protocol; on AArch64 the same build emits a flat
@@ -244,3 +246,58 @@ the static manifest) and the program repeats it.
   longer runs in production — and the isolation boundary, which is the
   only reason left to pay for a hypervisor once a workload is
   stateless.
+
+## Optional: giving the guest KVM
+
+`kvm-device-plugin.yaml` runs a device plugin on the nodes that have
+`/dev/kvm`, after which a workload asks for `devic.es/kvm: 1` and stays
+exactly as unprivileged as it was — no privileged flag, no hostPath, no
+capability added. The scheduler, rather than a hand-maintained
+nodeSelector, knows where the device is.
+
+```sh
+kubectl apply -f unikernel/k8s/kvm-device-plugin.yaml
+kubectl label node <node> devic.es/kvm=true
+kubectl -n nurl-unikernel patch deploy nurl-unikernel --type strategic -p '
+  {"spec":{"template":{"spec":{
+     "securityContext":{"supplementalGroups":[993]},
+     "containers":[{"name":"qemu","resources":{"limits":{"devic.es/kvm":"1"}}}]}}}}'
+```
+
+`993` is the gid of the `kvm` group **on that node** (`getent group
+kvm`), not a constant. The device arrives in the container with the
+host's ownership — `root:kvm 0660` — and a container running as a
+non-root user is not in that group. What makes this worth spelling out
+is the failure mode: QEMU's answer to `EACCES` on `/dev/kvm` is to
+emulate instead, so the pod comes up, passes its probes, serves correct
+answers, and is simply slower. `entrypoint.sh` logs `accel=kvm` or
+`accel=tcg` on its first line; that line is the check.
+
+### What it buys, measured
+
+Same image, same node, same pod spec, one with the device and one
+without. Latency and CPU are 2000 sequential keep-alive requests to
+`/healthz`; the CPU figure is the container's own cgroup accounting
+(`cpu.stat usage_usec`), not a sampled estimate. Idle is 30 s with only
+the kubelet's probes.
+
+| | KVM | TCG |
+|---|---|---|
+| boot: `entrypoint` → listening | 35–45 ms | 53–97 ms |
+| wall time per request | 1.15–1.17 ms | 1.48–1.82 ms |
+| **container CPU per request** | **276–306 µs** | **940–991 µs** |
+| idle | 5 millicores | 22 millicores |
+
+The wall-clock difference is the least interesting number here — it is
+mostly client and network path. The CPU is the one that decides whether
+this is a resident or a demo: **~3.3× less CPU per request and ~4× less
+at idle**, on a workload whose guest is halting between poller ticks
+either way.
+
+### The trade nobody announces
+
+Requesting the resource collapses the deployment onto the nodes that
+have it. On a cluster where one node has `vmx` and the others do not,
+adding one line to a manifest converts a two-node deployment into a
+single-node one — availability traded for speed, silently, unless
+somebody says so. This section is that somebody.

--- a/unikernel/k8s/kvm-device-plugin.yaml
+++ b/unikernel/k8s/kvm-device-plugin.yaml
@@ -1,0 +1,93 @@
+# unikernel/k8s/kvm-device-plugin.yaml — so that /dev/kvm can be
+# REQUESTED rather than taken.
+#
+# `deploy.yaml` deliberately does not ask for KVM: asking means either a
+# privileged container with a hostPath onto /dev/kvm — which hands that
+# pod the whole node — or a device plugin. This is the device plugin.
+# After it, a workload adds one resource request and stays as
+# unprivileged as it was, and the SCHEDULER knows which nodes have the
+# device instead of a nodeSelector somebody has to maintain.
+#
+# Apply, label the nodes that actually have /dev/kvm, then ask for it:
+#
+#   kubectl apply -f unikernel/k8s/kvm-device-plugin.yaml
+#   kubectl label node <node> devic.es/kvm=true
+#   kubectl -n nurl-unikernel patch deploy nurl-unikernel --type strategic -p '
+#     {"spec":{"template":{"spec":{
+#        "securityContext":{"supplementalGroups":[<gid of the kvm group on that node>]},
+#        "containers":[{"name":"qemu","resources":{"limits":{"devic.es/kvm":"1"}}}]}}}}'
+#
+# TWO THINGS THAT WILL BITE:
+#
+#   * The device arrives in the container with the HOST's ownership,
+#     typically `root:kvm 0660`. A container that runs as a non-root
+#     user is not in that group and gets EACCES — and QEMU's fallback is
+#     to emulate, so the pod comes up, serves correctly, and is simply
+#     slower. `supplementalGroups` is the fix, and the gid is a property
+#     of the node (`getent group kvm`), not of this manifest.
+#
+#   * Requesting the resource collapses the deployment onto the nodes
+#     that have it. On a cluster where one node has vmx and the rest do
+#     not, that is a trade of availability for speed, made silently by
+#     adding a resource request. Say it out loud or leave KVM alone.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: device-plugins
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kvm-device-plugin
+  namespace: device-plugins
+  labels:
+    app: kvm-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app: kvm-device-plugin
+  template:
+    metadata:
+      labels:
+        app: kvm-device-plugin
+    spec:
+      # Only where the device exists. The label is set by hand because
+      # the fact it records — this node's CPU has vmx/svm and the kernel
+      # exposed /dev/kvm — is not something a plugin can advertise
+      # before it has been scheduled onto the node.
+      nodeSelector:
+        devic.es/kvm: "true"
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: plugin
+          image: ghcr.io/squat/generic-device-plugin:latest
+          args:
+            - --device
+            - |
+              {"name": "kvm", "groups": [{"count": 8, "paths": [{"path": "/dev/kvm"}]}]}
+          # count: 8 — /dev/kvm is not consumed by being opened, so the
+          # number is a policy about how many VM-shaped pods this node
+          # should run at once, not a property of the hardware.
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits:   { cpu: 100m, memory: 64Mi }
+          ports:
+            - containerPort: 8080
+              name: http
+          # The one privileged thing in this directory, and the reason
+          # everything else here is not: a node-level component so that
+          # workloads can stay ordinary.
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath: { path: /var/lib/kubelet/device-plugins }
+        - name: dev
+          hostPath: { path: /dev }


### PR DESCRIPTION
`deploy.yaml` still does not ask for KVM. This adds the thing that makes
asking cheap: a device plugin on the nodes that have `/dev/kvm`, after
which a workload adds `devic.es/kvm: 1` to its limits and stays **exactly
as unprivileged as it was** — no privileged flag, no hostPath onto
`/dev`, no capability added. The scheduler knows where the device is,
instead of a nodeSelector somebody has to keep in sync with the hardware.

The one privileged thing in the directory is now the DaemonSet, which is
a node-level component; everything else stayed ordinary.

## What it buys, measured

Same image, same node, same pod spec — one with the device and one
without. 2000 sequential keep-alive requests to `/healthz`; the CPU
figure is the container's own cgroup accounting (`cpu.stat usage_usec`),
not a sampled estimate; idle is 30 s with only the kubelet's probes.

| | KVM | TCG |
|---|---|---|
| boot: `entrypoint` → listening | 35–45 ms | 53–97 ms |
| wall time per request | 1.15–1.17 ms | 1.48–1.82 ms |
| **container CPU per request** | **276–306 µs** | **940–991 µs** |
| idle | 5 millicores | 22 millicores |

The wall-clock difference is the least interesting number in that table
— it is mostly client and network path. The CPU is the one that decides
whether this is a resident or a demo: **~3.3× less per request, ~4× less
at idle**, on a guest that halts between poller ticks either way.

## Two failure modes the README states out loud

Both are quiet, which is why they are in the docs rather than in a
comment.

**The device arrives with the host's ownership** — `root:kvm 0660` — and
a container running as a non-root user is not in that group.
`supplementalGroups` with that node's gid is the fix, and the gid is a
property of the node (`getent group kvm`), not a constant this manifest
can carry. What makes it worth a paragraph is the failure mode: QEMU's
answer to `EACCES` on `/dev/kvm` is to emulate instead, so the pod comes
up, passes its probes, serves correct answers, and is simply slower.
`entrypoint.sh`'s first line says `accel=kvm` or `accel=tcg`; that line
is the check.

**Requesting the resource collapses the deployment onto the nodes that
have it.** Where one node has `vmx` and the others do not, one line of
manifest turns a two-node deployment into a single-node one —
availability traded for speed, silently, unless somebody says so.

## Scope

Docs and one new manifest. No code, no goldens, nothing that CI's build
or test paths touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x
