### PR TITLE
unikernel: a page returned to the allocator has to come back mapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TLS 1.3 from the unikernel on Kubernetes** —
+  `unikernel/k8s/deploy-kvm.yaml`, built by `build_image.sh --tls`. The
+  same `server.nu` serves TLS when the launcher hands it `cert=` and
+  `key=`; the handshake is `stdlib/std/tls.nu`, pure NURL with no
+  libssl, which is why it links into a machine with no operating system.
+  It is also the workload that justifies the KVM device plugin: a
+  handshake is where a guest spends real cycles.
+
+  The server key is P-256 and that is not a preference. Measured in the
+  guest, same image, same handshake, only the key type differing:
+  **RSA-2048 costs ~490 ms per handshake, P-256 costs 4–11 ms** — ninety
+  times, and the difference between a TLS endpoint and a demonstration
+  that TLS is possible. `--tls` generates a self-signed P-256 key per
+  build, so no private key is ever committed.
+
+  TLS handshakes in six seconds, same image and key: **KVM 856, TCG
+  469**.
+
 ### Fixed
 
 - **A page returned to the guest's allocator came back unmapped.** Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A page returned to the guest's allocator came back unmapped.** Every
+  coroutine stack is allocated with a guard page below it, and arming
+  that guard clears the present bit in its PTE. When the coroutine
+  ended, `munmap` returned the whole range to the page allocator — and
+  touched no page tables, so the guard page went back into the pool with
+  that bit still clear. The pool handed it to somebody else, nolibc's
+  `malloc` carved an arena across it, and the first write to a block
+  that landed there took a page fault **inside malloc**, long after the
+  coroutine that protected it had gone.
+
+  Reachable by anyone who could open a TCP connection: twenty
+  connections that sent one byte and hung up killed a server. Narrowed
+  by measurement rather than reading — the same attack against the
+  sequential `server_run` did nothing, which put it on the fiber path;
+  it survived swapping `spawn_owned` for `spawn`, which cleared the
+  closure-environment free; and `nm` put the faulting instruction inside
+  `malloc`, on a write to a not-present page in the middle of an
+  ordinary heap. Guest memory size made no difference, so it was
+  corruption and not exhaustion.
+
+  `munmap` now restores a range's protection before releasing it, in
+  that order, so a range is never on the free list while it is
+  unmapped — with a new `pa_owns` to ask the ownership question first,
+  because a file mapping points into the image and its page tables are
+  not ours to rewrite. All three architectures had the same `munmap`.
+
+  `unikernel/demos/guardpages.nu` is the gate, and it needs no network,
+  no TLS and no timing: coroutines come and go, then the memory they
+  gave back is allocated and **written**. The write is the assertion.
+  Against the old `munmap` it faults; against the fixed one it prints
+  what it wrote.
+
 ## [0.54.0] — 2026-08-27
 
 ### Added

