### PR TITLE
Release v0.54.0: fold #1022 into the release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] — 2026-08-27
+
 ### Added
 
 - **TLS 1.3 from the unikernel on Kubernetes** —
@@ -27,44 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   TLS handshakes in six seconds, same image and key: **KVM 856, TCG
   469**.
-
-### Fixed
-
-- **A page returned to the guest's allocator came back unmapped.** Every
-  coroutine stack is allocated with a guard page below it, and arming
-  that guard clears the present bit in its PTE. When the coroutine
-  ended, `munmap` returned the whole range to the page allocator — and
-  touched no page tables, so the guard page went back into the pool with
-  that bit still clear. The pool handed it to somebody else, nolibc's
-  `malloc` carved an arena across it, and the first write to a block
-  that landed there took a page fault **inside malloc**, long after the
-  coroutine that protected it had gone.
-
-  Reachable by anyone who could open a TCP connection: twenty
-  connections that sent one byte and hung up killed a server. Narrowed
-  by measurement rather than reading — the same attack against the
-  sequential `server_run` did nothing, which put it on the fiber path;
-  it survived swapping `spawn_owned` for `spawn`, which cleared the
-  closure-environment free; and `nm` put the faulting instruction inside
-  `malloc`, on a write to a not-present page in the middle of an
-  ordinary heap. Guest memory size made no difference, so it was
-  corruption and not exhaustion.
-
-  `munmap` now restores a range's protection before releasing it, in
-  that order, so a range is never on the free list while it is
-  unmapped — with a new `pa_owns` to ask the ownership question first,
-  because a file mapping points into the image and its page tables are
-  not ours to rewrite. All three architectures had the same `munmap`.
-
-  `unikernel/demos/guardpages.nu` is the gate, and it needs no network,
-  no TLS and no timing: coroutines come and go, then the memory they
-  gave back is allocated and **written**. The write is the assertion.
-  Against the old `munmap` it faults; against the fixed one it prints
-  what it wrote.
-
-## [0.54.0] — 2026-08-27
-
-### Added
 
 - **`unikernel/k8s/kvm-device-plugin.yaml`** — a device plugin so the
   guest can be given `/dev/kvm` without giving its pod the node. A
@@ -307,6 +271,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The literal follows the manifest — grep it before bumping.
 
 ### Fixed
+
+- **A page returned to the guest's allocator came back unmapped.** Every
+  coroutine stack is allocated with a guard page below it, and arming
+  that guard clears the present bit in its PTE. When the coroutine
+  ended, `munmap` returned the whole range to the page allocator — and
+  touched no page tables, so the guard page went back into the pool with
+  that bit still clear. The pool handed it to somebody else, nolibc's
+  `malloc` carved an arena across it, and the first write to a block
+  that landed there took a page fault **inside malloc**, long after the
+  coroutine that protected it had gone.
+
+  Reachable by anyone who could open a TCP connection: twenty
+  connections that sent one byte and hung up killed a server. Narrowed
+  by measurement rather than reading — the same attack against the
+  sequential `server_run` did nothing, which put it on the fiber path;
+  it survived swapping `spawn_owned` for `spawn`, which cleared the
+  closure-environment free; and `nm` put the faulting instruction inside
+  `malloc`, on a write to a not-present page in the middle of an
+  ordinary heap. Guest memory size made no difference, so it was
+  corruption and not exhaustion.
+
+  `munmap` now restores a range's protection before releasing it, in
+  that order, so a range is never on the free list while it is
+  unmapped — with a new `pa_owns` to ask the ownership question first,
+  because a file mapping points into the image and its page tables are
+  not ours to rewrite. All three architectures had the same `munmap`.
+
+  `unikernel/demos/guardpages.nu` is the gate, and it needs no network,
+  no TLS and no timing: coroutines come and go, then the memory they
+  gave back is allocated and **written**. The write is the assertion.
+  Against the old `munmap` it faults; against the fixed one it prints
+  what it wrote.
 
 - **`unikernel/tests/hypervisor_gate.sh` could not actually boot
   Firecracker.** From v1.16 the one-shot JSON config requires a `drives`


### PR DESCRIPTION
#1022 merged after the release PR (#1021) and wrote its two entries under
a fresh `[Unreleased]`. It belongs in **v0.54.0** rather than the release
after it: the guard-page fix is reachable by anyone who can open a TCP
connection to a guest — twenty one-byte connections killed a server —
and tagging without it would ship release notes for a machine we already
know crashes.

CHANGELOG only, no code:

- **TLS 1.3 from the unikernel on Kubernetes** → top of `[0.54.0]` Added.
- **A page returned to the guest's allocator came back unmapped** → top of
  `[0.54.0]` Fixed.
- `[Unreleased]` is left empty, which is the shape every previous tag was
  cut in (`git show v0.53.0:CHANGELOG.md`).

The tag follows this merge and names main's merge commit, per
`RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkczcBzhvg6a3qxFssKAc9