### PR TITLE
packages: anomaly 0.6.0 — the metadata is editable, the autoencoder is visible

### DIFF
--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.6.0
+
+- **The metadata is editable from the dashboard.** `PUT
+  /models/dynamic/<model>/metadata` takes the editable half of the
+  metadata — the retrain schedule and the per-version configs — as a
+  patch in which every field is optional: what the body omits keeps its
+  value, an unknown version name adds a version, and
+  `"replace_versions": true` deletes the ones the body omits. Values are
+  clamped into a trainable range rather than rejected, so a hand-written
+  JSON edit cannot produce a version that fails to train. The learned
+  half (column kinds, categories, feature order, scaler) is still never
+  accepted from a client: it is refitted at every train and a
+  hand-written copy would silently desync every forest. Library:
+  `model_apply_meta_patch`, `model_set_version_enabled`,
+  `meta_apply_versions_json`, `meta_find_version`,
+  `meta_version_enabled`, `meta_version_margin`.
+- The Model Manager drawer now edits what it used to only print: a
+  checkbox and a margin field per version (the two settings that bite at
+  the very next detect), and an *Advanced · edit metadata as JSON* box
+  holding the same document the route takes, for the geometry and forest
+  sizes that take effect at the next retrain. The retrain-schedule form
+  goes through the same route.
+- **The autoencoder is visible.** It has been trainable since 0.4.0
+  (`anomaly train-ae`, `POST /train/autoencoder/<model>`) and its verdict
+  has ridden along in every detect, but nothing in the dashboard ever
+  said so, so a model's most interesting version was invisible unless you
+  read the JSON. `GET .../metadata` now carries an `autoencoder` block
+  (trained, enabled, threshold, points trained on, anomalies filtered,
+  margin, feature names, layer sizes) — its state lives in
+  `autoencoder.json`, not the metadata, which is why it had no place in
+  `meta_to_json` — and the drawer has an Autoencoder section that shows
+  it and trains or retrains it, hidden geometry and contamination
+  included. `POST /train/autoencoder/<model>` accepts an optional
+  `{"hidden": [..], "contamination": x}` body instead of always using
+  64-32-64 and automatic contamination.
+- Disabling the `autoencoder` version now actually mutes it. The verdict
+  was gated on the trained net alone and ignored the `enabled` flag its
+  own `VerCfg` has carried since 0.4.0, so the one version you could not
+  turn off was the one the UI never showed. Disabling it keeps the net —
+  unlike a forest version, whose blob is deleted, because a resurrected
+  forest would be scoring against a feature order and scaler the model
+  has since moved past, and the autoencoder's net carries its own frozen
+  feature order.
+- Every path dependency is pinned on the major (`^0`) instead of the
+  minor, the way `http` already was since 0.5.6. A 0.x minor release of
+  `iforest`, `gpu`, `gpukit`, `cli` or `mlp` no longer leaves this
+  package resolving an older copy from the registry than the one it is
+  built and tested against here.
+- Internal: `__an_margin_of` moved to `src/prep.nu` as the shared
+  `meta_version_margin`, and `__an_jarr_of_strs` took the
+  single-underscore shared spelling — both were about to be called across
+  files, which is the compiler's obsolete `__` path.
+- `tests/anomaly_test.sh` gained the `metaedit` unit suite (55 checks)
+  and live-HTTP coverage of the metadata route; its CLI batch check now
+  sorts under `LC_ALL=C`, because `sort -g` reads `0.15` as `0` in a
+  comma-decimal locale and silently ranked every row equal.
+
 ## 0.5.6
 
 - Requires `http ^0` instead of `^0.3`. http has been 0.4.0 since #1014

--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -151,15 +151,57 @@ command with `--store DIR`.
 | `GET\|POST /force_train/<model>` | retrain now |
 | `POST /detect_anomalies` | batch-score a CSV file (`{"file_path": ..., "has_header": ...}`) |
 | `GET /models/dynamic` | list models with metadata |
-| `GET /models/dynamic/<m>/metadata` | model metadata |
+| `GET /models/dynamic/<m>/metadata` | model metadata, plus the autoencoder's own state |
+| `PUT /models/dynamic/<m>/metadata` | edit the schedule and the per-version configs (see below) |
 | `GET /models/dynamic/<m>/data?limit=N\|all` | recent raw points |
 | `POST /models/dynamic/<m>/reset` | drop data + forests, keep the name |
 | `DELETE\|GET /delete_model/<m>` | delete entirely |
 | `PUT /api/dynamic/<m>/schedule` | `{"below_max_retrain_frequency": .., "at_max_retrain_frequency": ..}` |
 | `POST /api/dynamic/<m>/finetune` | recalibrate decision margins |
+| `POST /train/autoencoder/<m>` | train the autoencoder version — optional `{"hidden": [..], "contamination": x}` |
 
 Model names must match `^[a-zA-Z0-9_]+$`. The router is a plain function
 over `HttpRequest` — the test suite drives every route without a socket.
+
+### Editing the metadata
+
+`PUT /models/dynamic/<m>/metadata` takes the *editable half* of the
+metadata. Both keys are optional, but at least one must be present, and
+every field inside is optional too — what the patch omits keeps its value,
+so a checkbox can send one field:
+
+```jsonc
+{
+  "schedule": { "below_max": 50, "at_max": 1000 },
+  "versions": {
+    "weekly":      { "enabled": false },          // stop scoring, drop the forest
+    "daily":       { "decision_margin": 0.2 },    // effective at the next detect
+    "seasonal":    { "n_estimators": 500 },       // effective at the next retrain
+    "hourly":      { "window_minutes": 60 }       // an unknown name ADDS a version
+  },
+  "replace_versions": false                        // true ⇒ omitted versions are deleted
+}
+```
+
+The response echoes the whole updated metadata. Two fields bite
+immediately — `enabled` and `decision_margin`; the geometry
+(`window_minutes` / `window_points` / `window_size` / `step_size`) and the
+forest size (`n_estimators` / `max_samples` / `contamination`) take effect
+at the next retrain, so a config change can never desync a trained forest
+from the scoring path. Values are clamped into a trainable range rather
+than rejected.
+
+Disabling a forest version **deletes its forest**: its verdict is gone from
+the next detect and re-enabling it costs a retrain. That is deliberate —
+a kept blob would be resurrected trained against a feature order and scaler
+the model has since moved past. The `autoencoder` version is only *muted*:
+its net carries its own frozen feature order, stays valid across retrains,
+and is far too expensive to throw away on a checkbox.
+
+The *learned* half of the metadata — column kinds, category vocabularies,
+the authoritative feature order and the scaler — is never accepted from a
+client. It is refitted at every train, and a hand-written copy would
+silently desync every forest.
 
 ## Dashboard
 
@@ -168,7 +210,7 @@ build step — plain HTML/CSS/JS that talks to the routes above):
 
 | Page | What it does |
 | --- | --- |
-| `/` · `/modelmanager.html` | list models, train / finetune / reset / delete, edit retrain schedule, inspect metadata |
+| `/` · `/modelmanager.html` | list models, train / finetune / reset / delete, toggle versions and retune their margins, train the autoencoder, edit the retrain schedule — or the whole editable metadata as raw JSON |
 | `/modeltrainer.html` | feed points (`/detect`) one at a time or in bulk (paste JSON lines / generate synthetic), force-train |
 | `/visualize.html` | plot any numeric feature of a model's stored points over time |
 | `/anomalies.html` | re-score stored points via `/detect_only` and highlight the anomalies (chart + table with the flagging versions) |
@@ -190,8 +232,10 @@ $ `deps/anomaly/src/dynamic.nu`
 ```
 
 `model_open / model_ingest / model_detect_only / model_force_train /
-model_reset / model_delete / model_finetune / model_set_schedule /
-model_set_margin / model_metadata / model_free`, plus the layers beneath:
+model_reset / model_delete / model_finetune / model_train_autoencoder /
+model_set_schedule / model_set_margin / model_set_version_enabled /
+model_set_version_window / model_apply_meta_patch / model_metadata /
+model_free`, plus the layers beneath:
 preprocessing + scaler (`prep.nu`), the per-point decision core over
 `iforest` (`model.nu`), bulk/batch scoring + training with the GPU path
 (`score.nu`), persistence (`store.nu`), batch CSV (`csvdata.nu`) and the