--- a/unikernel/boot/pagealloc.c
+++ b/unikernel/boot/pagealloc.c
@@ -141,6 +141,19 @@ static void pa_absorb_tail(void) {
  * length than it allocated is a bug in the caller, and this allocator
  * has no header to check it against, which is the price of not spending
  * a word on every page. */
+/* Is this range one of ours? The same bounds test `pa_free` makes,
+ * exposed because the caller has something to do BEFORE handing a range
+ * back — see `munmap` in the platform files: a page that was protected
+ * while it was in use has to be made writable again before it returns
+ * to the pool, and doing that to a mapping that is not ours would be a
+ * write to somebody else's page tables. */
+int pa_owns(pa_size_t p, pa_size_t len) {
+    pa_size_t n = pa_round(len);
+    if (p == 0 || n == 0) return 0;
+    if (p < pa_base || p + n > pa_end || p + n < p) return 0;
+    return 1;
+}
+
 int pa_free(pa_size_t p, pa_size_t len) {
     pa_size_t n = pa_round(len);
     if (p == 0 || n == 0) return 0;

--- a/unikernel/boot/platform_arm64.c
+++ b/unikernel/boot/platform_arm64.c
@@ -246,6 +246,11 @@ static unsigned char *heap_end;
 void          pa_init(unsigned long base, unsigned long len);
 unsigned long pa_alloc(unsigned long want);
 int           pa_free(unsigned long p, unsigned long len);
+int  pa_owns(unsigned long p, unsigned long len);
+
+/* Defined below; declared here because `munmap` restores a range's
+ * protection before returning it to the allocator. */
+int mprotect(void *p, unsigned long len, int prot);
 void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
                        unsigned long *largest, unsigned long *lost, int *holes);
 
@@ -299,7 +304,31 @@ void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off)
 }
 
 int munmap(void *p, unsigned long len) {
-    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+    /* A page goes back to the allocator MAPPED, and that is an
+     * invariant rather than a courtesy.
+     *
+     * A coroutine's stack is allocated here and its guard page is then
+     * mprotect'ed PROT_NONE — the present bit cleared in its PTE. When
+     * the coroutine ends, this used to return the whole range to the
+     * page allocator with that bit still clear, so the guard page went
+     * back into the pool unmapped. Nothing noticed until something else
+     * was handed it: nolibc's malloc carved an arena across it and the
+     * first write to a block landing on that page took a #PF on a
+     * not-present page, INSIDE malloc, long after the coroutine that
+     * protected it had gone. Measured cost of finding that from the
+     * fault alone: an afternoon. Twenty connections that send one byte
+     * and hang up were enough to kill a server.
+     *
+     * So: restore before releasing, and only for ranges that are ours —
+     * a mapping of the baked-in filesystem points into the image, and
+     * rewriting page tables for it would be a write into somebody
+     * else's business. `pa_free` rejects those by address; `pa_owns`
+     * asks the same question first, because the order matters: a range
+     * must never be on the free list while it is still unmapped. */
+    if (!pa_owns((unsigned long)p, len)) return 0;
+    (void)mprotect(p, len, 0x1 | 0x2);   /* PROT_READ | PROT_WRITE */
+    (void)pa_free((unsigned long)p, len);
+    return 0;
 }
 
 long long nurl_guest_mem(int which) {

--- a/unikernel/boot/platform_riscv64.c
+++ b/unikernel/boot/platform_riscv64.c
@@ -240,6 +240,11 @@ static unsigned char *heap_end;
 void          pa_init(unsigned long base, unsigned long len);
 unsigned long pa_alloc(unsigned long want);
 int           pa_free(unsigned long p, unsigned long len);
+int  pa_owns(unsigned long p, unsigned long len);
+
+/* Defined below; declared here because `munmap` restores a range's
+ * protection before returning it to the allocator. */
+int mprotect(void *p, unsigned long len, int prot);
 void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
                        unsigned long *largest, unsigned long *lost, int *holes);
 
@@ -293,7 +298,31 @@ void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off)
 }
 
 int munmap(void *p, unsigned long len) {
-    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+    /* A page goes back to the allocator MAPPED, and that is an
+     * invariant rather than a courtesy.
+     *
+     * A coroutine's stack is allocated here and its guard page is then
+     * mprotect'ed PROT_NONE — the present bit cleared in its PTE. When
+     * the coroutine ends, this used to return the whole range to the
+     * page allocator with that bit still clear, so the guard page went
+     * back into the pool unmapped. Nothing noticed until something else
+     * was handed it: nolibc's malloc carved an arena across it and the
+     * first write to a block landing on that page took a #PF on a
+     * not-present page, INSIDE malloc, long after the coroutine that
+     * protected it had gone. Measured cost of finding that from the
+     * fault alone: an afternoon. Twenty connections that send one byte
+     * and hang up were enough to kill a server.
+     *
+     * So: restore before releasing, and only for ranges that are ours —
+     * a mapping of the baked-in filesystem points into the image, and
+     * rewriting page tables for it would be a write into somebody
+     * else's business. `pa_free` rejects those by address; `pa_owns`
+     * asks the same question first, because the order matters: a range
+     * must never be on the free list while it is still unmapped. */
+    if (!pa_owns((unsigned long)p, len)) return 0;
+    (void)mprotect(p, len, 0x1 | 0x2);   /* PROT_READ | PROT_WRITE */
+    (void)pa_free((unsigned long)p, len);
+    return 0;
 }
 
 long long nurl_guest_mem(int which) {

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -360,6 +360,11 @@ static unsigned char *heap_end;
 void          pa_init(unsigned long base, unsigned long len);
 unsigned long pa_alloc(unsigned long want);
 int           pa_free(unsigned long p, unsigned long len);
+int  pa_owns(unsigned long p, unsigned long len);
+
+/* Defined below; declared here because `munmap` restores a range's
+ * protection before returning it to the allocator. */
+int mprotect(void *p, unsigned long len, int prot);
 void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
                        unsigned long *largest, unsigned long *lost, int *holes);
 
@@ -450,10 +455,31 @@ void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off)
 }
 
 int munmap(void *p, unsigned long len) {
-    /* A mapping of the baked-in filesystem points into the image, not
-     * into the heap; pa_free rejects it by address, which is exactly the
-     * check that keeps the image out of the free list. */
-    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+    /* A page goes back to the allocator MAPPED, and that is an
+     * invariant rather than a courtesy.
+     *
+     * A coroutine's stack is allocated here and its guard page is then
+     * mprotect'ed PROT_NONE — the present bit cleared in its PTE. When
+     * the coroutine ends, this used to return the whole range to the
+     * page allocator with that bit still clear, so the guard page went
+     * back into the pool unmapped. Nothing noticed until something else
+     * was handed it: nolibc's malloc carved an arena across it and the
+     * first write to a block landing on that page took a #PF on a
+     * not-present page, INSIDE malloc, long after the coroutine that
+     * protected it had gone. Measured cost of finding that from the
+     * fault alone: an afternoon. Twenty connections that send one byte
+     * and hang up were enough to kill a server.
+     *
+     * So: restore before releasing, and only for ranges that are ours —
+     * a mapping of the baked-in filesystem points into the image, and
+     * rewriting page tables for it would be a write into somebody
+     * else's business. `pa_free` rejects those by address; `pa_owns`
+     * asks the same question first, because the order matters: a range
+     * must never be on the free list while it is still unmapped. */
+    if (!pa_owns((unsigned long)p, len)) return 0;
+    (void)mprotect(p, len, 0x1 | 0x2);   /* PROT_READ | PROT_WRITE */
+    (void)pa_free((unsigned long)p, len);
+    return 0;
 }
 
 /* What the machine has and what it is using — the numbers a long-running

--- a/unikernel/demos/guardpages.expected
+++ b/unikernel/demos/guardpages.expected
@@ -1,0 +1,3 @@
+coroutines came and went, then wrote pages: 1024
+and again after a second round: 1024
+every page the coroutines gave back was writable: yes

--- a/unikernel/demos/guardpages.nu
+++ b/unikernel/demos/guardpages.nu
@@ -1,0 +1,73 @@
+// unikernel/demos/guardpages.nu — a page that came back from a
+// coroutine has to come back MAPPED.
+//
+// Every coroutine stack is allocated with a guard page below it, and
+// arming that guard means clearing the present bit in its PTE. Giving
+// the stack back returns the whole range to the page allocator — and
+// for a while it returned the guard page with that bit still clear. The
+// pool then handed the page to somebody else, nolibc's malloc carved an
+// arena across it, and the first write to a block that happened to land
+// there took a page fault INSIDE malloc, long after the coroutine that
+// protected it had ended. On a server, twenty connections that sent one
+// byte and hung up were enough.
+//
+// So: make coroutines come and go, then allocate and WRITE the memory
+// they gave back. A guard page that returned unmapped is a fault here,
+// at a line that says what it was doing, instead of a fault in the
+// allocator with nothing to point at.
+
+$ `stdlib/std/async.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ churn i n → v {
+    : ~ i k 0
+    ~ < k n {
+        ( spawn \ → v {} )
+        = k + k 1
+    }
+    ( runtime_run )
+}
+
+// Write one byte on every page of a freshly allocated block. The write
+// is the assertion: a page the allocator handed out but nobody mapped
+// faults here rather than silently later.
+@ touch_pages i blocks i bytes → i {
+    : ~ i pages 0
+    : ~ i b 0
+    ~ < b blocks {
+        : ( Vec u ) v ( vec_with_cap [u] bytes )
+        ( vec_set_len [u] v bytes )
+        : ~ i off 0
+        ~ < off bytes {
+            : b _w ( vec_set [u] v off # u 65 )
+            = pages + pages 1
+            = off + off 4096
+        }
+        ( vec_free [u] v )
+        = b + b 1
+    }
+    ^ pages
+}
+
+@ main → i {
+    ( runtime_init 0 )
+    // Enough coroutines that their stacks and guard pages are certain
+    // to be recycled by the allocations below, and few enough that the
+    // demo stays a second long.
+    ( churn 64 )
+    : i pages ( touch_pages 64 65536 )
+    ( nurl_print `coroutines came and went, then wrote pages: ` )
+    ( nurl_print ( nurl_str_int pages ) )
+    ( nurl_print `\n` )
+    ( churn 64 )
+    : i more ( touch_pages 64 65536 )
+    ( nurl_print `and again after a second round: ` )
+    ( nurl_print ( nurl_str_int more ) )
+    ( nurl_print `\n` )
+    ( nurl_print `every page the coroutines gave back was writable: ` )
+    ( nurl_print ? == pages more `yes` `no` )
+    ( nurl_print `\n` )
+    ( runtime_shutdown )
+    ^ 0
+}

--- a/unikernel/k8s/build_image.sh
+++ b/unikernel/k8s/build_image.sh
@@ -21,23 +21,52 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HERE="$ROOT/unikernel/k8s"
 TAG="${TAG:-nurl-unikernel-httpd:0.1.0}"
 PUSH=""
+TLS=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -t) TAG="$2"; shift 2 ;;
         --push) PUSH=1; shift ;;
+        --tls) TLS=1; shift ;;
         *) echo "usage: build_image.sh [-t repo:tag] [--push]" >&2; exit 2 ;;
     esac
 done
 
 ELF="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}/k8sd.elf"
-"$ROOT/unikernel/build_unikernel.sh" "$HERE/server.nu" -o "$ELF"
+
+# --tls bakes a certificate into the image's read-only filesystem, and
+# the guest then serves TLS 1.3 out of `stdlib/std/tls.nu` — pure NURL,
+# no libssl, which is why it links into a machine with no operating
+# system at all.
+#
+# The key is P-256 and that is not a preference. Measured in the guest,
+# same image, same handshake, only the server key's type differing:
+# RSA-2048 costs ~490 ms per handshake, P-256 costs 4-11 ms. Ninety
+# times, and it is the difference between a TLS endpoint and a
+# demonstration that TLS is possible.
+#
+# Self-signed and generated per build, so every image has its own
+# identity and no private key is ever committed. A deployment that
+# needs a real certificate mounts one and points `cert=`/`key=` at it.
+FSARG=""
+if [ -n "$TLS" ]; then
+    command -v openssl >/dev/null 2>&1 || { echo "build_image.sh: --tls needs openssl" >&2; exit 2; }
+    TLSDIR="$(mktemp -d)"
+    trap 'rm -rf "$TLSDIR"' EXIT
+    mkdir -p "$TLSDIR/etc/tls"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$TLSDIR/etc/tls/key.pem" 2>/dev/null
+    openssl req -x509 -new -key "$TLSDIR/etc/tls/key.pem" -out "$TLSDIR/etc/tls/cert.pem" \
+            -days 3650 -subj "/CN=nurl-unikernel" 2>/dev/null
+    FSARG="--fs $TLSDIR"
+fi
+
+"$ROOT/unikernel/build_unikernel.sh" $FSARG "$HERE/server.nu" -o "$ELF"
 
 # A context of exactly the two files that go into the image. The
 # repository's .dockerignore excludes build/, and a two-file context
 # is also a faster and more truthful build than sending the tree.
 STAGE="$(mktemp -d)"
-trap 'rm -rf "$STAGE"' EXIT
+trap 'rm -rf "$STAGE" "${TLSDIR:-}"' EXIT
 cp "$ELF" "$STAGE/server.elf"
 cp "$HERE/entrypoint.sh" "$STAGE/entrypoint.sh"
 chmod 0755 "$STAGE/entrypoint.sh"

--- a/unikernel/k8s/deploy-kvm.yaml
+++ b/unikernel/k8s/deploy-kvm.yaml
@@ -1,0 +1,108 @@
+# unikernel/k8s/deploy-kvm.yaml — the same server, over TLS 1.3, in a
+# machine with no operating system, on a vCPU the node actually gave it.
+#
+# This is what `kvm-device-plugin.yaml` is for. The workload it enables
+# is deliberately the CPU-bound one: a TLS handshake is where a guest
+# spends real cycles, so it is where hardware virtualisation stops being
+# a nice-to-have. Measured in the guest, same image, same key:
+#
+#     TLS 1.3 handshakes in 6 s     KVM 856      TCG 469
+#
+# The certificate is baked into the image's read-only filesystem by
+# `build_image.sh --tls`, self-signed and generated per build. The
+# handshake itself is `stdlib/std/tls.nu` — pure NURL, no libssl, which
+# is why it links into a freestanding image at all.
+#
+#   unikernel/k8s/build_image.sh --tls -t nurl-kvm:0.1.0
+#   kubectl apply -f unikernel/k8s/deploy-kvm.yaml
+#   kubectl -n nurl-kvm port-forward svc/nurl-kvm 8443:443
+#   curl -k https://localhost:8443/info
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nurl-kvm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nurl-kvm
+  namespace: nurl-kvm
+  labels:
+    app: nurl-kvm
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nurl-kvm
+  template:
+    metadata:
+      labels:
+        app: nurl-kvm
+    spec:
+      # No nodeSelector: the `devic.es/kvm` request below IS the node
+      # selector, and it is one the scheduler keeps up to date. What it
+      # costs is stated in kvm-device-plugin.yaml — a deployment that
+      # asks for the device can only run where the device is.
+      securityContext:
+        # The gid of the `kvm` group ON THE NODE (`getent group kvm`),
+        # not a constant. The device arrives owned by root:kvm 0660 and
+        # this container is not root. Get it wrong and nothing breaks:
+        # QEMU falls back to emulation and the pod serves correct
+        # answers more slowly. `kubectl logs` line 1 says which.
+        supplementalGroups: [993]
+      containers:
+        - name: qemu
+          image: nurl-kvm:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: https
+              containerPort: 8443
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TLS
+              value: "1"
+            - name: PORT
+              value: "8443"
+            - name: GUEST_PORT
+              value: "8443"
+          startupProbe:
+            httpGet: { path: /healthz, port: https, scheme: HTTPS }
+            periodSeconds: 1
+            failureThreshold: 30
+          readinessProbe:
+            httpGet: { path: /healthz, port: https, scheme: HTTPS }
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: https, scheme: HTTPS }
+            periodSeconds: 20
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits:
+              cpu: "1"
+              memory: 512Mi
+              devic.es/kvm: 1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nurl-kvm
+  namespace: nurl-kvm
+spec:
+  selector:
+    app: nurl-kvm
+  ports:
+    - name: https
+      port: 443
+      targetPort: https

--- a/unikernel/k8s/entrypoint.sh
+++ b/unikernel/k8s/entrypoint.sh
@@ -57,7 +57,15 @@ tsc_khz() {
 # The program cannot find that out, and a program that asserts it
 # anyway is one whose banner stops being checkable the day the same
 # source is built the other way — which it now is.
-APPEND="tsc_khz=$(tsc_khz) wallclock=$(date +%s) pod=${POD} port=${GUEST_PORT} platform=unikernel"
+# TLS when the image was built with --tls and the deployment asks for
+# it. Two keys rather than one flag: a program told "use TLS" that then
+# guesses where its certificate lives has a failure mode you cannot see.
+TLS_KEYS=""
+if [ "${TLS:-0}" = "1" ]; then
+    TLS_KEYS=" cert=${TLS_CERT:-etc/tls/cert.pem} key=${TLS_KEY:-etc/tls/key.pem}"
+fi
+
+APPEND="tsc_khz=$(tsc_khz) wallclock=$(date +%s) pod=${POD} port=${GUEST_PORT} platform=unikernel${TLS_KEYS}"
 echo "entrypoint: accel=${ACCEL} append=[${APPEND}] forwarding :${PORT} -> guest:${GUEST_PORT}" >&2
 
 # exec, so QEMU is PID 1 and Kubernetes' SIGTERM reaches the hypervisor

--- a/unikernel/k8s/server.nu
+++ b/unikernel/k8s/server.nu
@@ -94,7 +94,7 @@ $ `stdlib/ext/env.nu`
     ^ ( response_text 200 `ok\n` )
 }
 
-@ h_info ( Vec i ) c i boot_ns String pod String platform → HttpResponse {
+@ h_info ( Vec i ) c i boot_ns String pod String platform b use_tls → HttpResponse {
     : i n ( stat_bump c 0 )
     : Json j ( json_obj_new )
     ( json_obj_set j `server` ( json_str_lit `nurl-http` ) )
@@ -105,6 +105,7 @@ $ `stdlib/ext/env.nu`
     // when the node's kernel exec'd the binary, `unknown` when nobody
     // said.
     ( json_obj_set j `platform` ( json_str_lit ( string_data platform ) ) )
+    ( json_obj_set j `tls` ? use_tls ( json_str_lit `1.3` ) ( json_str_lit `none` ) )
     ( json_obj_set j `uptime_ms` ( json_int ( uptime_ms boot_ns ) ) )
     ( json_obj_set j `requests` ( json_int n ) )
     ( json_obj_set j `unix_time` ( json_int ( now_seconds ) ) )
@@ -158,7 +159,23 @@ $ `stdlib/ext/env.nu`
     : ( Vec i ) counters ( vec_new [i] )
     ( vec_push [i] counters 0 )
 
-    ?? ( tcp_listen `0.0.0.0` port ) {
+    // TLS when the launcher supplied a certificate, plaintext when it
+    // did not. Same program, same routes, same everything above the
+    // listener — `tcp_listen_tls` reads two files and the layers below
+    // do the rest, and those layers are `stdlib/std/tls.nu`: pure NURL,
+    // no libssl, which is why this links into a machine with no
+    // operating system at all.
+    //
+    // Two keys rather than one flag, because a program that is told
+    // "use TLS" and then guesses where the certificate lives is a
+    // program whose failure mode is a path you cannot see.
+    : String cert ( env_var_or `cert` `` )
+    : String key ( env_var_or `key` `` )
+    : b use_tls && > ( nurl_str_len ( string_data cert ) ) 0 > ( nurl_str_len ( string_data key ) ) 0
+    : !TcpListener NetErr lr ? use_tls
+    ( tcp_listen_tls `0.0.0.0` port ( string_data cert ) ( string_data key ) )
+    ( tcp_listen `0.0.0.0` port )
+    ?? lr {
         F e → {
             ( nurl_print `listen failed: ` )
             ( nurl_print ( net_err_name e ) )
@@ -172,7 +189,7 @@ $ `stdlib/ext/env.nu`
             ( router_get rt `/healthz`
             \ HttpRequest req Params ps → HttpResponse { ^ ( h_health counters ) } )
             ( router_get rt `/info`
-            \ HttpRequest req Params ps → HttpResponse { ^ ( h_info counters boot_ns pod platform ) } )
+            \ HttpRequest req Params ps → HttpResponse { ^ ( h_info counters boot_ns pod platform use_tls ) } )
             ( router_get rt `/metrics`
             \ HttpRequest req Params ps → HttpResponse { ^ ( h_metrics counters boot_ns ) } )
 
@@ -182,6 +199,7 @@ $ `stdlib/ext/env.nu`
 
             ( nurl_print `nurl unikernel serving on 0.0.0.0:` )
             ( nurl_print ( nurl_str_int port ) )
+            ( nurl_print ? use_tls ` (TLS)` `` )
             ( nurl_print `\n` )
 
             : !v NetErr rr ( server_run_async srv )
@@ -199,6 +217,8 @@ $ `stdlib/ext/env.nu`
     }
     ( string_free pod )
     ( string_free platform )
+    ( string_free cert )
+    ( string_free key )
     ( vec_free [i] counters )
     ^ 0
 }

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -84,7 +84,7 @@ done
 # one that goes looking for devices.
 demos=0
 if [ $# -eq 0 ]; then
-    for demo in devices netdev dhcp loopback idle; do
+    for demo in devices netdev dhcp loopback idle guardpages; do
         src="$ROOT/unikernel/demos/$demo.nu"
         exp="$ROOT/unikernel/demos/$demo.expected"
         [ -f "$src" ] && [ -f "$exp" ] || continue


### PR DESCRIPTION
Two commits. The first is a remotely-triggerable memory-corruption fix in
the guest; the second is the deployment that found it.

## A page returned to the allocator came back unmapped

Every coroutine stack is allocated with a guard page below it, and arming
that guard clears the present bit in its PTE. When the coroutine ended,
`munmap` returned the whole range to the page allocator and **touched no
page tables** — so the guard page went back into the pool with that bit
still clear. The pool handed it to somebody else, nolibc's `malloc`
carved an arena across it, and the first write to a block that landed on
that page took a `#PF` **inside malloc**, long after the coroutine that
protected it had gone.

Anyone who could open a TCP connection could do it. **Twenty connections
that sent one byte and hung up killed a server.**

### How it was narrowed

Every step was an experiment, not a reading:

| step | result | what it ruled out |
|---|---|---|
| same attack, plaintext instead of TLS | identical crash | TLS |
| same program built with sequential `server_run` | survives 30 | everything not on the fiber path |
| `spawn_owned` → `spawn` (env leaked instead of freed) | still crashes | the closure-environment free |
| instrumented `nurl_fiber_unpark` to abort on a dead coroutine | never fires | stale waiter slots, dead handles |
| `nm` on the faulting `rip` | inside `malloc` | the NURL layers entirely |
| 256 MiB vs 1024 MiB of guest memory | no difference | exhaustion — this is corruption |

That left one candidate, and it was in the file that says what `mmap` and
`munmap` are made of when there is no kernel underneath.

### The fix

The invariant, not a patch at the call site: **a page goes back to the
allocator mapped.** `munmap` restores the range's protection before
releasing it, in that order, so a range is never on the free list while
it is unmapped. New `pa_owns` asks the ownership question first — a
mapping of the baked-in filesystem points into the image and its page
tables are not ours to rewrite. All three architectures carried the same
`munmap`; all three are fixed.

### The gate

`unikernel/demos/guardpages.nu` needs no network, no TLS and no timing:
coroutines come and go, then the memory they gave back is allocated and
**written**. The write is the assertion. Against the old `munmap` it
faults with `cr2` in the middle of the heap; against the fixed one it
prints what it wrote, twice, and says the counts matched.

Verified beyond the gate: 200 one-byte connections followed by 500
truncated TLS hellos against a guest that used to die on 20 — still
answering afterwards. Live in a cluster: 300 truncated hellos plus 988
real handshakes against a pod, zero restarts.

## TLS 1.3 from the unikernel

The same `server.nu` serves TLS when the launcher hands it `cert=` and
`key=`. Two keys rather than one flag: a program told "use TLS" that then
guesses where its certificate lives has a failure mode you cannot see.
The handshake is `stdlib/std/tls.nu` — pure NURL, no libssl, which is why
it links into a machine with no operating system at all.

This is the workload `kvm-device-plugin.yaml` was for. A handshake is
where a guest spends real cycles:

**TLS handshakes in six seconds, same image and key: KVM 856, TCG 469.**

### The server key is P-256, and that is not a preference

Measured in the guest, same image, same handshake, only the key type
differing:

| RSA-2048 | P-256 |
|---|---|
| ~490 ms per handshake | 4–11 ms per handshake |

Ninety times — the difference between a TLS endpoint and a demonstration
that TLS is possible. `build_image.sh --tls` generates a self-signed
P-256 key per build and bakes it into the image's read-only filesystem,
so no private key is ever committed and every image has its own identity.
A deployment that needs a real certificate mounts one and points
`cert=`/`key=` at it.

`/info` reports `tls` beside `platform`, and both are what the launcher
said rather than what the program would like to be true.

## Why they ship together

The deployment is what found the bug — the first version crash-looped in
a real cluster — and it is also the fix's integration test. The fix
stands on its own and is the first commit; reviewing it alone is enough
to take it.

## Gates

`./build.sh` (bootstrap fixed point + compiler corpus) green · QEMU guest
suite **30/30**, `guardpages` included · nolibc corpus **517/0** · nolibc
unit gates all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x
