### PR TITLE
simd: run the clone the dispatcher never picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The `simd` clone the dispatcher never picks is now run against the
+  goldens** — `compiler/tests/simd_baseline_agree.sh`, wired into
+  `./build.sh` next to `simd_dispatch_ir.sh`.
+
+  The `simd` prefix emits every marked function twice and chooses on a
+  cached CPUID answer. `simd_dispatch_ir.sh` proves both clones are
+  *built* — two definitions, feature bits on the wide one only, a
+  dispatcher owning the undecorated symbol, `ymm` in the object code.
+  What nothing proved is that the other one *computes the right
+  answer*, because no test can run it: on a host with AVX2 — every
+  x86-64 runner this project uses — the dispatcher picks the wide clone
+  every time, and on a host without, the wide clone is what never runs.
+  `--no-cpu-dispatch` appeared in no build script and no workflow.
+
+  Every one of the eleven functions the prefix marks today is
+  post-quantum cryptography: `__ntt`, `__invntt`, `__poly_basemul`,
+  `__cbd_batch` and the three `__kpke_*` in `mlkem.nu`,
+  `mldsa_keygen_derand` / `mldsa_sign_mu` / `mldsa_verify_mu` in
+  `mldsa.nu`, and `__kf1600x4`, the x4 Keccak sponge under both. A
+  divergence between the two lowerings there is not a slow path; it is
+  a wrong key on the half of a fleet that was never tested.
+
+  The gate builds `mlkem_vectors`, `mldsa_vectors` and `sha3x4_vectors`
+  a second time with `--no-cpu-dispatch` and requires **both** lowerings
+  to produce the committed golden — all three ML-KEM levels, all three
+  ML-DSA levels, and the x4 sponge either side of both rates. They
+  agree today; that is now a fact a build checks rather than an
+  assumption.
+
+  Two things it does that a naive version would not. It first proves
+  the two legs are *different machine code* — 2057 `ymm` instructions
+  inside the wide clones of `mlkem_vectors` against 0 anywhere in the
+  baseline build, 2315 against 0 for `mldsa_vectors` — because
+  "the outputs match" is equally true of two builds of identical code,
+  which is exactly what a silently-dropped clone produces. And it reads
+  the marked set out of `stdlib/` rather than carrying a list, so
+  marking a twelfth function without giving it a driver fails the build
+  by name.
+
+  Verified by breaking it three ways: forcing both legs to
+  `--no-cpu-dispatch` (the "clone silently stopped being emitted"
+  regression) fails the different-code assertion on all three drivers
+  and reports all eleven functions uncovered, while every output still
+  matches its golden — which is precisely the regression no existing
+  test could see; changing `3329` to `3330` in `__ntt`'s modulus
+  broadcast fails both lowerings of `mlkem_vectors`; and appending an
+  undriven `simd` function to `mlkem.nu` fails the coverage assertion
+  by name.
+
+  ~10 s. Skips with a message on non-x86-64 hosts, where there is only
+  one lowering to begin with and `--no-cpu-dispatch` is mandatory —
+  so the macOS ARM64 runner, which also runs `./build.sh`, is
+  unaffected.
+
 ## [0.54.0] — 2026-08-27
 
 ### Added

--- a/build.sh
+++ b/build.sh
@@ -610,6 +610,14 @@ if (( RUN_TESTS == 1 )); then
     # answers are right; nothing in it can notice the wide clone
     # silently disappearing, which is the regression that costs 1.7x.
     step "simd dispatch IR" bash compiler/tests/simd_dispatch_ir.sh
+    # And the clone the dispatcher did NOT pick. simd_dispatch_ir.sh
+    # proves both are built; the corpus only ever runs the one this
+    # CPU selects, which on every x86-64 runner here is the wide one.
+    # This builds the vector corpus a second time with
+    # --no-cpu-dispatch and requires the baseline lowering to produce
+    # the same goldens — the ML-KEM / ML-DSA keys are the same keys on
+    # a machine without AVX2 or they are not, and nothing else asks.
+    step "simd baseline agree" bash compiler/tests/simd_baseline_agree.sh
 fi
 
 # ── nurlfmt ──────────────────────────────────────────────────

--- a/compiler/tests/simd_baseline_agree.sh
+++ b/compiler/tests/simd_baseline_agree.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  compiler/tests/simd_baseline_agree.sh — the clone that did NOT run.
+#
+#  `simd` emits every marked function twice and picks one on a cached
+#  CPUID answer. simd_dispatch_ir.sh proves both clones are BUILT and
+#  that only the wide one carries feature bits. What neither it nor any
+#  behavioural test can do is EXECUTE the other one: on a host with
+#  AVX2 — every x86-64 CI runner this project uses — the dispatcher
+#  picks the wide clone every time, so the baseline lowering of these
+#  kernels is compiled, shipped, and never once run against a known
+#  answer. On a host without AVX2 it is the wide clone that never runs,
+#  and nothing in the tree noticed either way: `--no-cpu-dispatch`
+#  appeared in no build script and no workflow.
+#
+#  Every function the prefix marks today is post-quantum cryptography
+#  (ML-KEM, ML-DSA, the x4 Keccak sponge under both). A divergence
+#  between the two lowerings there is not a slow path — it is a wrong
+#  key on half the machines in a fleet, on the half that was never
+#  tested.
+#
+#  So: build the vector corpus twice, once each way, and require both
+#  to produce the golden. The `off` leg is the load-bearing one — it is
+#  the answer nothing else asks for.
+#
+#  Every assertion greps for a POSITIVE marker. "The outputs match" is
+#  worth nothing on its own: two builds of identical machine code match
+#  too, which is exactly what a silently-dropped clone would produce.
+#  So the ymm counts are checked first, and the run is only credited
+#  when the two binaries are demonstrably different code.
+#
+#  The driver list below is a starting point, not the coverage claim:
+#  assertion 3 reads every `simd`-marked function out of stdlib/ and
+#  fails if the drivers do not reach one. Marking a new function
+#  without giving it a driver fails here, by name.
+#
+#  Run from anywhere; it cd's to the repo root.
+#
+#  Exit codes:
+#    0 — every driver agreed with its golden in both lowerings
+#    1 — a divergence, a build failure, or an uncovered marked function
+#    2 — environment problem (no nurlc / no runtime.o)
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR" || exit 2
+
+NURLC="$ROOT_DIR/build/nurlc"
+[[ -x "$NURLC" ]] || NURLC="$ROOT_DIR/nurlc"
+if [[ ! -x "$NURLC" ]]; then
+    echo "ERROR: nurlc not found — run ./build.sh first." >&2
+    exit 2
+fi
+if [[ ! -f "$ROOT_DIR/stdlib/runtime.o" ]]; then
+    echo "ERROR: stdlib/runtime.o not found — run ./build.sh first." >&2
+    exit 2
+fi
+
+# The toolchain build.sh resolved, when this runs under it; the same
+# fallbacks split_equivalence.sh uses when it does not.
+CLANG="${CLANG:-clang}"
+OPAQUE_FLAGS="${OPAQUE_FLAGS-}"
+if [[ -z "${AS_NEEDED+set}" ]]; then
+    AS_NEEDED="-Wl,--as-needed"
+    case "$(uname -s)" in Darwin) AS_NEEDED="-Wl,-dead_strip_dylibs" ;; esac
+fi
+if [[ -z "${DL_LIB+set}" ]]; then
+    DL_LIB=""
+    case "$(uname -s)" in Linux) DL_LIB="-ldl" ;; esac
+fi
+
+# The prefix names an x86-64 feature set and this gate LINKS AND RUNS
+# both legs, so it needs an x86-64 host — not merely a cross-capable
+# clang. On anything else nurlc must be given --no-cpu-dispatch (nurl.sh
+# does exactly that for every non-x86-64 target), which is the `off` leg
+# alone: there is no second lowering to compare it against. Skip loudly
+# rather than fail, so the macOS ARM64 and RISC-V runners that also run
+# ./build.sh keep going.
+case "$(uname -m)" in
+    x86_64|amd64) ;;
+    *)
+        echo "simd_baseline_agree: skipped — $(uname -m) has no x86-64-v3 clone to compare against"
+        exit 0
+        ;;
+esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+note() { printf '  %-52s %s\n' "$1" "$2"; }
+ok()   { note "$1" "ok ($2)"; }
+bad()  { note "$1" "FAIL — $2"; fails=$((fails + 1)); }
+
+# The corpus tests that drive the marked kernels through their public
+# API across the parameter seams: all three ML-KEM levels, all three
+# ML-DSA levels, and the x4 sponge either side of both rates.
+DRIVERS=(mlkem_vectors mldsa_vectors sha3x4_vectors)
+
+# ── 0. What this host will actually dispatch to ─────────────────────
+# Without this the whole script is theatre on an AVX2-less machine: the
+# two builds still agree, because both ran baseline code. Ask the
+# runtime rather than assuming, and say which comparison was made.
+# stdlib/runtime.o is LLVM bitcode for the LTO link the drivers use;
+# runtime.native.o is the ELF object, and the only one a plain -O0
+# probe can be linked against. Same recipe simd_dispatch_ir.sh uses.
+HOST_V3=unknown
+HOST_V3_SRC=""
+cat > "$WORK/cpu.c" <<'CEOF'
+#include <stdio.h>
+int nurl_cpu_x86_v3(void);
+int main(void) { printf("%d\n", nurl_cpu_x86_v3()); return 0; }
+CEOF
+if [[ -f "$ROOT_DIR/stdlib/runtime.native.o" ]] &&
+        "$CLANG" -O0 "$WORK/cpu.c" "$ROOT_DIR/stdlib/runtime.native.o" \
+            -o "$WORK/cpu" -lm -lpthread $DL_LIB -lsqlite3 >/dev/null 2>&1; then
+    HOST_V3="$("$WORK/cpu" 2>/dev/null)"
+    HOST_V3_SRC="the runtime's own CPUID"
+elif [[ -r /proc/cpuinfo && "$(uname -m)" == x86_64 ]]; then
+    # Same three feature bits nurl__cpu_detect() requires. Weaker than
+    # asking the runtime — it cannot see the XCR0 check — but it answers
+    # the only question this gate needs: which clone did the drivers run.
+    if grep -qm1 ' avx2 ' /proc/cpuinfo && grep -qm1 ' bmi2 ' /proc/cpuinfo &&
+            grep -qm1 ' fma ' /proc/cpuinfo; then HOST_V3=1; else HOST_V3=0; fi
+    HOST_V3_SRC="/proc/cpuinfo"
+fi
+case "$HOST_V3" in
+    1) note "host dispatches to" "the x86-64-v3 clone, per $HOST_V3_SRC" ;;
+    0) note "host dispatches to" "the baseline clone, per $HOST_V3_SRC — the wide one is NOT exercised here" ;;
+    *) note "host dispatches to" "UNKNOWN — neither the runtime probe nor /proc/cpuinfo answered" ;;
+esac
+
+# ── 1 & 2. Each driver, built both ways ─────────────────────────────
+build_leg() {  # build_leg <test> <leg: on|off>
+    local name="$1" leg="$2" flag=""
+    [[ "$leg" == off ]] && flag="--no-cpu-dispatch"
+    # shellcheck disable=SC2086
+    "$NURLC" $flag "$SCRIPT_DIR/$name.nu" > "$WORK/$name.$leg.ll" \
+        2> "$WORK/$name.$leg.cerr" || return 1
+    # shellcheck disable=SC2086
+    "$CLANG" -O2 -flto $OPAQUE_FLAGS -Wno-override-module $AS_NEEDED \
+        "$WORK/$name.$leg.ll" stdlib/runtime.o -o "$WORK/$name.$leg" \
+        -lm -lpthread $DL_LIB 2> "$WORK/$name.$leg.lerr" || return 1
+}
+
+# ymm instructions inside the bodies of the .x86v3 symbols only. The
+# baseline build has no such symbols, so its count is 0 by construction
+# — which is why the whole-binary count is checked for it instead.
+ymm_in_wide() {
+    objdump -d "$1" 2>/dev/null |
+        awk '/^[0-9a-f]+ <[^>]*\.x86v3>:/{p=1} /^$/{p=0} p' | grep -c 'ymm'
+}
+
+have_objdump=1
+command -v objdump >/dev/null 2>&1 || have_objdump=0
+
+for name in "${DRIVERS[@]}"; do
+    gold="$SCRIPT_DIR/outputs/$name.txt"
+    if [[ ! -f "$gold" ]]; then
+        bad "$name" "no golden at ${gold#"$ROOT_DIR"/}"
+        continue
+    fi
+    if ! build_leg "$name" on; then
+        bad "$name (dispatch on)" "build failed"
+        tail -3 "$WORK/$name.on.cerr" "$WORK/$name.on.lerr" 2>/dev/null
+        continue
+    fi
+    if ! build_leg "$name" off; then
+        bad "$name (--no-cpu-dispatch)" "build failed"
+        tail -3 "$WORK/$name.off.cerr" "$WORK/$name.off.lerr" 2>/dev/null
+        continue
+    fi
+
+    # The two binaries must be different machine code, or agreement is
+    # a tautology. The wide build carries ymm inside its clones; the
+    # baseline build carries none anywhere, because nurlc emits no
+    # target triple and clang's default x86-64 has no AVX.
+    if (( have_objdump )); then
+        w=$(ymm_in_wide "$WORK/$name.on")
+        b=$(objdump -d "$WORK/$name.off" 2>/dev/null | grep -c 'ymm')
+        n_clone=$(grep -cE '^define .*\.x86v3\(' "$WORK/$name.on.ll")
+        n_off=$(grep -cE '^define .*(\.base|\.x86v3)\(' "$WORK/$name.off.ll")
+        if (( w > 0 && b == 0 && n_clone > 0 && n_off == 0 )); then
+            ok "$name: the two legs are different code" \
+               "$n_clone clone$( ((n_clone == 1)) || echo s), $w ymm vs 0"
+        else
+            bad "$name: the two legs are different code" \
+                "wide-ymm=$w baseline-ymm=$b clones=$n_clone off-clones=$n_off"
+        fi
+    else
+        note "$name: the two legs are different code" "skipped (no objdump)"
+    fi
+
+    # Both legs against the golden. The `off` leg is the point; the
+    # `on` leg is checked here too so a failure names the lowering
+    # rather than leaving it to run_tests.sh to notice separately.
+    want_exit=$(sed -n 's/^EXIT //p' "$gold" | head -1)
+    sed -n '/^OUTPUT$/,$p' "$gold" | tail -n +2 > "$WORK/$name.gold.out"
+    for leg in on off; do
+        ( cd "$WORK" && "./$name.$leg" > "$name.$leg.out" 2>&1 )
+        got_exit=$?
+        sed 's/\r$//' "$WORK/$name.$leg.out" > "$WORK/$name.$leg.nrm"
+        mv -f "$WORK/$name.$leg.nrm" "$WORK/$name.$leg.out"
+        label="$name ($([[ $leg == off ]] && echo baseline || echo x86-64-v3) lowering)"
+        if [[ "$got_exit" != "${want_exit:-0}" ]]; then
+            bad "$label" "exit $got_exit, golden says ${want_exit:-0}"
+        elif cmp -s "$WORK/$name.$leg.out" "$WORK/$name.gold.out"; then
+            ok "$label" "$(wc -l < "$WORK/$name.$leg.out" | tr -d ' ') lines match the golden"
+        else
+            bad "$label" "output differs from the golden"
+            diff -u "$WORK/$name.gold.out" "$WORK/$name.$leg.out" | head -20
+        fi
+    done
+done
+
+# ── 3. Coverage: no marked function without a driver ────────────────
+# Read the set out of the source, not out of a list here. Private
+# functions reach the IR under a `__fpN` privacy suffix, so match on
+# the stem and let the suffix be whatever privacy produced — the same
+# rule simd_dispatch_ir.sh applies.
+mapfile -t MARKED < <(
+    grep -rhE '^[[:space:]]*(pub[[:space:]]+)?simd[[:space:]]+(pub[[:space:]]+)?@' stdlib/ |
+        sed -E 's/.*@[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/\1/' | sort -u
+)
+if (( ${#MARKED[@]} == 0 )); then
+    bad "marked functions found in stdlib" "none — the grep found nothing to cover"
+else
+    uncovered=()
+    for fn in "${MARKED[@]}"; do
+        found=0
+        for name in "${DRIVERS[@]}"; do
+            [[ -f "$WORK/$name.on.ll" ]] || continue
+            if grep -qE "^define .*@${fn}[a-z0-9_]*\.x86v3\(" "$WORK/$name.on.ll"; then
+                found=1; break
+            fi
+        done
+        (( found )) || uncovered+=("$fn")
+    done
+    if (( ${#uncovered[@]} == 0 )); then
+        ok "every simd-marked stdlib function has a driver" "${#MARKED[@]} functions"
+    else
+        bad "every simd-marked stdlib function has a driver" \
+            "uncovered: ${uncovered[*]}"
+    fi
+fi
+
+echo ""
+if (( fails == 0 )); then
+    case "$HOST_V3" in
+        1) echo "simd_baseline_agree: both lowerings produce the golden" ;;
+        0) echo "simd_baseline_agree: baseline lowering produces the golden — this host has no x86-64-v3, so the wide clone was not run" ;;
+        *) echo "simd_baseline_agree: both builds produce the golden — which clone the wide build ran could not be determined on this host" ;;
+    esac
+    exit 0
+fi
+echo "simd_baseline_agree: $fails assertion(s) FAILED"
+exit 1

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -317,6 +317,17 @@ Three consequences worth knowing:
   target must pass this flag, and `nurl.sh`, the unikernel scripts and the
   build API all do.
 
+**Both clones are tested, not just the one this CPU picks.** A
+behavioural test can only ever run the clone the dispatcher selects, so
+on an AVX2 host the baseline lowering of every marked function is
+compiled and never executed — and every function the prefix marks today
+is post-quantum cryptography, where a divergence between the two is a
+wrong key on the machines that were never tested rather than a slow
+path. `compiler/tests/simd_baseline_agree.sh` builds the vector corpus a
+second time with `--no-cpu-dispatch` and requires the baseline lowering
+to produce the same goldens, and it reads the marked set out of
+`stdlib/` so a newly marked function with no driver fails by name.
+
 Generic functions may not be marked: a generic is monomorphised after the
 whole program is parsed, so the prefix would not survive to its
 instantiations. nurlc rejects `simd` there rather than accept a prefix


### PR DESCRIPTION
## Why

`simd` emits every marked function twice and picks one on a cached CPUID
answer. `simd_dispatch_ir.sh` proves both clones are *built* — two
definitions, feature bits on the wide one only, a dispatcher owning the
undecorated symbol, `ymm` in the object code. Nothing proved the other
one computes the right answer, because no test can run it: on a host
with AVX2 — every x86-64 runner this project uses — the dispatcher picks
the wide clone every time, and on a host without, the wide clone is what
never runs.

`--no-cpu-dispatch` appeared in no build script and no workflow:

```
$ grep -rn "no-cpu-dispatch" build.sh .github/workflows/*.yml compiler/tests/*.sh \
      | grep -v simd_dispatch_ir
$
```

So on this machine — `nurl_cpu_x86_v3()` answers 1 — the baseline
lowering of every marked function is compiled, linked, shipped, and
never once run against a known answer.

All eleven functions the prefix marks today are post-quantum
cryptography: `__ntt`, `__invntt`, `__poly_basemul`, `__cbd_batch` and
the three `__kpke_*` in `mlkem.nu`, `mldsa_keygen_derand` /
`mldsa_sign_mu` / `mldsa_verify_mu` in `mldsa.nu`, and `__kf1600x4`, the
x4 Keccak sponge under both. A divergence between the two lowerings
there is not a slow path — it is a wrong key on the half of a fleet that
was never tested.

## What

`compiler/tests/simd_baseline_agree.sh` (new), run from `./build.sh`
next to `simd_dispatch_ir.sh`, inside the same `RUN_TESTS` guard — so
`--no-tests` and the `--san` bootstrap skip it as they skip the others.

It builds `mlkem_vectors`, `mldsa_vectors` and `sha3x4_vectors` a second
time with `--no-cpu-dispatch` and requires **both** lowerings to produce
the committed golden. Those three drive the marked kernels through their
public API across the parameter seams: all three ML-KEM levels, all
three ML-DSA levels, the x4 sponge either side of both rates.

Two parts are load-bearing:

* **It proves the two legs are different machine code first.** 2057
  `ymm` instructions inside the wide clones of `mlkem_vectors` against 0
  anywhere in the baseline build; 2315 against 0 for `mldsa_vectors`.
  Without this the gate is theatre — "the outputs match" is equally true
  of two builds of identical code, which is exactly what a
  silently-dropped clone would produce.
* **The driver list is not the coverage claim.** The script reads every
  `simd`-marked function out of `stdlib/` and fails by name if the
  drivers do not reach one, matching on the stem so the `__fpN` privacy
  suffix does not hide a miss. Marking a twelfth function without giving
  it a driver fails the build.

No goldens moved and no `.nu` file changed — the answers were already
right in both lowerings. What changed is that a build now checks it.

`docs/spec.md` §3.3b gains a paragraph, because "is the other clone ever
run?" is a fair question to ask of the prefix's semantics and the answer
used to be no.

## Proof

```
$ ./build.sh
BUILD SUCCESS & TESTS PASSED
Build time: 46s  ·  Test time: 1m 51s

$ compiler/tests/run_tests.sh
PASS 879 · FAIL 0 · MISSING 0 · ORPHAN 0 · SKIP 23  (jobs=12)
TESTS PASSED

$ bash compiler/tests/simd_baseline_agree.sh
  host dispatches to                                   the x86-64-v3 clone, per the runtime's own CPUID
  mlkem_vectors: the two legs are different code       ok (8 clones, 2057 ymm vs 0)
  mlkem_vectors (x86-64-v3 lowering)                   ok (14 lines match the golden)
  mlkem_vectors (baseline lowering)                    ok (14 lines match the golden)
  mldsa_vectors: the two legs are different code       ok (4 clones, 2315 ymm vs 0)
  mldsa_vectors (x86-64-v3 lowering)                   ok (16 lines match the golden)
  mldsa_vectors (baseline lowering)                    ok (16 lines match the golden)
  sha3x4_vectors: the two legs are different code      ok (1 clone, 222 ymm vs 0)
  sha3x4_vectors (x86-64-v3 lowering)                  ok (17 lines match the golden)
  sha3x4_vectors (baseline lowering)                   ok (17 lines match the golden)
  every simd-marked stdlib function has a driver       ok (11 functions)

simd_baseline_agree: both lowerings produce the golden
```

The gate costs ~10 s; `./build.sh`'s build phase went 36 s → 46 s and the
test phase is unchanged.

**A gate that has never failed has not been tested.** Broken three ways,
each reverted afterwards (`git diff` clean before the commit):

| Injected | What the gate said |
|---|---|
| Both legs forced to `--no-cpu-dispatch` — the "wide clone silently stopped being emitted" regression | different-code assertion FAILs on all three drivers (`wide-ymm=0 baseline-ymm=0 clones=0`), coverage FAILs listing all eleven functions — **and all six golden comparisons still pass**, which is precisely the regression no existing test can see |
| `3329` → `3330` in `__ntt`'s modulus broadcast (`stdlib/std/mlkem.nu:182`) | `mlkem_vectors` FAILs in **both** lowerings (`exit 1, golden says 0`); the other two drivers unaffected |
| `simd @ __negtest_kernel` appended to `mlkem.nu`, driven by nothing | `every simd-marked stdlib function has a driver  FAIL — uncovered: __negtest_kernel` |

Not run locally, left to CI: the Windows, macOS ARM64, FreeBSD,
sanitizer and unikernel jobs. The unikernel and macOS ARM64 paths are
the ones this change could plausibly disturb, and both are addressed by
the `uname -m` guard below rather than by luck — on a non-x86-64 host
the script prints one line and exits 0.

`nurlfmt` and `tools/check_strict_arity.sh` were not run: this branch
changes no `.nu` file.

## Known remaining

* **The gate is meaningful only on an x86-64 host with AVX2.** The
  prefix names an x86-64 feature set and this gate links and runs both
  legs, so on anything else there is no second lowering to compare
  against; the script skips with a message rather than failing. On an
  x86-64 host *without* AVX2 it still runs, still checks the baseline
  leg against the goldens, and says out loud that the wide clone was not
  exercised — a claim it makes from the runtime's own
  `nurl_cpu_x86_v3()`, falling back to `/proc/cpuinfo` when the probe
  cannot be linked. It never silently reports a comparison it did not
  make.
* **It is anchored on the goldens, not on leg-vs-leg equality.** That is
  the stronger check — any divergence makes at least one leg differ from
  the golden — but it does mean the gate covers exactly what the vector
  tests cover. A kernel input shape those three programs never produce
  is not tested in either lowering, and was not before this PR either.
* **`packages/pqc` and `bench/run_pq.sh` are untouched.** They drive the
  same kernels and would extend coverage, but they are not part of
  `./build.sh` and pulling them in is a separate change.
* The `simd`-marked set is checked against `stdlib/` only. A marked
  function in `packages/` or `examples/` would not be noticed; there are
  none today.

---

Machine-authored: written by Claude Opus 5 in Claude Code, reviewed and
run locally by me before opening.