--- a/packages/anomaly/SPEC.md
+++ b/packages/anomaly/SPEC.md
@@ -153,6 +153,16 @@ Persisted as JSON (`std/ext/json`). Fields:
 }
 ```
 
+**Editable vs learned.** `schedule` and `versions` are the user's to set
+(§6, `PUT /models/dynamic/<m>/metadata`, `model_apply_meta_patch`); everything
+else — `column_types`, `categories`, `feature_names`, `scaler` — is learned at
+each train and is never accepted from a client, because a hand-written copy
+would desync every trained forest. Within a version config, `enabled` and
+`decision_margin` take effect at the next detect; the window geometry and the
+forest size take effect at the next retrain. Disabling a forest version deletes
+its forest blob, so re-enabling costs a retrain; the `autoencoder` version is
+only muted, because its net carries its own frozen feature order.
+
 **Feature-order stability rule.** `feature_names` is authoritative once a model
 is first trained. At scoring time a point is projected onto exactly that vector:
 missing features default to `0`, unknown extras are dropped. This mirrors the
@@ -238,6 +248,19 @@ service so existing dashboards and the `modelmanager` UI keep working:
 - `POST /detect_anomalies` body = `{ file_path, model_name? }` → batch report:
   `anomaly_count`, `anomaly_percentage`, `anomaly_indices`, `has_anomalies`,
   `anomaly_details` (first 100).
+- `GET /models/dynamic/<model>/metadata` — §4.3 metadata plus an
+  `autoencoder` block (its own state lives in `autoencoder.json`, not the
+  metadata): `trained`, `enabled`, `reconstruction_threshold`,
+  `training_data_points`, `filtered_anomalies`, `decision_margin`,
+  `feature_names`, `layer_sizes`.
+- `PUT /models/dynamic/<model>/metadata` body = `{ schedule?, versions?,
+  replace_versions? }`, every field within optional (an omitted field keeps
+  its value; an unknown version name adds a version; `replace_versions`
+  deletes the versions the object omits). 400 on a shape that is not a JSON
+  object of objects, or on an empty patch. Response echoes the full metadata.
+- `POST /train/autoencoder/<model>` optional body = `{ hidden?: [int],
+  contamination?: float }` → `training_data_points`, `filtered_anomalies`,
+  `reconstruction_threshold`.
 - model-name validation: `^[a-zA-Z0-9_]+$` (reject otherwise, mirrors reference).
 
 The service is thin: parse JSON → call the library → serialise. It is

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,16 +1,16 @@
 [package]
 name = "anomaly"
-version = "0.5.6"
-description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
+version = "0.6.0"
+description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several versions judged at once: four time windows (short-term / daily / weekly / seasonal), a `timevector` sliding window that sees ORDER, and an on-demand `autoencoder` that catches marginally-normal-but-jointly-impossible points. A point is anomalous if any enabled version flags it; versions can be switched on and off, their thresholds retuned, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root: versions toggle, margins and the retrain schedule edit inline, the autoencoder trains from a button, and the whole editable metadata is reachable as raw JSON."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-iforest = { path = "../iforest", version = "^0.1" }
-gpu = { path = "../gpu", version = "^0.11" }
+iforest = { path = "../iforest", version = "^0" }
+gpu = { path = "../gpu", version = "^0" }
 http = { path = "../http", version = "^0" }
-cli = { path = "../cli", version = "^0.2.0" }
-gpukit = { path = "../gpukit", version = "^0.6" }
-mlp = { path = "../mlp", version = "^0.3" }
+cli = { path = "../cli", version = "^0" }
+gpukit = { path = "../gpukit", version = "^0" }
+mlp = { path = "../mlp", version = "^0" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.
 # The `serve` dashboard resolves its web root as <exe-dir>/../share/anomaly/static,

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -269,27 +269,6 @@ $ `src/store.nu`
 
 // ── Scoring ───────────────────────────────────────────────────────────
 
-// The live decision margin of a version comes from the CURRENT metadata,
-// not from the forest blob — so margin changes (fine-tune, config PUT)
-// take effect immediately, without a retrain. The blob's stored margin is
-// only the fallback for versions no longer present in the metadata.
-@ __an_margin_of * Meta mm s vname f dflt → f {
-    : i nv ( vec_len [VerCfg] . mm versions )
-    : ~ i k 0
-    ~ < k nv {
-        ?? ( vec_get [VerCfg] . mm versions k ) {
-            T vc → {
-                ? == ( nurl_str_eq ( string_data . vc vname ) vname ) 1 {
-                    ^ . vc decision_margin
-                } {}
-            }
-            F _ → {}
-        }
-        = k + k 1
-    }
-    ^ dflt
-}
-
 // Score an encoded point against every trained version. `ready` is false
 // until the model has trained at least once AND the ring holds min_points.
 // The last window_size−1 ring points before the current one, projected and
@@ -366,7 +345,7 @@ $ `src/store.nu`
                             ( vec_extend [f] tail x )
                             ? == ( vec_len [f] tail ) . vm n_cols {
                                 : f dfw ( anom_decision vm tail )
-                                : f marginw ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                                : f marginw ( meta_version_margin mm ( string_data . vm vname ) . vm margin )
                                 : b hitw <= dfw - 0.0 marginw
                                 ? hitw { = any T } {}
                                 ? || first < dfw worst { = worst dfw } {}
@@ -386,7 +365,7 @@ $ `src/store.nu`
                     }
                 } {
                     : f df ( anom_decision vm x )
-                    : f margin ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                    : f margin ( meta_version_margin mm ( string_data . vm vname ) . vm margin )
                     : b hit <= df - 0.0 margin
                     ? hit { = any T } {}
                     ? || first < df worst { = worst df } {}
@@ -405,12 +384,14 @@ $ `src/store.nu`
     }
     // The autoencoder verdict: reconstruction error against the trained
     // threshold, on the point projected onto the AE's OWN frozen feature
-    // order (independent of the forests' scaler and current feats).
+    // order (independent of the forests' scaler and current feats). Muted
+    // while its VerCfg is disabled — the net is kept, only the verdict
+    // goes away, because re-training it is not a checkbox-priced action.
     : AeModel cae . mo ae
-    ? . cae trained {
+    ? & . cae trained ( meta_version_enabled mm `autoencoder` T ) {
         : ( Vec f ) araw ( anomaly_project p . cae feats )
         : f adf ( ae_decision cae araw )
-        : f amargin ( __an_margin_of mm `autoencoder` 0.05 )
+        : f amargin ( meta_version_margin mm `autoencoder` 0.05 )
         : b ahit <= adf - 0.0 amargin
         ? ahit { = any T } {}
         ? || first < adf worst { = worst adf } {}
@@ -865,7 +846,7 @@ $ `src/store.nu`
                     = r + r 1
                 }
                 ( vec_free [f] dfs )
-                : f old ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                : f old ( meta_version_margin mm ( string_data . vm vname ) . vm margin )
                 : f adjusted * ( float_abs lowest ) 0.95
                 : b applied ( model_set_margin mo ( string_data . vm vname ) adjusted )
                 ( vec_push [FtVer] items @ FtVer {
@@ -967,4 +948,145 @@ $ `src/store.nu`
         = . mo next_train_at + . mm last_trained ( __an_sched_step mo )
     } {}
     ( store_save_meta . mo store ( string_data . mo mname ) mm )
+}
+
+// ── Editing a live model's metadata ───────────────────────────────────
+
+// Drop `vname`'s forest, in memory and on disk. A disabled version starts
+// from scratch when it is re-enabled: keeping the blob would resurrect a
+// forest trained against a feature order and scaler the model has since
+// moved past, and a stale width reads as a timevector window at scoring
+// time — a wrong verdict rather than an absent one.
+@ __an_drop_forest * Model mo s vname → v {
+    : ( Vec VerModel ) kept ( vec_new [VerModel] )
+    : i nf ( vec_len [VerModel] . mo forests )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( vec_get [VerModel] . mo forests k ) {
+            T vm → {
+                ? == ( nurl_str_eq ( string_data . vm vname ) vname ) 1 {
+                    ( anom_vermodel_free vm )
+                } { ( vec_push [VerModel] kept vm ) }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [VerModel] . mo forests )
+    = . mo forests kept
+    ( store_delete_forest . mo store ( string_data . mo mname ) vname )
+}
+
+// Every forest whose version is now off (or gone from the metadata) loses
+// its blob. The autoencoder has no forest, so it is never touched here.
+@ __an_prune_disabled * Model mo → v {
+    : *Meta mm . mo meta
+    : ( Vec String ) doomed ( vec_new [String] )
+    : i nf ( vec_len [VerModel] . mo forests )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( vec_get [VerModel] . mo forests k ) {
+            T vm → {
+                ? ( meta_version_enabled mm ( string_data . vm vname ) F ) {} {
+                    ( vec_push [String] doomed ( string_from ( string_data . vm vname ) ) )
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    : i nd ( vec_len [String] doomed )
+    = k 0
+    ~ < k nd {
+        ?? ( vec_get [String] doomed k ) {
+            T d → { ( __an_drop_forest mo ( string_data d ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] doomed \ String x → v { ( string_free x ) } )
+}
+
+// Turn one version on or off (persisted immediately). Disabling drops the
+// version's forest, so its verdict is gone from the very next detect and
+// re-enabling it costs a retrain. The `autoencoder` version is only muted:
+// its net carries its OWN frozen feature order, so it stays valid across
+// retrains and is far too expensive to throw away on a checkbox. Returns F
+// for an unknown version name.
+@ model_set_version_enabled * Model mo s vname b on → b {
+    : *Meta mm . mo meta
+    : i at ( meta_find_version mm vname )
+    ? < at 0 { ^ F } {}
+    ?? ( vec_get [VerCfg] . mm versions at ) {
+        T vc → {
+            : ~ VerCfg upd vc
+            = . upd enabled on
+            : b _o ( vec_set [VerCfg] . mm versions at upd )
+        }
+        F _ → {}
+    }
+    ? on {} {
+        ? == ( nurl_str_eq vname `autoencoder` ) 1 {} { ( __an_drop_forest mo vname ) }
+    }
+    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+    ^ T
+}
+
+// Apply an editable-metadata patch:
+//
+//   { "schedule": { "below_max": N, "at_max": N },
+//     "versions": { "<name>": { <any VerCfg field> }, ... },
+//     "replace_versions": bool }
+//
+// Both top-level keys are optional but at least one must be present. The
+// learned parts of the metadata (columns, categories, feature order,
+// scaler) are never taken from the client — see prep.nu. Per-version
+// fields split two ways: `enabled` and `decision_margin` bite at the very
+// next detect, the geometry and forest-size fields at the next retrain.
+// Returns "" on success, else the reason (400-worthy).
+@ model_apply_meta_patch * Model mo Json patch → String {
+    ? ( json_is_obj patch ) {} { ^ ( string_from `metadata must be a JSON object` ) }
+    : *Meta mm . mo meta
+    : ~ b touched F
+
+    ?? ( json_obj_get patch `schedule` ) {
+        T sj → {
+            ? ( json_is_obj sj ) {} { ^ ( string_from `schedule must be a JSON object` ) }
+            : i below ( _an_jint sj `below_max` . mm sched_below )
+            : i atmax ( _an_jint sj `at_max` . mm sched_at_max )
+            ? & > below 0 > atmax 0 {} {
+                ^ ( string_from `schedule.below_max and schedule.at_max must be positive` )
+            }
+            = . mm sched_below below
+            = . mm sched_at_max atmax
+            = touched T
+        }
+        F _ → {}
+    }
+
+    ?? ( json_obj_get patch `versions` ) {
+        T vj → {
+            : ~ b repl F
+            ?? ( json_obj_get patch `replace_versions` ) {
+                T rj → { = repl ( json_as_bool rj ) }
+                F _ → {}
+            }
+            ? < ( meta_apply_versions_json mm vj repl ) 0 {
+                ^ ( string_from `versions must be a JSON object of version configs` )
+            } {}
+            = touched T
+        }
+        F _ → {}
+    }
+
+    ? touched {} {
+        ^ ( string_from `nothing to update: expected a schedule and/or versions object` )
+    }
+
+    ( __an_prune_disabled mo )
+    ? ( model_is_trained mo ) {
+        = . mo next_train_at + . mm last_trained ( __an_sched_step mo )
+    } {}
+    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+    ^ ( string_new )
 }

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -495,7 +495,7 @@ $ `src/service.nu`
 }
 
 @ main → i {
-    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.5.6` )
+    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.6.0` )
     ( cli_flag_str c `store` 115 `DIR` `model store (default: $ANOMALY_HOME, else ~/.anomaly)` `` `ANOMALY_HOME` )
     ( cli_flag_str c `file` 102 `FILE` `for batch: read CSV from FILE instead of stdin` `` `` )
     ( cli_flag_str c `margin` 109 `M` `for batch: decision margin (default 0 = predict==-1)` `0` `` )

--- a/packages/anomaly/src/prep.nu
+++ b/packages/anomaly/src/prep.nu
@@ -653,7 +653,7 @@ $ `stdlib/ext/json.nu`
 }
 
 // ( Vec String ) → JSON array of strings.
-@ __an_jarr_of_strs ( Vec String ) xs → Json {
+@ _an_jarr_of_strs ( Vec String ) xs → Json {
     : Json a ( json_arr_new )
     : i n ( vec_len [String] xs )
     : ~ i k 0
@@ -727,7 +727,7 @@ $ `stdlib/ext/json.nu`
                 ( json_obj_set types ( string_data c ) ( json_str_lit ( __an_kind_str kind ) ) )
                 ? == kind COL_CATEGORICAL {
                     ?? ( vec_get [( Vec String )] . m cats k ) {
-                        T cv → { ( json_obj_set cats ( string_data c ) ( __an_jarr_of_strs cv ) ) }
+                        T cv → { ( json_obj_set cats ( string_data c ) ( _an_jarr_of_strs cv ) ) }
                         F _ → {}
                     }
                 } {}
@@ -738,7 +738,7 @@ $ `stdlib/ext/json.nu`
     }
     ( json_obj_set o `column_types` types )
     ( json_obj_set o `categories` cats )
-    ( json_obj_set o `feature_names` ( __an_jarr_of_strs . m feats ) )
+    ( json_obj_set o `feature_names` ( _an_jarr_of_strs . m feats ) )
 
     : Json sc ( json_obj_new )
     ( json_obj_set sc `mean` ( __an_jarr_of_floats . m sc_mean ) )
@@ -1033,4 +1033,165 @@ $ `stdlib/ext/json.nu`
         }
         F _ → { ^ @ ?*Meta { F } }
     }
+}
+
+// ── Editable metadata (dashboard / API) ───────────────────────────────
+//
+// Two parts of the metadata are the user's to set: the retrain schedule
+// and the per-version configs. Everything else — column kinds, category
+// vocabularies, the authoritative feature order, the scaler — is learned
+// from the data at each train, and a hand-edited copy would silently
+// desync every trained forest. The helpers below therefore only ever
+// touch `versions`; the schedule lives on Meta directly.
+
+// Index of the version named `vname`, or -1.
+@ meta_find_version * Meta m s vname → i {
+    : i nv ( vec_len [VerCfg] . m versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . m versions k ) {
+            T vc → { ? == ( nurl_str_eq ( string_data . vc vname ) vname ) 1 { ^ k } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ -1
+}
+
+// Is version `vname` enabled? `dflt` when there is no such version.
+@ meta_version_enabled * Meta m s vname b dflt → b {
+    : i at ( meta_find_version m vname )
+    ? < at 0 { ^ dflt } {}
+    ?? ( vec_get [VerCfg] . m versions at ) { T vc → { ^ . vc enabled } F _ → { ^ dflt } }
+}
+
+// Version `vname`'s decision margin; `dflt` when there is no such version.
+// The live margin of a version always comes from the CURRENT metadata, not
+// from its forest blob — so margin changes (fine-tune, a config PUT) take
+// effect immediately, without a retrain. The blob's stored margin is only
+// the fallback for versions no longer present in the metadata.
+@ meta_version_margin * Meta m s vname f dflt → f {
+    : i at ( meta_find_version m vname )
+    ? < at 0 { ^ dflt } {}
+    ?? ( vec_get [VerCfg] . m versions at ) { T vc → { ^ . vc decision_margin } F _ → { ^ dflt } }
+}
+
+// Clamp a config into the range the trainer can actually honour, so a
+// hand-written JSON patch can never produce a version that fails to train
+// (or trains something nonsensical). `contamination` < 0 means "auto".
+@ _an_vercfg_sane VerCfg vc → VerCfg {
+    : ~ VerCfg o vc
+    ? < . o window_min 0 { = . o window_min 0 } {}
+    ? < . o window_pts 0 { = . o window_pts 0 } {}
+    ? < . o window_size 0 { = . o window_size 0 } {}
+    ? > . o window_size 0 {
+        ? < . o step_size 1 { = . o step_size 1 } {}
+    } { = . o step_size 0 }
+    // The autoencoder version has no forest: its tree counts stay 0 so the
+    // config round-trips unchanged. Every other version must be trainable.
+    ? == ( nurl_str_eq ( string_data . o vname ) `autoencoder` ) 1 {
+        ? < . o n_estimators 0 { = . o n_estimators 0 } {}
+        ? < . o max_samples 0 { = . o max_samples 0 } {}
+    } {
+        ? < . o n_estimators 1 { = . o n_estimators 1 } {}
+        ? > . o n_estimators 5000 { = . o n_estimators 5000 } {}
+        ? < . o max_samples 1 { = . o max_samples 1 } {}
+    }
+    ? <= . o contamination 0.0 { = . o contamination -1.0 } {
+        ? > . o contamination 0.5 { = . o contamination 0.5 } {}
+    }
+    ? < . o decision_margin 0.0 { = . o decision_margin 0.0 } {}
+    ^ o
+}
+
+// Patch one version config from a JSON object. Every field is optional:
+// what the object omits keeps its current value, so the dashboard can PUT
+// `{"enabled": false}` without restating the whole config.
+@ _an_vercfg_patch VerCfg vc Json vo → VerCfg {
+    : ~ VerCfg o vc
+    = . o window_min ( _an_jint vo `window_minutes` . vc window_min )
+    = . o window_pts ( _an_jint vo `window_points` . vc window_pts )
+    = . o window_size ( _an_jint vo `window_size` . vc window_size )
+    = . o step_size ( _an_jint vo `step_size` . vc step_size )
+    = . o n_estimators ( _an_jint vo `n_estimators` . vc n_estimators )
+    = . o max_samples ( _an_jint vo `max_samples` . vc max_samples )
+    ?? ( json_obj_get vo `contamination` ) {
+        T cj → {
+            ? ( json_is_num cj ) {
+                : ?f cf ( json_num_as_f cj )
+                ?? cf { T x → { = . o contamination x } F _ → {} }
+            } { = . o contamination -1.0 }
+        }
+        F _ → {}
+    }
+    ?? ( json_obj_get vo `decision_margin` ) {
+        T dj → {
+            : ?f df ( json_num_as_f dj )
+            ?? df { T x → { = . o decision_margin x } F _ → {} }
+        }
+        F _ → {}
+    }
+    ?? ( json_obj_get vo `enabled` ) { T ej → { = . o enabled ( json_as_bool ej ) } F _ → {} }
+    ^ ( _an_vercfg_sane o )
+}
+
+// Apply a `versions` JSON object (the shape meta_to_json emits) to the
+// metadata. Each key names a version and its value is a PARTIAL config;
+// a key naming no existing version ADDS one, with `_an_vercfg_of_json`'s
+// defaults filling the gaps. With `replace`, the resulting list is exactly
+// the keys given — versions the object omits are dropped, which is how the
+// advanced JSON editor deletes one. Returns the version count afterwards,
+// or -1 when `vers` is not a JSON object.
+@ meta_apply_versions_json * Meta m Json vers b replace → i {
+    ? ( json_is_obj vers ) {} { ^ -1 }
+    : ( Vec String ) keys ( json_obj_keys vers )
+    : i nk ( vec_len [String] keys )
+    : ~ i k 0
+    ~ < k nk {
+        ?? ( vec_get [String] keys k ) {
+            T vn → {
+                ?? ( json_obj_get vers ( string_data vn ) ) {
+                    T vo → {
+                        ? ( json_is_obj vo ) {
+                            : i at ( meta_find_version m ( string_data vn ) )
+                            ? >= at 0 {
+                                ?? ( vec_get [VerCfg] . m versions at ) {
+                                    T cur → {
+                                        : b _o ( vec_set [VerCfg] . m versions at ( _an_vercfg_patch cur vo ) )
+                                    }
+                                    F _ → {}
+                                }
+                            } {
+                                ( vec_push [VerCfg] . m versions
+                                ( _an_vercfg_sane ( _an_vercfg_of_json ( string_data vn ) vo ) ) )
+                            }
+                        } {}
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ? replace {
+        : ( Vec VerCfg ) kept ( vec_new [VerCfg] )
+        : i nv ( vec_len [VerCfg] . m versions )
+        = k 0
+        ~ < k nv {
+            ?? ( vec_get [VerCfg] . m versions k ) {
+                T vc → {
+                    ? ( json_obj_has vers ( string_data . vc vname ) ) {
+                        ( vec_push [VerCfg] kept vc )
+                    } { ( _an_vercfg_free vc ) }
+                }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        ( vec_free [VerCfg] . m versions )
+        = . m versions kept
+    } {}
+    ( vec_free_with [String] keys \ String x → v { ( string_free x ) } )
+    ^ ( vec_len [VerCfg] . m versions )
 }

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -9,12 +9,14 @@
 //   GET|POST /force_train/<model>             retrain now
 //   POST   /detect_anomalies                  batch-score a CSV file
 //   GET    /models/dynamic                    list models + metadata
-//   GET    /models/dynamic/<model>/metadata   metadata
+//   GET    /models/dynamic/<model>/metadata   metadata (+ autoencoder state)
+//   PUT    /models/dynamic/<model>/metadata   edit schedule / version configs
 //   GET    /models/dynamic/<model>/data       recent points (?limit=N|all)
 //   POST   /models/dynamic/<model>/reset      drop data+forests, keep name
 //   DELETE|GET /delete_model/<model>          delete entirely
 //   PUT    /api/dynamic/<model>/schedule      retraining schedule
 //   POST   /api/dynamic/<model>/finetune      recalibrate margins
+//   POST   /train/autoencoder/<model>         train the autoencoder version
 //
 // Model names must match ^[a-zA-Z0-9_]+$ (400 otherwise, same message as
 // the reference). Divergence from the reference: /detect_anomalies scores
@@ -437,6 +439,43 @@ $ `src/csvdata.nu`
     ^ r
 }
 
+// The autoencoder version's own state, which lives outside the metadata
+// (autoencoder.json, not meta.json) and so has no place in meta_to_json.
+// `enabled` is read back from the metadata: disabling the version mutes
+// the verdict but keeps the trained net.
+@ __an_ae_json Store st s name * Meta mm → Json {
+    : Json o ( json_obj_new )
+    ?? ( store_load_ae st name ) {
+        T ae → {
+            ( json_obj_set o `trained` ( json_bool . ae trained ) )
+            ( json_obj_set o `enabled` ( json_bool ( meta_version_enabled mm `autoencoder` F ) ) )
+            ( json_obj_set o `reconstruction_threshold` ( json_float . ae threshold ) )
+            ( json_obj_set o `training_data_points` ( json_int . ae trained_on ) )
+            ( json_obj_set o `filtered_anomalies` ( json_int . ae filtered ) )
+            ( json_obj_set o `decision_margin` ( json_float ( meta_version_margin mm `autoencoder` 0.05 ) ) )
+            ( json_obj_set o `feature_names` ( _an_jarr_of_strs . ae feats ) )
+            : Json layers ( json_arr_new )
+            : Mlp net . ae net
+            : i nl ( vec_len [i] . net sizes )
+            : ~ i k 0
+            ~ < k nl {
+                ?? ( vec_get [i] . net sizes k ) {
+                    T sz → { ( json_arr_push layers ( json_int sz ) ) }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( json_obj_set o `layer_sizes` layers )
+            ( ae_free ae )
+        }
+        F → {
+            ( json_obj_set o `trained` ( json_bool F ) )
+            ( json_obj_set o `enabled` ( json_bool ( meta_version_enabled mm `autoencoder` F ) ) )
+        }
+    }
+    ^ o
+}
+
 @ __an_h_metadata HttpRequest req Params p → HttpResponse {
     : String mname ( __an_param_model p )
     ? ( __an_name_ok ( string_data mname ) ) {} {
@@ -450,6 +489,7 @@ $ `src/csvdata.nu`
         T mm → {
             : Json o ( meta_to_json mm )
             ( json_obj_set o `model_name` ( json_str_lit ( string_data mname ) ) )
+            ( json_obj_set o `autoencoder` ( __an_ae_json st ( string_data mname ) mm ) )
             ( http_response_free resp )
             = resp ( response_json 200 o )
             ( json_free o )
@@ -617,6 +657,58 @@ $ `src/csvdata.nu`
     }
 }
 
+@ __an_h_meta_update HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : ?Json bodyo ( __an_body_json req )
+    ?? bodyo {
+        T body → {
+            : *Model mo ( model_open st ( string_data mname ) )
+            : String err ( model_apply_meta_patch mo body )
+            ( json_free body )
+            ? == ( string_len err ) 0 {} {
+                : HttpResponse rbad ( __an_json_err 400 ( string_data err ) )
+                ( string_free err )
+                ( model_free mo )
+                ( store_free st )
+                ( string_free mname )
+                ^ rbad
+            }
+            ( string_free err )
+            : *Meta mm ( model_metadata mo )
+            : String msg ( string_from `Metadata updated for model ` )
+            ( string_push_str msg ( string_data mname ) )
+            : Json o ( __an_ok_msg ( string_data msg ) )
+            ( string_free msg )
+            : Json meta ( meta_to_json mm )
+            ( json_obj_set meta `model_name` ( json_str_lit ( string_data mname ) ) )
+            ( json_obj_set meta `autoencoder` ( __an_ae_json st ( string_data mname ) mm ) )
+            ( json_obj_set o `metadata` meta )
+            : HttpResponse r ( response_json 200 o )
+            ( json_free o )
+            ( model_free mo )
+            ( store_free st )
+            ( string_free mname )
+            ^ r
+        }
+        F _ → {
+            ( store_free st )
+            ( string_free mname )
+            ^ ( __an_json_err 400 `No data provided` )
+        }
+    }
+}
+
 @ __an_h_train_ae HttpRequest req Params p → HttpResponse {
     : String mname ( __an_param_model p )
     ? ( __an_name_ok ( string_data mname ) ) {} {
@@ -631,8 +723,46 @@ $ `src/csvdata.nu`
         ^ r404
     }
     : *Model mo ( model_open st ( string_data mname ) )
+    // Optional body: {"hidden": [64, 32, 64], "contamination": 0.1}.
+    // Absent (or empty / unparsable) → the 64-32-64 default and the
+    // pre-filter's own "auto" contamination.
     : ( Vec i ) hidden ( vec_new [i] )
-    : String err ( model_train_autoencoder mo hidden -1.0 )
+    : ~ f contam -1.0
+    ?? ( __an_body_json req ) {
+        T body → {
+            ?? ( json_obj_get body `hidden` ) {
+                T ha → {
+                    ? ( json_is_arr ha ) {
+                        : i nh ( json_arr_len ha )
+                        : ~ i k 0
+                        ~ < k nh {
+                            ?? ( json_arr_get ha k ) {
+                                T e → {
+                                    : ?i hv ( json_num_as_i e )
+                                    ?? hv { T x → { ? > x 0 { ( vec_push [i] hidden x ) } {} } F _ → {} }
+                                }
+                                F _ → {}
+                            }
+                            = k + k 1
+                        }
+                    } {}
+                }
+                F _ → {}
+            }
+            ?? ( json_obj_get body `contamination` ) {
+                T cj → {
+                    ? ( json_is_num cj ) {
+                        : ?f cf ( json_num_as_f cj )
+                        ?? cf { T x → { ? > x 0.0 { = contam x } {} } F _ → {} }
+                    } {}
+                }
+                F _ → {}
+            }
+            ( json_free body )
+        }
+        F _ → {}
+    }
+    : String err ( model_train_autoencoder mo hidden contam )
     ( vec_free [i] hidden )
     ? == ( string_len err ) 0 {
         : AeModel tae . mo ae
@@ -851,6 +981,7 @@ $ `src/csvdata.nu`
     ( router_post r `/detect_anomalies` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_batch req p ) } )
     ( router_get r `/models/dynamic` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_models req p ) } )
     ( router_get r `/models/dynamic/:model/metadata` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_metadata req p ) } )
+    ( router_put r `/models/dynamic/:model/metadata` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_meta_update req p ) } )
     ( router_get r `/models/dynamic/:model/data` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_data req p ) } )
     ( router_post r `/models/dynamic/:model/reset` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_reset req p ) } )
     ( router_delete r `/delete_model/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_delete req p ) } )

