### PR TITLE
json: full JSONTestSuite conformance — the surrogate lookahead was not pure, and NUL truncated the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`stdlib/ext/json.nu` passes the full JSONTestSuite — 283/283 must-accept /
+  must-reject verdicts correct.** Six `n_` documents parsed clean before, from
+  two roots:
+
+  * **The surrogate-pair lookahead consumed as it peeked.** After `\uD800`,
+    a `\` was swallowed before knowing whether `u` followed — so in
+    `["\uD800\"]` the escape lost its backslash, the stray quote closed the
+    string, and a document whose string never terminates parsed successfully.
+    And when `\u` did follow with malformed hex (`\u`, `\u1`, `\u1x`,
+    `\uDd"`), a code path its own comment called "best-effort recovery"
+    dropped the error a plain `\uZZZZ` raises. The lookahead is now pure —
+    `\u` is consumed only after both bytes matched, and once consumed the
+    four digits must be hex, the rule every other escape lives by. A
+    complete-but-unpaired surrogate stays accepted as U+FFFD (RFC 8259
+    leaves it undefined), and a value that breaks a pair re-enters the
+    pairing loop, so `\uD800` followed by a real pair still decodes the
+    real code point.
+
+  * **`json_parse` takes `s`, so the document ended at the first NUL** —
+    `123\0` truncated to `123` and parsed clean. The parser was already
+    length-based internally; only the entry ran `strlen`. New entries carry
+    the length end to end: `json_parse_n src len` (the root entry — an
+    embedded NUL is an ordinary rejected byte) and `json_parse_bytes buf`
+    for `( Vec u )` payloads (network buffers, `read_file_bytes` results).
+    `json_parse` is now a documented C-string wrapper over `json_parse_n`.
+
+  `tools/json_conformance.sh` runs the full suite against the byte-exact
+  harness (clones JSONTestSuite shallow when absent); the six regressions
+  plus the pairing/NUL semantics are pinned by
+  `compiler/tests/json_surrogate_lookahead.nu`. Parse throughput is
+  unchanged (measured A/B on `bench/json_parse`), and the parser fuzzer's
+  3000-iteration ASan+UBSan pass stays clean.
+
+
 ### Changed
 
 - **The Linux I/O reactor became a netpoller — and the HTTP facade now

--- a/compiler/tests/json_surrogate_lookahead.nu
+++ b/compiler/tests/json_surrogate_lookahead.nu
@@ -1,0 +1,115 @@
+// json_surrogate_lookahead.nu — the surrogate-pair LOOKAHEAD must be
+// pure, and the parser must see the whole byte range.
+//
+// Six JSONTestSuite n_ cases parsed CLEAN before this test existed,
+// from two roots:
+//
+//   * The low-surrogate lookahead consumed as it peeked. After
+//     `\uD800`, a `\` was swallowed before knowing whether `u`
+//     followed — so in `["\uD800\"]` the escape lost its backslash,
+//     the stray quote closed the string, and a document whose string
+//     NEVER terminates parsed successfully. And when `\u` did follow
+//     with malformed hex (`\u`, `\u1`, `\u1x`, `\uDd"`), the
+//     "best-effort" fallthrough dropped the error a plain `\uZZZZ`
+//     would have raised. Now the lookahead consumes `\u` only after
+//     both bytes matched, and once consumed the four digits MUST be
+//     hex — the same rule every other escape lives by.
+//
+//   * `json_parse` takes `s`, so the document ends at the first NUL:
+//     `123\0` TRUNCATED to `123` and parsed clean. The length-carrying
+//     entries (`json_parse_n`, `json_parse_bytes`) never read past
+//     their length, so the NUL is an ordinary rejected byte.
+//
+// A complete-but-unpaired surrogate stays ACCEPTED as U+FFFD (RFC 8259
+// leaves it undefined; the replacement policy is pinned by
+// json_rfc8259_strings), and the value that broke a pair re-enters the
+// pairing loop, so a high surrogate followed by a real pair still
+// decodes the real code point.
+//
+// Expected output:
+//   surrogate then escaped quote rejected
+//   surrogate then bare escape-u rejected
+//   surrogate then 1-digit escape rejected
+//   surrogate then bad hex rejected
+//   incomplete low escape rejected
+//   escape after replaced high accepted: EF BF BD 0A
+//   high then real pair: EF BF BD F0 9D 84 9E
+//   nul after number rejected: bad format
+//   nul-free prefix still parses: 123
+
+$ `stdlib/ext/json.nu`
+$ `stdlib/core/string.nu`
+
+@ show s label s src → v {
+    ?? ( json_parse src ) {
+        T j → {
+            : String s2 ( json_stringify j )
+            ( nurl_print label ) ( nurl_print `: ` )
+            ( nurl_println ( string_data s2 ) )
+            ( string_free s2 ) ( json_free j )
+        }
+        F e → {
+            ( nurl_print label ) ( nurl_println ` rejected` )
+        }
+    }
+}
+
+// Parse and print the FIRST string element's bytes as hex.
+@ show_hex s label s src → v {
+    ?? ( json_parse src ) {
+        T j → {
+            ( nurl_print label ) ( nurl_print `: ` )
+            : String hex ( string_new )
+            ?? ( json_arr_get j 0 ) {
+                T el → {
+                    : s raw ( json_str_data el )
+                    : s digits `0123456789ABCDEF`
+                    : *u dp # *u digits
+                    : i n ( nurl_str_len raw )
+                    : ~ i k 0
+                    ~ < k n {
+                        ? > k 0 { ( string_push_char hex 32 ) } {}
+                        : i b & 255 # i . # *u raw k
+                        ( string_push_char hex # i . dp >> b 4 )
+                        ( string_push_char hex # i . dp & b 15 )
+                        = k + k 1
+                    }
+                }
+                F → { ( string_push_str hex `no element` ) }
+            }
+            ( nurl_println ( string_data hex ) )
+            ( string_free hex )
+            ( json_free j )
+        }
+        F e → {
+            ( nurl_print label ) ( nurl_println ` REJECTED` )
+        }
+    }
+}
+
+@ main → i {
+    ( show `surrogate then escaped quote` `["\uD800\\"]` )
+    ( show `surrogate then bare escape-u` `["\uD800\\u"]` )
+    ( show `surrogate then 1-digit escape` `["\uD800\\u1"]` )
+    ( show `surrogate then bad hex` `["\uD800\\u1x"]` )
+    ( show `incomplete low escape` `["\uD834\\uDd"]` )
+    ( show_hex `escape after replaced high accepted` `["\uD800\\n"]` )
+    ( show_hex `high then real pair` `["\uD800𝄞"]` )
+    : s withnul `123`
+    : !Json JsonError rn ( json_parse_n withnul 4 )
+    ?? rn {
+        T j → { ( json_free j ) ( nurl_println `nul after number ACCEPTED` ) }
+        F e → { ( nurl_println `nul after number rejected: bad format` ) }
+    }
+    : !Json JsonError rp ( json_parse_n withnul 3 )
+    ?? rp {
+        T j → {
+            : String s2 ( json_stringify j )
+            ( nurl_print `nul-free prefix still parses: ` )
+            ( nurl_println ( string_data s2 ) )
+            ( string_free s2 ) ( json_free j )
+        }
+        F e → { ( nurl_println `nul-free prefix REJECTED` ) }
+    }
+    ^ 0
+}

--- a/compiler/tests/outputs/json_surrogate_lookahead.txt
+++ b/compiler/tests/outputs/json_surrogate_lookahead.txt
@@ -1,0 +1,13 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+surrogate then escaped quote rejected
+surrogate then bare escape-u rejected
+surrogate then 1-digit escape rejected
+surrogate then bad hex rejected
+incomplete low escape rejected
+escape after replaced high accepted: EF BF BD 0A
+high then real pair: EF BF BD F0 9D 84 9E
+nul after number rejected: bad format
+nul-free prefix still parses: 123

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -65,7 +65,10 @@
 //   ( json_type_name j )              → s    "null"/"bool"/"num"/"str"/"arr"/"obj"
 //
 // Parser / serializer:
-//   ( json_parse raw )                → ! Json JsonError
+//   ( json_parse raw )                → ! Json JsonError   raw as s; ends at NUL
+//   ( json_parse_n raw len )          → ! Json JsonError   exact byte range (the root
+//                                       entry — an embedded NUL is rejected, not truncated)
+//   ( json_parse_bytes buf )          → ! Json JsonError   ( Vec u ), borrowed
 //   ( json_stringify j )              → String  compact (always valid JSON)
 //   ( json_pretty    j )              → String  2-space indented
 //   ( json_format_error e )           → String  "<kind> at line L col C" (caller owns)
@@ -301,10 +304,10 @@ $ `stdlib/core/vec.nu`
     i depth
 }
 
-@ __jp_new s txt → *JsonParser {
+@ __jp_new s txt i len → *JsonParser {
     : *JsonParser p # *JsonParser ( nurl_alloc Z JsonParser )
     = . p src txt
-    = . p len ( nurl_str_len txt )
+    = . p len len
     = . p pos 0
     = . p depth 0
     ^ p
@@ -668,43 +671,50 @@ $ `stdlib/core/vec.nu`
                                         ? == esc 98 { ( string_push_char out 8 ) } {
                                             ? == esc 102 { ( string_push_char out 12 ) } {
                                                 ? == esc 117 {
-                                                    // \uXXXX — read 4 hex digits, decode to a UTF-8 byte sequence.
-                                                    // If the value is a high surrogate (0xD800..0xDBFF) the spec
-                                                    // requires a following `\uYYYY` low surrogate (0xDC00..0xDFFF);
-                                                    // combine them into a single supplementary code point. Any
-                                                    // other value (including a lone low surrogate or unmatched
-                                                    // high surrogate) is emitted as-is via the 3-byte path.
+                                                    // \uXXXX — read 4 hex digits, decode to a UTF-8 byte
+                                                    // sequence. A high surrogate (0xD800..0xDBFF) pairs with a
+                                                    // following `\uYYYY` low surrogate (0xDC00..0xDFFF) into one
+                                                    // supplementary code point. The pairing LOOKAHEAD is pure:
+                                                    // it consumes `\u` only after BOTH bytes matched, so a
+                                                    // `\uD800\"` leaves the `\"` escape intact for the ordinary
+                                                    // loop (the old code swallowed the backslash — JSONTestSuite
+                                                    // n_string_1_surrogate_then_escape parsed CLEAN with a stolen
+                                                    // quote). Once `\u` is consumed the four digits MUST be hex:
+                                                    // a malformed escape is a syntax error everywhere else, and
+                                                    // the old "best-effort" fallthrough silently dropped it (five
+                                                    // more n_ cases accepted). A complete-but-unpaired surrogate
+                                                    // is NOT a syntax error (RFC 8259 leaves it undefined) — it
+                                                    // becomes U+FFFD via __jp_push_utf8, and the value that broke
+                                                    // the pair re-enters the loop so `\uD800\uD834\uDD1E` still
+                                                    // pairs the clef. The i_ conformance class pins the policy.
                                                     : i h ( __jp_read_hex4 p )
                                                     ? < h 0 {
                                                         ( string_free out )
                                                         ^ @ !String JsonError { F ( __jp_err_at p token_start @ ParseErr { BadFormat } ) }
                                                     } {}
-                                                    ? & >= h 55296 <= h 56319 {
-                                                        // Possible high surrogate — try to consume `\uYYYY`.
-                                                        ? & ! ( __jp_eof p ) == ( __jp_peek p ) 92 {
-                                                            = . p pos + . p pos 1
-                                                            ? & ! ( __jp_eof p ) == ( __jp_peek p ) 117 {
-                                                                = . p pos + . p pos 1
-                                                                : i l ( __jp_read_hex4 p )
-                                                                ? & >= l 56320 <= l 57343 {
-                                                                    : i cp + + 65536 << - h 55296 10 - l 56320
-                                                                    ( __jp_push_utf8 out cp )
-                                                                } {
-                                                                    // Not a valid low surrogate — emit the high alone,
-                                                                    // then re-process the second `\uXXXX` as a code point.
-                                                                    ( __jp_push_utf8 out h )
-                                                                    ? >= l 0 { ( __jp_push_utf8 out l ) } {}
-                                                                }
+                                                    : ~ i cur h
+                                                    : ~ b done F
+                                                    ~ ! done {
+                                                        ? & & >= cur 55296 <= cur 56319
+                                                        & == ( __jp_byte_at p . p pos ) 92 == ( __jp_byte_at p + . p pos 1 ) 117
+                                                        {
+                                                            = . p pos + . p pos 2
+                                                            : i l ( __jp_read_hex4 p )
+                                                            ? < l 0 {
+                                                                ( string_free out )
+                                                                ^ @ !String JsonError { F ( __jp_err_at p token_start @ ParseErr { BadFormat } ) }
+                                                            } {}
+                                                            ? & >= l 56320 <= l 57343 {
+                                                                ( __jp_push_utf8 out + + 65536 << - cur 55296 10 - l 56320 )
+                                                                = done T
                                                             } {
-                                                                // After `\` was no `u` — emit high alone, the `\?` got
-                                                                // swallowed; best-effort recovery.
-                                                                ( __jp_push_utf8 out h )
+                                                                ( __jp_push_utf8 out cur )
+                                                                = cur l
                                                             }
                                                         } {
-                                                            ( __jp_push_utf8 out h )
+                                                            ( __jp_push_utf8 out cur )
+                                                            = done T
                                                         }
-                                                    } {
-                                                        ( __jp_push_utf8 out h )
                                                     }
                                                 } {
                                                     ( string_free out )
@@ -923,8 +933,28 @@ $ `stdlib/core/vec.nu`
     ^ @ !Json JsonError { T @ Json { JObj kvs } }
 }
 
+// Byte-buffer entry: parse exactly the buffer's bytes (a network
+// payload, a read_file_bytes result). BORROWS the Vec — the caller
+// still owns and frees it.
+@ json_parse_bytes ( Vec u ) buf → !Json JsonError {
+    ^ ( json_parse_n # s ( vec_data [u] buf ) ( vec_len [u] buf ) )
+}
+
+// C-string entry: the document ends at the first NUL. A payload that
+// may legitimately carry stray NUL bytes (a network buffer, a file
+// read as bytes) must go through json_parse_n / json_parse_bytes —
+// through this entry a `123\0garbage` payload would TRUNCATE at the
+// NUL and parse clean (JSONTestSuite n_multidigit_number_then_00).
 @ json_parse s src → !Json JsonError {
-    ? == ( nurl_str_len src ) 0 {
+    ^ ( json_parse_n src ( nurl_str_len src ) )
+}
+
+// Length-carrying entry — the root parser. Never reads past `len`, so
+// an embedded NUL is an ordinary byte: inside a string it is a bare
+// control character (BadFormat), between tokens it is an unexpected
+// byte (BadFormat) — rejected, never silently truncated.
+@ json_parse_n s src i len → !Json JsonError {
+    ? <= len 0 {
         : JsonError e @ JsonError {
             @ ParseErr { Empty }
             0
@@ -933,7 +963,7 @@ $ `stdlib/core/vec.nu`
         }
         ^ @ !Json JsonError { F e }
     } {}
-    : *JsonParser p ( __jp_new src )
+    : *JsonParser p ( __jp_new src len )
     : !Json JsonError r ( __jp_parse_value p )
     ?? r {
         T j → {

--- a/tools/json_conformance.sh
+++ b/tools/json_conformance.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/json_conformance.sh — run stdlib/ext/json.nu against the full
+#  JSONTestSuite corpus (github.com/nst/JSONTestSuite, MIT).
+#
+#  Verdict rules (the suite's own contract):
+#    y_*.json  MUST parse            — a rejection is a finding
+#    n_*.json  MUST be rejected      — an acceptance is a finding
+#    i_*.json  implementation-defined — reported, never a failure
+#
+#  The harness reads each file as BYTES (read_file_bytes →
+#  json_parse_bytes), so embedded NULs and invalid UTF-8 reach the
+#  parser instead of truncating at the C-string boundary — exactly the
+#  gap that let n_multidigit_number_then_00 parse clean before
+#  json_parse_n existed.
+#
+#  Usage:  tools/json_conformance.sh [suite-dir]
+#    suite-dir   a JSONTestSuite checkout (default: clone a shallow
+#                copy under build/JSONTestSuite when absent)
+#
+#  Exit codes: 0 all y_/n_ verdicts correct · 1 findings · 2 env problem
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+SUITE="${1:-$ROOT/build/JSONTestSuite}"
+NURLC="$ROOT/build/nurlc"
+RUNTIME="$ROOT/stdlib/runtime.o"
+BUILD="$ROOT/build/jsonconform"
+
+[[ -x "$NURLC" && -f "$RUNTIME" ]] || { echo "ERROR: run ./build.sh first" >&2; exit 2; }
+
+if [[ ! -d "$SUITE/test_parsing" ]]; then
+    echo "# cloning JSONTestSuite (shallow) into $SUITE" >&2
+    git clone --depth 1 https://github.com/nst/JSONTestSuite "$SUITE" >/dev/null 2>&1 \
+        || { echo "ERROR: no suite at $SUITE and clone failed" >&2; exit 2; }
+fi
+
+mkdir -p "$BUILD"
+cat > "$BUILD/harness.nu" <<'NU'
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/fs.nu`
+
+@ main → i {
+    : s path ( nurl_argv_get 1 )
+    : !( Vec u ) IoErr fr ( read_file_bytes path )
+    ?? fr {
+        T buf → {
+            : !Json JsonError r ( json_parse_bytes buf )
+            ( vec_free [u] buf )
+            ?? r {
+                T j → { ( json_free j ) ^ 0 }
+                F e → { ^ 1 }
+            }
+        }
+        F e → { ^ 2 }
+    }
+}
+NU
+"$NURLC" "$BUILD/harness.nu" > "$BUILD/harness.ll" || exit 2
+LIBS="-lm -lpthread -ldl"
+command -v pkg-config >/dev/null && LIBS="$LIBS $(pkg-config --libs openssl zlib 2>/dev/null)"
+clang -O2 -flto "$BUILD/harness.ll" "$RUNTIME" $LIBS -o "$BUILD/harness" 2>/dev/null || exit 2
+
+pass=0; fail=0; impl_ok=0; impl_rej=0
+for f in "$SUITE"/test_parsing/*.json; do
+    b="$(basename "$f")"
+    timeout 10 "$BUILD/harness" "$f" >/dev/null 2>&1; rc=$?
+    case "$b" in
+        y_*) if [[ $rc -eq 0 ]]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FALSE-REJECT(rc=$rc) $b"; fi ;;
+        n_*) if [[ $rc -eq 1 ]]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FALSE-ACCEPT(rc=$rc) $b"; fi ;;
+        i_*) if [[ $rc -eq 0 ]]; then impl_ok=$((impl_ok+1)); else impl_rej=$((impl_rej+1)); fi ;;
+    esac
+done
+echo "json-conformance: $pass/$((pass+fail)) y_/n_ verdicts correct · i_: $impl_ok accepted, $impl_rej rejected"
+[[ $fail -eq 0 ]] || exit 1


### PR DESCRIPTION
## The audit

`stdlib/ext/json.nu` is load-bearing (LLM tool-use payloads), so it was run against the full [JSONTestSuite](https://github.com/nst/JSONTestSuite) corpus — 318 files, byte-exact. **Six `n_` (must-reject) documents parsed clean.** Two roots:

### 1. The surrogate-pair lookahead consumed as it peeked

After `\uD800`, a `\` was swallowed before knowing whether `u` followed — so in `["\uD800\"]` the escape lost its backslash, the stray quote closed the string, and a document whose string **never terminates** parsed successfully. When `\u` did follow with malformed hex (`\u`, `\u1`, `\u1x`, `\uDd"`), a path whose own comment said *"best-effort recovery"* dropped the error a plain `\uZZZZ` raises.

The lookahead is now pure: `\u` is consumed only after both bytes matched, and once consumed the four digits must be hex — the rule every other escape lives by. A complete-but-unpaired surrogate stays accepted as U+FFFD (RFC 8259 leaves it undefined; `json_rfc8259_strings` pins the policy), and a value that breaks a pair re-enters the pairing loop, so `\uD800` followed by a real pair still decodes the real code point.

### 2. `json_parse` takes `s`, so the document ended at the first NUL

`123\0` truncated to `123` and parsed clean. The parser was already length-based internally — only the entry ran `strlen`. New entries carry the length end to end:

- `json_parse_n src len` — the root entry; an embedded NUL is an ordinary rejected byte
- `json_parse_bytes buf` — `( Vec u )` payloads (network buffers, `read_file_bytes` results)
- `json_parse` — documented C-string wrapper over `json_parse_n`

## Verification

- **283/283 y_/n_ verdicts correct** (was 277); i_ class: 31 accepted-with-replacement, 4 rejected (UTF-16 inputs — this is a UTF-8 parser)
- `tools/json_conformance.sh` makes the run repeatable (clones the suite shallow when absent, reads files as bytes)
- `compiler/tests/json_surrogate_lookahead.nu` pins the six regressions + pairing/NUL semantics
- Parse throughput unchanged: A/B on `bench/json_parse`, 10.85 vs 10.87 ms median
- Parser-mutational fuzz (3000 iters, ASan+UBSan): clean
- Full golden suite: 902/902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxLjWgGyferfDAkXCAhZyp