### PR TITLE
Release v0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.56.0] — 2026-08-29
 
 ### Added
 
@@ -16639,7 +16639,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.55.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.56.0...HEAD
+[0.56.0]: https://github.com/nurl-lang/nurl/compare/v0.55.0...v0.56.0
 [0.55.0]: https://github.com/nurl-lang/nurl/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/nurl-lang/nurl/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/nurl-lang/nurl/compare/v0.52.0...v0.53.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-29 · Current release: **0.55.0** · Language: **Grammar
+_Last reviewed: 2026-08-29 · Current release: **0.56.0** · Language: **Grammar
 v2.7** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -87,7 +87,9 @@ What is solid today:
   spanning collections, hashing, serialization, a full HTTP/1.1+2 + WebSocket
   stack, database clients, distributed systems (p2p overlay, CRDTs), MCP, and the Anthropic Claude API.
 - **Targets.** Linux x86_64 (primary, CI-tested), Windows x86_64 (CI-tested:
-  bootstrap fixed point + the Windows golden corpus on every push and PR),
+  bootstrap fixed point + the Windows golden corpus on every push and PR,
+  plus a Linux-side mingw-w64 cross-link gate, since the Windows runner's
+  two toolchains are both UCRT and the cross one is not),
   macOS ARM64 (CI-tested on Apple Silicon: bootstrap fixed point + the
   full corpus against the same goldens as Linux, on every push and PR;
   needs Homebrew LLVM, no prebuilt toolchain) and macOS x86_64

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -114,6 +114,14 @@ aggregate (`vec_push`, `json_obj_set`, …) and an escaping position are
 all silent, and so is a callee that hands back a *view* rather than a
 fresh handle. Regression `compiler/tests/lint_owned_temp.nu`.
 
+For the specific case above there is now a shorter answer than binding:
+`( nurl_eprint_int . resp status )` allocates nothing at all. The `_int`
+overloads exist on both streams — `print_int` / `println_int` /
+`eprint_int` / `eprintln_int` — and format on the stack, so a diagnostic
+that prints a number never needs `nurl_str_int` and never had a string to
+own. Binding remains the general rule; not needing a string is better
+than owning one.
+
 Bind first, then use. And do **not** then also free it by hand: the
 binding already carries a drop, so an explicit `nurl_free` on top is a
 double-free. That one is now an `error:` — see §2.1b; the rest of this

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -159,6 +159,23 @@ Cursor, Windsurf, Zed and other MCP-capable IDEs accept the same URL
 run the server binary directly. `nurlapi/main.nu` is a NURL program — no
 Python or Node runtime involved.
 
+**Asking the compiler to check harder.** Every build tool takes `flags`,
+a space-separated string of nurlc flags from a fixed allow-list:
+
+| Flag | What it does |
+|---|---|
+| `--lint` | report an allocation nothing owns (docs/MEMORY.md §1) |
+| `--no-borrowck` | compile with the borrow checker off |
+| `--strict-borrowck` | the stricter §2.4 argument rules |
+| `--no-strict-arity` | accept the n-ary `&` / `\|` spellings |
+| `--no-cpu-dispatch` | no x86-64-v3 clone for `simd` functions |
+
+`--lint`'s findings arrive in `nurlc_stderr` of an ordinary successful
+build, so a lint run is a normal build you read the stderr of. It is an
+allow-list rather than a passthrough because nurlc also takes `--keep=`
+and `--split-out=`, which name paths inside the container; anything not
+on the list is a 400 naming what is, never a silently dropped flag.
+
 **Running what you built.** `nurl_build_native` takes `run=true` to
 execute the program and return its exit code, stdout and stderr in the
 same call — one round trip from source to output. It is **off** on the


### PR DESCRIPTION
Two merges since v0.55.0 — #1034 (the packer) and #1035 (five findings
from testing the release through MCP). Both had written their own
[Unreleased] entries; audited by set, nothing missing, nothing lost.

MINOR, not patch, and the run started out looking like a patch. It is a
fix-heavy release — the headline is that every Windows CROSS build had
been failing to link since 0.54.0, hello world included, because
`nurl_tz_offset` called a UCRT-only CRT export while the distro mingw-w64
that /build_windows uses targets msvcrt. But two of the entries are in
`### Added`, and RELEASING.md's rule does not bend for how the run felt:

  * `nurl_eprint_int` / `nurl_eprintln_int` are new builtins. Code
    written against them does not compile on 0.55.0.
  * `flags` is a new parameter on five build endpoints and five MCP
    tools, and it is what makes `--lint` and `--no-borrowck` reachable
    at all from an agent.

Beyond the rename, three prose fixes the release surfaced:

  * `docs/PLAYGROUND.md` documented no way to pass a compiler flag,
    because until #1035 there was none. It now carries the allow-list and
    says where `--lint`'s findings come out (`nurlc_stderr` of an
    ordinary successful build).
  * `docs/MEMORY.md` §1's own lint example is `( nurl_eprint
    ( nurl_str_int . resp status ) )`, and the fix it teaches — bind
    first — is no longer the shortest one for that line. `nurl_eprint_int`
    allocates nothing. The general rule stays; the example now names the
    better answer beside it.
  * `ROADMAP.md`'s targets line said Windows is CI-tested and meant the
    Windows runner. That was true and still let a two-release outage
    through, so it now names the cross-link gate as a separate thing.

`docs/PLATFORMS.md` was updated in #1035 itself. `nurlweb/public/index.html`
is deliberately untouched: web-deploy regenerates it from the tagged state.

Bootstrap fixed point, 885 tests, nurlfmt --check (1204 files),
check_mingw_cross: green. tools/gen-site-facts.sh reads v0.56.0 from the
new heading.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x