--- a/packages/anomaly/static/modelmanager.html
+++ b/packages/anomaly/static/modelmanager.html
@@ -88,6 +88,38 @@
   .vtable { width: 100%; font-size: 12px; }
   .vtable th, .vtable td { padding: 5px 8px; text-align: right; }
   .vtable th:first-child, .vtable td:first-child { text-align: left; font-family: var(--mono); }
+  .vtable input[type=number] { width: 84px; padding: 3px 6px; font-size: 12px; text-align: right; }
+  .vtable input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
+  .vtable tr.off td:first-child { color: var(--muted); }
+  .vtable td.dim { color: var(--muted); }
+  .section-head { display: flex; align-items: baseline; gap: 10px; margin: 0 0 10px; }
+  .section-head h3 { margin: 0; }
+  .section-head .spacer { flex: 1; }
+  .hint { color: var(--muted); font-size: 11.5px; margin: 8px 0 0; line-height: 1.45; }
+  textarea { width: 100%; min-height: 240px; font-family: var(--mono); font-size: 12px;
+             background: var(--bg); color: var(--fg); border: 1px solid var(--border);
+             border-radius: 8px; padding: 10px; resize: vertical; line-height: 1.45; }
+  textarea:focus { outline: none; border-color: var(--accent); }
+  textarea.bad { border-color: var(--danger); }
+  details.adv { border: 1px solid var(--border); border-radius: var(--radius);
+                background: var(--panel2); padding: 0; }
+  details.adv > summary { cursor: pointer; padding: 10px 14px; font-size: 12px;
+                          font-weight: 600; color: var(--muted); list-style: none; }
+  details.adv > summary::-webkit-details-marker { display: none; }
+  details.adv > summary::before { content: "\25B8 "; color: var(--accent); }
+  details.adv[open] > summary::before { content: "\25BE "; }
+  details.adv > summary:hover { color: var(--fg); }
+  .adv-body { padding: 0 14px 14px; }
+  .ae-grid { display: grid; grid-template-columns: 130px 1fr; gap: 4px 12px; font-size: 13px;
+             margin-bottom: 12px; }
+  .ae-grid dt { color: var(--muted); }
+  .ae-grid dd { margin: 0; font-family: var(--mono); word-break: break-word; }
+  .ae-form { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+  .ae-form .field input { width: 130px; }
+  .dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+         background: var(--muted); margin-right: 6px; vertical-align: 1px; }
+  .dot.on { background: var(--ok); }
+  .dot.off { background: var(--warn); }
   .sched-form { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .field label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
@@ -300,6 +332,9 @@ function closeDrawer() {
   $("backdrop").classList.remove("open");
   render();
 }
+// Only these two version fields are editable inline: they bite at the very
+// next detect. Geometry and forest size live in the advanced JSON editor
+// because they only take effect at the next retrain.
 function renderDrawer(name) {
   const m = MODELS[name];
   $("dTitle").textContent = name;
@@ -307,6 +342,7 @@ function renderDrawer(name) {
   const feats = m.feature_names || [];
   const sched = m.schedule || { below_max: 0, at_max: 0 };
   const vers = m.versions || {};
+  const ae = m.autoencoder || { trained: false, enabled: false };
 
   let colChips = Object.keys(cols).map(c =>
     '<span class="chip">' + esc(c) + ' <span class="t">' + esc(cols[c]) + "</span></span>").join("");
@@ -314,12 +350,32 @@ function renderDrawer(name) {
 
   let vrows = Object.keys(vers).map(vn => {
     const v = vers[vn];
-    return "<tr><td>" + esc(vn) + "</td><td>" + (v.enabled ? "✓" : "–") + "</td>" +
-      "<td>" + (v.window_minutes || 0) + "m/" + (v.window_points || 0) + "p</td>" +
-      "<td>" + (v.n_estimators || 0) + "×" + (v.max_samples || 0) + "</td>" +
-      "<td>" + fmtNum(v.decision_margin) + "</td></tr>";
+    const isAe = vn === "autoencoder";
+    const win = isAe ? "–"
+      : (v.window_size > 0 ? v.window_size + "×" + (v.step_size || 1) + " pts"
+                           : (v.window_minutes || 0) + "m/" + (v.window_points || 0) + "p");
+    const trees = isAe ? "–" : (v.n_estimators || 0) + "×" + (v.max_samples || 0);
+    return '<tr' + (v.enabled ? "" : ' class="off"') + '><td>' + esc(vn) + "</td>" +
+      '<td><input type="checkbox" data-v="' + esc(vn) + '" data-f="enabled"' +
+        (v.enabled ? " checked" : "") + "></td>" +
+      '<td class="dim">' + esc(win) + "</td>" +
+      '<td class="dim">' + esc(trees) + "</td>" +
+      '<td><input type="number" step="0.001" min="0" data-v="' + esc(vn) + '" data-f="margin" value="' +
+        (Number(v.decision_margin) || 0) + '"></td></tr>';
   }).join("");
   if (!vrows) vrows = '<tr><td colspan="5" class="muted">no versions</td></tr>';
+
+  const aeState = ae.trained
+    ? (ae.enabled ? '<span class="dot on"></span>trained &amp; scoring'
+                  : '<span class="dot off"></span>trained, muted (version disabled)')
+    : '<span class="dot"></span>not trained';
+  const aeRows = ae.trained
+    ? "<dt>Threshold</dt><dd>" + fmtNum(ae.reconstruction_threshold) + "</dd>" +
+      "<dt>Trained on</dt><dd>" + (ae.training_data_points ?? 0).toLocaleString() +
+        " pts <span class=\"muted\">(" + (ae.filtered_anomalies ?? 0) + " filtered)</span></dd>" +
+      "<dt>Layers</dt><dd>" + esc((ae.layer_sizes || []).join(" → ") || "–") + "</dd>" +
+      "<dt>Margin</dt><dd>" + fmtNum(ae.decision_margin) + "</dd>"
+    : "";
 
   $("dBody").innerHTML =
     '<div class="section"><h3>Overview</h3><dl class="kv">' +
@@ -332,18 +388,58 @@ function renderDrawer(name) {
 
     '<div class="section"><h3>Columns</h3><div class="chips">' + colChips + "</div></div>" +
 
-    '<div class="section"><h3>Versions</h3><table class="vtable">' +
+    '<div class="section">' +
+      '<div class="section-head"><h3>Versions</h3><div class="spacer"></div>' +
+        '<button class="small primary" id="vSave">Save versions</button></div>' +
+      '<table class="vtable" id="vTbl">' +
       "<thead><tr><th>name</th><th>on</th><th>window</th><th>trees</th><th>margin</th></tr></thead>" +
-      "<tbody>" + vrows + "</tbody></table></div>" +
+      "<tbody>" + vrows + "</tbody></table>" +
+      '<p class="hint">A point is anomalous if <b>any</b> enabled version flags it ' +
+        "(score ≤ −margin). On/off and margin take effect at the next detect; " +
+        "disabling a forest version discards its forest, so re-enabling costs a retrain. " +
+        "The autoencoder is only muted — its net is kept.</p>" +
+    "</div>" +
+
+    '<div class="section"><h3>Autoencoder</h3>' +
+      '<div style="margin-bottom:10px">' + aeState + "</div>" +
+      (aeRows ? '<dl class="ae-grid">' + aeRows + "</dl>" : "") +
+      '<div class="ae-form">' +
+        '<div class="field"><label>hidden layers</label>' +
+          '<input type="text" id="aeHidden" placeholder="64,32,64"></div>' +
+        '<div class="field"><label>contamination</label>' +
+          '<input type="text" id="aeCont" placeholder="auto"></div>' +
+        '<button id="aeTrain">' + (ae.trained ? "Retrain" : "Train") + " autoencoder</button>" +
+      "</div>" +
+      '<p class="hint">Trains a reconstruction model on the ring after an isolation-forest ' +
+        "pre-filter drops the obvious outliers. Explicit only — never part of the retrain " +
+        "schedule. Leave the fields empty for 64-32-64 and automatic contamination.</p>" +
+    "</div>" +
 
     '<div class="section"><h3>Retrain schedule</h3>' +
       '<div class="sched-form">' +
         '<div class="field"><label>below max (every N pts)</label>' +
-          '<input type="number" id="schedBelow" min="0" value="' + (sched.below_max || 0) + '"></div>' +
+          '<input type="number" id="schedBelow" min="1" value="' + (sched.below_max || 0) + '"></div>' +
         '<div class="field"><label>at max (every N pts)</label>' +
-          '<input type="number" id="schedAt" min="0" value="' + (sched.at_max || 0) + '"></div>' +
-        '<button class="primary" onclick="saveSchedule(\'' + esc(name) + '\')">Save</button>' +
+          '<input type="number" id="schedAt" min="1" value="' + (sched.at_max || 0) + '"></div>' +
+        '<button class="primary" id="schedSave">Save</button>' +
       "</div></div>" +
+
+    '<div class="section"><details class="adv" id="advBox">' +
+      "<summary>Advanced · edit metadata as JSON</summary>" +
+      '<div class="adv-body">' +
+        '<textarea id="advText" spellcheck="false"></textarea>' +
+        '<div class="sched-form" style="margin-top:10px">' +
+          '<button class="primary" id="advApply">Apply JSON</button>' +
+          '<button id="advRevert">Revert</button>' +
+          '<label class="muted" style="display:flex;align-items:center;gap:6px;font-size:12px">' +
+            '<input type="checkbox" id="advReplace"> replace versions (delete the ones omitted)</label>' +
+        "</div>" +
+        '<p class="hint">This is the editable half of the metadata, exactly as ' +
+          "<code>PUT /models/dynamic/" + esc(name) + "/metadata</code> takes it. Omitted fields keep " +
+          "their value. The learned half — column kinds, categories, feature order, scaler — is " +
+          "not editable: it is refitted at every train and a hand-written copy would desync every " +
+          "forest.</p>" +
+      "</div></details></div>" +
 
     '<div class="section"><h3>Actions</h3><div class="actions" style="justify-content:flex-start">' +
       '<button onclick="doAction(\'train\',\'' + esc(name) + '\',this)">Force train</button>' +
@@ -351,26 +447,98 @@ function renderDrawer(name) {
       '<a class="btn" href="/visualize.html?model=' + enc(name) + '">Visualize →</a>' +
       '<a class="btn" href="/anomalies.html?model=' + enc(name) + '">Anomalies →</a>' +
     "</div></div>";
+
+  $("vSave").onclick    = (e) => saveVersions(name, e.currentTarget);
+  $("schedSave").onclick= (e) => saveSchedule(name, e.currentTarget);
+  $("aeTrain").onclick  = (e) => trainAE(name, e.currentTarget);
+  $("advApply").onclick = (e) => applyAdvanced(name, e.currentTarget);
+  $("advRevert").onclick= () => { $("advText").value = advSource(m); $("advText").classList.remove("bad"); };
+  $("advText").value = advSource(m);
+  $("vTbl").querySelectorAll("input").forEach(el =>
+    el.onchange = () => { const tr = el.closest("tr");
+                          if (el.dataset.f === "enabled") tr.classList.toggle("off", !el.checked); });
 }
+
+// The editable half of the metadata, pretty-printed for the JSON editor.
+function advSource(m) {
+  return JSON.stringify({ schedule: m.schedule || {}, versions: m.versions || {} }, null, 2);
+}
+
+// PUT a patch and adopt the metadata the service echoes back.
+async function putMeta(name, patch, btn, what) {
+  const orig = btn ? btn.textContent : "";
+  if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spin"></span>'; }
+  try {
+    const d = await api("PUT", "/models/dynamic/" + enc(name) + "/metadata", patch);
+    if (d && d.metadata) MODELS[name] = d.metadata;
+    toast((d && d.message) || "Saved", "ok", what);
+    renderDrawer(name);
+    render();
+    return true;
+  } catch (e) {
+    toast(e.message, "err", what + " failed");
+    return false;
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = orig; }
+  }
+}
+
+function saveVersions(name, btn) {
+  const versions = {};
+  $("vTbl").querySelectorAll("input[data-v]").forEach(el => {
+    const v = versions[el.dataset.v] || (versions[el.dataset.v] = {});
+    if (el.dataset.f === "enabled") v.enabled = el.checked;
+    else {
+      const x = parseFloat(el.value);
+      if (isFinite(x)) v.decision_margin = x;
+    }
+  });
+  return putMeta(name, { versions }, btn, "versions");
+}
+
+function applyAdvanced(name, btn) {
+  const ta = $("advText");
+  let patch;
+  try { patch = JSON.parse(ta.value); }
+  catch (e) { ta.classList.add("bad"); toast(e.message, "err", "Invalid JSON"); return; }
+  ta.classList.remove("bad");
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+    toast("expected a JSON object", "err", "Invalid JSON"); return;
+  }
+  if ($("advReplace").checked) patch.replace_versions = true;
+  return putMeta(name, patch, btn, "metadata");
+}
+
+async function trainAE(name, btn) {
+  const body = {};
+  const hs = ($("aeHidden").value || "").split(",").map(x => parseInt(x, 10)).filter(x => x > 0);
+  if (hs.length) body.hidden = hs;
+  const c = parseFloat($("aeCont").value);
+  if (isFinite(c) && c > 0) body.contamination = c;
+  const orig = btn.textContent;
+  btn.disabled = true; btn.innerHTML = '<span class="spin"></span>';
+  try {
+    const d = await api("POST", "/train/autoencoder/" + enc(name), body);
+    toast("trained on " + (d.training_data_points ?? "?") + " pts, " +
+          (d.filtered_anomalies ?? 0) + " filtered", "ok", "autoencoder");
+    await openDrawer(name);
+  } catch (e) {
+    toast(e.message, "err", "Autoencoder failed");
+  } finally {
+    btn.disabled = false; btn.textContent = orig;
+  }
+}
+
 function fmtNum(x) {
   if (x === null || x === undefined) return "–";
   if (typeof x !== "number") return esc(x);
   return Math.abs(x) < 1e-4 && x !== 0 ? x.toExponential(2) : x.toFixed(4).replace(/\.?0+$/, "");
 }
 
-async function saveSchedule(name) {
+function saveSchedule(name, btn) {
   const below = parseInt($("schedBelow").value, 10) || 0;
   const at = parseInt($("schedAt").value, 10) || 0;
-  try {
-    const d = await api("PUT", "/api/dynamic/" + enc(name) + "/schedule", {
-      below_max_retrain_frequency: below,
-      at_max_retrain_frequency: at,
-    });
-    toast((d && d.message) || "Schedule saved", "ok", "schedule");
-    await load();
-  } catch (e) {
-    toast(e.message, "err", "Schedule failed");
-  }
+  return putMeta(name, { schedule: { below_max: below, at_max: at } }, btn, "schedule");
 }
 
 $("auto").onchange = (e) => {

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -4,7 +4,7 @@
 # ============================================================
 #  tests/anomaly_test.sh — the package's full test suite:
 #    1. unit suites  : prep (M1), model (M2), store (M3),
-#                      dynamic (M4), versions (M5), service (M6)
+#                      dynamic (M4), versions (M5), metaedit, service (M6)
 #    2. CLI          : detect/score/train/ls/info/batch/reset/rm
 #    3. live HTTP    : `anomaly serve` + curl against the routes
 #
@@ -29,7 +29,7 @@ ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
 
 echo "[1/3] unit suites"
-for t in prep model store dynamic versions timevector autoencoder service gpu; do
+for t in prep model store dynamic versions timevector autoencoder metaedit service gpu; do
     if ! $NURL "tests/${t}_test.nu" "$WORK/${t}_test" >/dev/null 2>"$WORK/build.err"; then
         echo "FAIL: could not build ${t}_test:"; tail -5 "$WORK/build.err"; exit 1
     fi
@@ -69,7 +69,9 @@ echo "$S" | grep -q '"anomaly":true' && ok "CLI score (detect-only)" || bad "CLI
 "$A" train s1 | grep -q 'trained on' && ok "CLI train" || bad "CLI train"
 B=$(printf 'a,b\n1,2\n1.1,2.1\n0.9,1.9\n50,50\n1,2\n1,2.2\n' | "$A" batch -H --margin 0.1 2>/dev/null)
 [ "$(echo "$B" | wc -l)" = 6 ] && ok "CLI batch scores every row" || bad "CLI batch rows"
-WORST=$(echo "$B" | sort -k2 -g | head -1 | cut -f1)
+# LC_ALL=C: `sort -g` reads "0.15" as 0 in a comma-decimal locale (fi_FI),
+# which silently ranks every row equal.
+WORST=$(echo "$B" | LC_ALL=C sort -k2 -g | head -1 | cut -f1)
 [ "$WORST" = "3" ] && ok "CLI batch ranks the outlier row worst" || bad "CLI batch outlier row ($WORST)"
 "$A" reset s1 >/dev/null && "$A" rm s1 >/dev/null && [ -z "$("$A" ls)" ] && ok "CLI reset + rm" || bad "CLI reset/rm"
 
@@ -102,6 +104,29 @@ CODE=$(curl -s -o "$WORK/rae" -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/
 [ "$CODE" = "200" ] && grep -q '"reconstruction_threshold"' "$WORK/rae" && ok "HTTP autoencoder train" || bad "HTTP AE train ($CODE: $(cat "$WORK/rae" | head -c 120))"
 curl -s -X POST "http://127.0.0.1:$PORT/detect_only/live" -d '{"temp": 24.5}' | grep -q '"autoencoder"' \
     && ok "HTTP detect carries the autoencoder version" || bad "HTTP AE version in detect"
+curl -s -X POST "http://127.0.0.1:$PORT/train/autoencoder/live" -d '{"hidden":[16,8,16]}' >/dev/null
+curl -s "http://127.0.0.1:$PORT/models/dynamic/live/metadata" | grep -q '"layer_sizes":\[1,16,8,16,1\]' \
+    && ok "HTTP AE train honours the requested hidden layers" || bad "HTTP AE hidden layers"
+# Editable metadata: the version editor and the advanced JSON box both
+# drive PUT /models/dynamic/<model>/metadata.
+curl -s "http://127.0.0.1:$PORT/models/dynamic/live/metadata" | grep -q '"autoencoder"' \
+    && ok "HTTP metadata carries the autoencoder state" || bad "HTTP metadata autoencoder block"
+CODE=$(curl -s -o "$WORK/rput" -w '%{http_code}' -X PUT \
+    "http://127.0.0.1:$PORT/models/dynamic/live/metadata" \
+    -d '{"versions":{"weekly":{"enabled":false},"daily":{"decision_margin":0.44}},"schedule":{"below_max":25,"at_max":500}}')
+{ [ "$CODE" = "200" ] && grep -q '"decision_margin":0.44' "$WORK/rput"; } \
+    && ok "HTTP metadata PUT applies a partial patch" || bad "HTTP metadata PUT ($CODE)"
+curl -s -X POST "http://127.0.0.1:$PORT/detect_only/live" -d '{"temp": 24.5}' | grep -q '"weekly"' \
+    && bad "HTTP disabled version still scores" || ok "HTTP a disabled version stops scoring"
+[ -f "$WORK/svcmodels/live/version_weekly.forest" ] \
+    && bad "HTTP disabled version kept its forest blob" || ok "HTTP disabling drops the forest blob"
+CODE=$(curl -s -o "$WORK/rput2" -w '%{http_code}' -X PUT \
+    "http://127.0.0.1:$PORT/models/dynamic/live/metadata" -d '{"versions":[]}')
+[ "$CODE" = "400" ] && ok "HTTP metadata PUT rejects a bad shape" || bad "HTTP metadata PUT shape ($CODE)"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
+    "http://127.0.0.1:$PORT/models/dynamic/nosuch/metadata" -d '{"schedule":{"below_max":5,"at_max":5}}')
+[ "$CODE" = "404" ] && ok "HTTP metadata PUT 404s an unknown model" || bad "HTTP metadata PUT 404 ($CODE)"
+
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "http://127.0.0.1:$PORT/delete_model/live")
 [ "$CODE" = "200" ] && ok "HTTP delete" || bad "HTTP delete ($CODE)"
 

--- a/packages/anomaly/tests/metaedit_test.nu
+++ b/packages/anomaly/tests/metaedit_test.nu
@@ -1,0 +1,343 @@
+// metaedit_test.nu — editing a model's metadata from outside (the API the
+// dashboard's version editor and its advanced JSON box drive).
+//   patch     — a partial version object touches only the fields it names;
+//               an unknown key ADDS a version; `replace` drops the rest.
+//   clamp     — hand-written nonsense is clamped into a trainable range,
+//               and the forest-less `autoencoder` config round-trips as-is.
+//   toggle    — disabling a forest version drops its forest and its verdict;
+//               re-enabling costs a retrain. The autoencoder is only muted.
+//   errors    — the shapes model_apply_meta_patch refuses.
+// Store root: $ANOMALY_TEST_DIR (default ./anomaly_metaedit_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/score.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: i T0 1700000000
+: ~ i g_lcg 1
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ near f a f b → b {
+    ^ < ( float_abs - a b ) 0.000000001
+}
+
+@ lcg_u01 → f {
+    = g_lcg % + * g_lcg 1103515245 12345 2147483648
+    ^ / # f g_lcg 2147483648.0
+}
+
+@ ingest_temp * Model mo f temp i at → v {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    : !Verdict String r ( model_ingest_at mo j at )
+    ( json_free j )
+    ?? r {
+        T vd → { ( verdict_free vd ) }
+        F e → { ( string_free e ) }
+    }
+}
+
+// A model with 60 points of a tight temp regime, trained.
+@ seed * Model mo → v {
+    ( model_set_limits mo 20 150000 )
+    ( model_set_schedule mo 10 1000 )
+    : ~ i k 1
+    ~ <= k 60 {
+        ( ingest_temp mo + 20.0 * 0.4 ( lcg_u01 ) + T0 * k 60 )
+        = k + k 1
+    }
+    : i _n ( model_force_train_at mo + T0 * 61 60 )
+}
+
+// Does the verdict of a probe carry a slice named `vname`?
+@ has_version * Model mo s vname → b {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float 20.2 ) )
+    : !Verdict String r ( model_detect_only mo j )
+    ( json_free j )
+    ?? r {
+        T vd → {
+            : ~ b found F
+            : i nv ( vec_len [VerVerdict] . vd versions )
+            : ~ i k 0
+            ~ < k nv {
+                ?? ( vec_get [VerVerdict] . vd versions k ) {
+                    T vv → {
+                        ? == ( nurl_str_eq ( string_data . vv vvname ) vname ) 1 { = found T } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( verdict_free vd )
+            ^ found
+        }
+        F e → { ( string_free e ) ^ F }
+    }
+}
+
+// Apply a JSON patch written as text; returns the error text (owned).
+@ patch_text * Model mo s src → String {
+    : !Json JsonError r ( json_parse src )
+    ?? r {
+        T j → {
+            : String err ( model_apply_meta_patch mo j )
+            ( json_free j )
+            ^ err
+        }
+        F _ → { ^ ( string_from `unparsable test patch` ) }
+    }
+}
+
+// ── Scenario 1: partial patches, adds, replace ────────────────────────
+
+@ test_patch Store st → v {
+    = g_lcg 1
+    : *Model mo ( model_open_at st `patch` T0 )
+    ( seed mo )
+    : *Meta mm ( model_metadata mo )
+
+    : i before ( vec_len [VerCfg] . mm versions )
+    : String e1 ( patch_text mo `{"versions":{"daily":{"decision_margin":0.33}}}` )
+    ( check == ( string_len e1 ) 0 `patch: a one-field version object is accepted` )
+    ( string_free e1 )
+    ( check ( near ( meta_version_margin mm `daily` -1.0 ) 0.33 ) `patch: the named field changed` )
+    ( check == ( vec_len [VerCfg] . mm versions ) before `patch: no version was added or lost` )
+    ( check == ( meta_version_margin mm `weekly` -1.0 ) 0.06 `patch: other versions are untouched` )
+
+    : i at_daily ( meta_find_version mm `daily` )
+    ?? ( vec_get [VerCfg] . mm versions at_daily ) {
+        T vc → {
+            ( check == . vc window_min 1440 `patch: omitted fields keep their value` )
+            ( check == . vc n_estimators 300 `patch: omitted forest size keeps its value` )
+            ( check . vc enabled `patch: omitted enabled keeps its value` )
+        }
+        F _ → { ( check F `patch: daily still present` ) }
+    }
+
+    // An unknown key adds a version, defaults filling the gaps.
+    : String e2 ( patch_text mo `{"versions":{"hourly":{"window_minutes":60,"n_estimators":150}}}` )
+    ( check == ( string_len e2 ) 0 `add: an unknown version name is accepted` )
+    ( string_free e2 )
+    : i at_h ( meta_find_version mm `hourly` )
+    ( check >= at_h 0 `add: the new version is in the metadata` )
+    ?? ( vec_get [VerCfg] . mm versions at_h ) {
+        T vc → {
+            ( check == . vc window_min 60 `add: the given fields are honoured` )
+            ( check == . vc n_estimators 150 `add: forest size honoured` )
+            ( check == . vc max_samples 256 `add: absent fields take the default` )
+            ( check . vc enabled `add: a new version is enabled` )
+        }
+        F _ → { ( check F `add: hourly readable` ) }
+    }
+
+    // It really trains and scores.
+    : i _n ( model_force_train_at mo + T0 * 62 60 )
+    ( check ( has_version mo `hourly` ) `add: the new version trains and scores` )
+
+    // replace_versions: the list becomes exactly the keys given.
+    : String e3 ( patch_text mo
+    `{"versions":{"short_term":{},"hourly":{}},"replace_versions":true}` )
+    ( check == ( string_len e3 ) 0 `replace: accepted` )
+    ( string_free e3 )
+    ( check == ( vec_len [VerCfg] . mm versions ) 2 `replace: only the named versions survive` )
+    ( check < ( meta_find_version mm `daily` ) 0 `replace: an omitted version is gone` )
+    ( check >= ( meta_find_version mm `hourly` ) 0 `replace: a named version stays` )
+
+    // The schedule half of the patch.
+    : String e4 ( patch_text mo `{"schedule":{"below_max":25,"at_max":500}}` )
+    ( check == ( string_len e4 ) 0 `schedule: accepted` )
+    ( string_free e4 )
+    ( check == . mm sched_below 25 `schedule: below_max applied` )
+    ( check == . mm sched_at_max 500 `schedule: at_max applied` )
+
+    ( model_free mo )
+
+    // Everything survived the round trip through disk.
+    : *Model re ( model_open_at st `patch` T0 )
+    : *Meta rm ( model_metadata re )
+    ( check == ( vec_len [VerCfg] . rm versions ) 2 `persist: the version list reloads` )
+    ( check == . rm sched_below 25 `persist: the schedule reloads` )
+    ( model_free re )
+}
+
+// ── Scenario 2: clamping ──────────────────────────────────────────────
+
+@ test_clamp Store st → v {
+    = g_lcg 7
+    : *Model mo ( model_open_at st `clamp` T0 )
+    ( seed mo )
+    : *Meta mm ( model_metadata mo )
+
+    : String e ( patch_text mo
+    `{"versions":{"daily":{"n_estimators":-5,"max_samples":0,"window_minutes":-60,"window_size":8,"step_size":0,"decision_margin":-1.0,"contamination":0.9}}}` )
+    ( check == ( string_len e ) 0 `clamp: a nonsense config is accepted, not rejected` )
+    ( string_free e )
+    : i at ( meta_find_version mm `daily` )
+    ?? ( vec_get [VerCfg] . mm versions at ) {
+        T vc → {
+            ( check == . vc n_estimators 1 `clamp: a forest has at least one tree` )
+            ( check == . vc max_samples 1 `clamp: max_samples floors at 1` )
+            ( check == . vc window_min 0 `clamp: a negative window becomes "all"` )
+            ( check == . vc step_size 1 `clamp: a sliding window steps at least 1` )
+            ( check ( near . vc decision_margin 0.0 ) `clamp: a negative margin becomes 0` )
+            ( check ( near . vc contamination 0.5 ) `clamp: contamination caps at 0.5` )
+        }
+        F _ → { ( check F `clamp: daily readable` ) }
+    }
+
+    // 0 contamination means "auto" (-1), the same as the string spelling.
+    : String e2 ( patch_text mo `{"versions":{"weekly":{"contamination":0}}}` )
+    ( string_free e2 )
+    : i atw ( meta_find_version mm `weekly` )
+    ?? ( vec_get [VerCfg] . mm versions atw ) {
+        T vc → { ( check < . vc contamination 0.0 `clamp: contamination 0 means auto` ) }
+        F _ → { ( check F `clamp: weekly readable` ) }
+    }
+
+    // The autoencoder has no forest: its zeroed tree counts round-trip.
+    : ( Vec i ) hidden ( vec_new [i] )
+    : String aerr ( model_train_autoencoder mo hidden -1.0 )
+    ( vec_free [i] hidden )
+    ( check == ( string_len aerr ) 0 `clamp: the autoencoder trains` )
+    ( string_free aerr )
+    : String e3 ( patch_text mo `{"versions":{"autoencoder":{"decision_margin":0.07}}}` )
+    ( string_free e3 )
+    : i ata ( meta_find_version mm `autoencoder` )
+    ?? ( vec_get [VerCfg] . mm versions ata ) {
+        T vc → {
+            ( check == . vc n_estimators 0 `clamp: the autoencoder keeps 0 trees` )
+            ( check == . vc max_samples 0 `clamp: the autoencoder keeps 0 samples` )
+            ( check ( near . vc decision_margin 0.07 ) `clamp: its margin is still editable` )
+        }
+        F _ → { ( check F `clamp: autoencoder readable` ) }
+    }
+    ( model_free mo )
+}
+
+// ── Scenario 3: enable / disable ──────────────────────────────────────
+
+@ test_toggle Store st → v {
+    = g_lcg 3
+    : *Model mo ( model_open_at st `toggle` T0 )
+    ( seed mo )
+    ( check ( has_version mo `weekly` ) `toggle: weekly scores while enabled` )
+
+    ( check ( model_set_version_enabled mo `weekly` F ) `toggle: disabling a known version` )
+    ( check == ( model_set_version_enabled mo `nosuch` F ) F `toggle: an unknown version is refused` )
+    ( check == ( has_version mo `weekly` ) F `toggle: a disabled version stops scoring at once` )
+    : ~ b blob_gone T
+    ?? ( store_load_forest . mo store `toggle` `weekly` ) {
+        T vm → { = blob_gone F ( anom_vermodel_free vm ) }
+        F _ → {}
+    }
+    ( check blob_gone `toggle: the disabled version's forest blob is gone` )
+    ( model_free mo )
+
+    // Re-enabling does not resurrect a stale forest: it waits for a retrain.
+    : *Model re ( model_open_at st `toggle` T0 )
+    ( check ( model_set_version_enabled re `weekly` T ) `toggle: re-enabling a known version` )
+    ( check == ( has_version re `weekly` ) F `toggle: re-enabled but not yet retrained = no verdict` )
+    : i _n ( model_force_train_at re + T0 * 62 60 )
+    ( check ( has_version re `weekly` ) `toggle: the retrain brings the verdict back` )
+
+    // The autoencoder is muted, not thrown away.
+    : ( Vec i ) hidden ( vec_new [i] )
+    : String aerr ( model_train_autoencoder re hidden -1.0 )
+    ( vec_free [i] hidden )
+    ( check == ( string_len aerr ) 0 `toggle: the autoencoder trains` )
+    ( string_free aerr )
+    ( check ( has_version re `autoencoder` ) `toggle: the autoencoder scores once trained` )
+    ( check ( model_set_version_enabled re `autoencoder` F ) `toggle: the autoencoder version toggles` )
+    ( check == ( has_version re `autoencoder` ) F `toggle: a disabled autoencoder is silent` )
+    ( check ( model_set_version_enabled re `autoencoder` T ) `toggle: re-enabling the autoencoder` )
+    ( check ( has_version re `autoencoder` ) `toggle: its net was kept — no retrain needed` )
+    ( model_free re )
+}
+
+// ── Scenario 4: refused shapes ────────────────────────────────────────
+
+@ test_errors Store st → v {
+    = g_lcg 5
+    : *Model mo ( model_open_at st `errs` T0 )
+    ( seed mo )
+
+    : String e1 ( patch_text mo `{}` )
+    ( check > ( string_len e1 ) 0 `error: an empty patch is refused` )
+    ( string_free e1 )
+    : String e2 ( patch_text mo `{"versions":[1,2]}` )
+    ( check > ( string_len e2 ) 0 `error: versions must be an object` )
+    ( string_free e2 )
+    : String e3 ( patch_text mo `{"schedule":7}` )
+    ( check > ( string_len e3 ) 0 `error: schedule must be an object` )
+    ( string_free e3 )
+    : String e4 ( patch_text mo `{"schedule":{"below_max":0,"at_max":0}}` )
+    ( check > ( string_len e4 ) 0 `error: a non-positive schedule is refused` )
+    ( string_free e4 )
+    : String e5 ( patch_text mo `[1,2,3]` )
+    ( check > ( string_len e5 ) 0 `error: the patch itself must be an object` )
+    ( string_free e5 )
+
+    // A refused patch changes nothing.
+    : *Meta mm ( model_metadata mo )
+    ( check == . mm sched_below 10 `error: a refused patch leaves the schedule alone` )
+    ( model_free mo )
+}
+
+@ main → i {
+    : ~ String root ( string_from `./anomaly_metaedit_test` )
+    ?? ( env_get `ANOMALY_TEST_DIR` ) {
+        T d → { ( string_free root ) = root d }
+        F _ → {}
+    }
+    : !v IoErr junk ( dir_remove_all ( string_data root ) )
+    ?? junk { T _ → {} F _ → {} }
+    : Store st ( store_open ( string_data root ) )
+
+    ( test_patch st )
+    ( test_clamp st )
+    ( test_toggle st )
+    ( test_errors st )
+
+    ( store_free st )
+    : !v IoErr fin ( dir_remove_all ( string_data root ) )
+    ?? fin { T _ → {} F _ → {} }
+    ( string_free root )
+
+    : String summary ( string_from `metaedit_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/service_test.nu
+++ b/packages/anomaly/tests/service_test.nu
@@ -216,6 +216,76 @@ $ `src/service.nu`
     ( check == . sch2 status 400 `svc: empty schedule -> 400` )
     ( json_free . sch2 body )
 
+    // Editable metadata: PUT /models/dynamic/<m>/metadata.
+    : SvcOut mu ( fire r `PUT` `/models/dynamic/svc/metadata` ``
+    `{"versions":{"weekly":{"enabled":false},"daily":{"decision_margin":0.44}},"schedule":{"below_max":30,"at_max":600}}` )
+    ( check == . mu status 200 `svc: metadata PUT -> 200` )
+    : ~ b patch_applied F
+    : ~ b weekly_off F
+    : ~ i below2 -1
+    ?? ( json_obj_get . mu body `metadata` ) {
+        T md → {
+            ?? ( json_obj_get md `versions` ) {
+                T vs → {
+                    ?? ( json_obj_get vs `daily` ) {
+                        T d → {
+                            ?? ( json_obj_get d `decision_margin` ) {
+                                T dm → {
+                                    ?? ( json_num_as_f dm ) {
+                                        T x → { = patch_applied < ( float_abs - x 0.44 ) 0.000001 }
+                                        F _ → {}
+                                    }
+                                }
+                                F _ → {}
+                            }
+                        }
+                        F _ → {}
+                    }
+                    ?? ( json_obj_get vs `weekly` ) {
+                        T w → { = weekly_off == ( jbool_of w `enabled` ) F }
+                        F _ → {}
+                    }
+                }
+                F _ → {}
+            }
+            ?? ( json_obj_get md `schedule` ) {
+                T sc → { = below2 ( jint_of sc `below_max` ) }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ( check patch_applied `svc: metadata PUT sets a version margin` )
+    ( check weekly_off `svc: metadata PUT disables a version` )
+    ( check == below2 30 `svc: metadata PUT sets the schedule` )
+    ( json_free . mu body )
+
+    : SvcOut mu2 ( fire r `PUT` `/models/dynamic/svc/metadata` `` `{"versions":[]}` )
+    ( check == . mu2 status 400 `svc: metadata PUT rejects a non-object versions` )
+    ( json_free . mu2 body )
+    : SvcOut mu3 ( fire r `PUT` `/models/dynamic/svc/metadata` `` `{}` )
+    ( check == . mu3 status 400 `svc: an empty metadata patch -> 400` )
+    ( json_free . mu3 body )
+    : SvcOut mu4 ( fire r `PUT` `/models/dynamic/nope/metadata` `` `{"schedule":{"below_max":5,"at_max":5}}` )
+    ( check == . mu4 status 404 `svc: metadata PUT on an unknown model -> 404` )
+    ( json_free . mu4 body )
+
+    // The metadata GET carries the autoencoder's own state.
+    : SvcOut aem ( fire r `GET` `/models/dynamic/svc/metadata` `` `` )
+    : ~ b ae_block F
+    ?? ( json_obj_get . aem body `autoencoder` ) {
+        T ab → { = ae_block == ( jbool_of ab `trained` ) F }
+        F _ → {}
+    }
+    ( check ae_block `svc: metadata carries an autoencoder block` )
+    ( json_free . aem body )
+
+    // Put weekly back so the routes below see the default version set.
+    : SvcOut mu5 ( fire r `PUT` `/models/dynamic/svc/metadata` ``
+    `{"versions":{"weekly":{"enabled":true},"daily":{"decision_margin":0.12}},"schedule":{"below_max":25,"at_max":1000}}` )
+    ( check == . mu5 status 200 `svc: metadata PUT restores the defaults` )
+    ( json_free . mu5 body )
+
     // Fine-tune.
     : SvcOut ft ( fire r `POST` `/api/dynamic/svc/finetune` `` `{}` )
     ( check == . ft status 200 `svc: finetune -> 200` )


### PR DESCRIPTION
Three things the dashboard could not do.

## 1. Edit the metadata

`PUT /models/dynamic/<model>/metadata` takes the **editable half** of the metadata — the retrain schedule and the per-version configs — as a patch in which every field is optional:

```jsonc
{ "schedule": { "below_max": 50, "at_max": 1000 },
  "versions": { "weekly": {"enabled": false},          // stop scoring, drop the forest
                "daily":  {"decision_margin": 0.2},    // effective at the next detect
                "hourly": {"window_minutes": 60} },    // an unknown name ADDS a version
  "replace_versions": false }                          // true ⇒ omitted versions are deleted
```

What the body omits keeps its value, so a checkbox can send one field. Values are clamped into a range the trainer can honour rather than rejected, so a hand-written edit cannot produce a version that fails to train. The response echoes the whole metadata.

The Model Manager drawer now edits what it used to only print: a checkbox and a margin field per version — the two settings that bite at the very next detect — and an *Advanced · edit metadata as JSON* box holding exactly the document the route takes, for the window geometry and forest sizes that take effect at the next retrain. The schedule form goes through the same route.

The **learned** half — column kinds, category vocabularies, the authoritative feature order, the scaler — is still never accepted from a client. It is refitted at every train and a hand-written copy would silently desync every forest, so the route does not offer the rope.

Disabling a forest version deletes its forest blob, deliberately: a kept blob would be resurrected trained against a feature order and scaler the model has since moved past, and a stale width reads as a timevector window at scoring time — a wrong verdict rather than an absent one. Re-enabling therefore costs a retrain.

## 2. Show the autoencoder

It has been trainable since 0.4.0 (`anomaly train-ae`, `POST /train/autoencoder/<model>`) and its verdict has ridden along in every detect, but `static/` did not contain the string "autoencoder" — a model's most interesting version was invisible unless you read the JSON by hand.

`GET .../metadata` now carries an `autoencoder` block (trained, enabled, threshold, points trained on, anomalies filtered, margin, feature names, layer sizes); its state lives in `autoencoder.json` rather than the metadata, which is why it had no place in `meta_to_json`. The drawer grew an Autoencoder section that shows it and trains or retrains it, and `POST /train/autoencoder/<model>` accepts an optional `{"hidden": [..], "contamination": x}` body instead of always using 64-32-64 and automatic contamination.

While wiring the checkbox: **disabling the `autoencoder` version did nothing.** The verdict was gated on the trained net alone and ignored the `enabled` flag its own `VerCfg` has carried since 0.4.0 — the one version you could not turn off was the one the UI never showed. Disabling it now mutes it and *keeps* the net, unlike a forest version: its net carries its own frozen feature order, so it stays valid across retrains and is far too expensive to throw away on a checkbox.

## 3. Pin the dependencies on the major

`iforest`, `gpu`, `cli`, `gpukit` and `mlp` join `http` at `^0`, so a 0.x minor release of any of them no longer leaves an install from the registry resolving an older copy than the one this tree is built and tested against — the gap #1027 closed for http alone.

## Internals

`__an_margin_of` moved to `src/prep.nu` as the shared `meta_version_margin` (its doc comment with it) and `__an_jarr_of_strs` took the single-underscore shared spelling; both were about to be called across files, which is the compiler's obsolete `__` path.

New library entry points: `model_apply_meta_patch`, `model_set_version_enabled`, `meta_apply_versions_json`, `meta_find_version`, `meta_version_enabled`, `meta_version_margin`.

## Tests

- new `metaedit` unit suite — 55 checks: partial patches, adds, replace, clamping, the enable/disable asymmetry, refused shapes
- the metadata route through `router_handle` in `service_test` (38 → 47)
- live-HTTP coverage in `anomaly_test.sh`

Full suite **38/38**, clean under ASan/UBSan. The dashboard round trip was driven end to end in headless Chrome: toggle, margin, raw-JSON edit, autoencoder train and mute.

Unrelated one-liner in the same file: the CLI batch check sorted with `sort -g`, which reads `0.15` as `0` in a comma-decimal locale (fi_FI) and silently ranked every row equal. It now sorts under `LC_ALL=C`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxLjWgGyferfDAkXCAhZyp