### PR TITLE
crypto: the handshake path stops paying for secrecy it does not need — TLS handshakes +9%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The TLS handshake's crypto dropped a set of costs that bought
+  nothing — public-exponent inversions no longer pretend to be secret,
+  squarings no longer run as general multiplies, and per-call table
+  builds became process globals.** Measured on the handshake profile
+  (single-core µs/op before → after): X25519 keygen 43 → 30, ECDSA
+  P-256 sign 99 → 85, P-256 fixed-base comb 60 → 52, X25519 shared
+  secret 65 → 61; end to end the server answers ~9% more TLS
+  handshakes per second (loopback, `oha -c 20 --disable-keepalive`).
+  Five root fixes, each verified against the old path and the corpus
+  KATs (RFC 7748 vectors, ECDSA/TLS tests, 500-element differential
+  sqr/mul/inv sweeps):
+
+  * `std/p256_field` gains a dedicated Montgomery **squaring**
+    (`_p256_sqr_d`, 10 products against the multiply's 16); the point
+    doubling, mixed addition and affine conversions that spelled
+    `mul x x` now use it — 37% of a fixed-base comb's field ops are
+    squarings, and a Fermat inversion is ~95%.
+  * `_p256_inv_d` is a fixed **p−2 addition chain** (255 S + 13 M).
+    The old ladder ran 256 S + 256 M with a constant-time select per
+    bit — but the exponent is a public curve constant, so half of
+    those multiplies were computed to be discarded. The schedule
+    depends only on p−2; the data path stays branch-free either way.
+  * `std/p256_scalar`'s `p256n_inv_be` (the ECDSA k⁻¹) is a fixed
+    4-bit window over the public n−2 — one multiply per non-zero
+    nibble instead of per set bit, and no per-bit limb copies.
+  * `std/x25519`'s `_inv25519` is the standard ref10 chain
+    (254 S + 11 M; the tweetnacl-style ladder it replaces multiplied
+    on 252 of 254 steps). Two inversions per handshake.
+  * The X25519 keygen comb walks a **niels-form table** — cached, one
+    build per process — with a dedicated extended-coordinate doubling
+    (4M+4S) and ref10 `ge_madd` mixed addition (7M) in place of two
+    generic 9-M complete additions per iteration, and a 15-limb
+    constant-time scan in place of 20 (Z = 1 is implicit). The old
+    path re-materialised the 320-limb table on every public key.
+  * `std/hash_sha256` shares one process-global round-constant table;
+    it was rebuilt and heap-allocated on every `sha256_init`, one of
+    which runs per HMAC leg of the TLS key schedule and per RFC 6979
+    nonce step.
+
+  Constant-time discipline is unchanged where it matters: every value
+  derived from secret data still moves through branch-free, mask-merged
+  arithmetic; the only schedules that became data-dependent depend on
+  public curve constants alone.
+
 - **The netpoller's overload surplus now spills into a fair global FIFO,
   and workers drain the epoll instance on a fixed cadence — the p99 an
   HTTP service pays under saturation drops by a third (TLS: 40%) at no

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -265,7 +265,7 @@ $ `stdlib/std/p384_field.nu`  // fixed-width P-384 verify core (public path)
     // all-zero identity output, as before).
     : ( Vec i ) zinv ( _mag4 )
     ( _p256_inv_d scr zinv . acc z )
-    ( _p256_mul_d scr . acc z zinv zinv )
+    ( _p256_sqr_d scr . acc z zinv )
     ( _p256_mul_d scr . acc x . acc x . acc z )
     ( _p256_mul_d scr . acc z . acc z zinv )
     ( _p256_mul_d scr . acc y . acc y . acc z )

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -33,10 +33,24 @@ $ `stdlib/std/bytes.nu`
 
 // ── 64-entry round-constant table per FIPS 180-4 §4.2.2 ────────────
 
+// One process-wide copy of the round-constant table, built on first use
+// and BORROWED by every handle: the table is a public constant, and a TLS
+// key schedule runs one `sha256_init` per HMAC leg — a 64-word build and
+// a heap alloc/free per digest bought nothing. Benign init race: two
+// first callers may both build; one pointer wins, the losing 256-byte
+// copy leaks once (same discipline as the P-256 comb tables).
+: ~ i g_sha256_k 0
+
+@ __sha256_k_shared → ( Vec u32 ) {
+    ? == g_sha256_k 0 {
+        : ( Vec u32 ) k ( __sha256_K )
+        = g_sha256_k # i . k ctl
+    } {}
+    ^ @ ( Vec u32 ) { # s g_sha256_k }
+}
+
 @ __sha256_K → ( Vec u32 ) {
-    // Filled by index through a raw `*u32`: this table is rebuilt on every
-    // `sha256_init`, and TLS's key schedule runs one of those per HMAC leg,
-    // so sixty-four capacity-checked pushes are sixty-four too many.
+    // Filled by index through a raw `*u32`.
     : ( Vec u32 ) k ( vec_with_cap [u32] 64 )
     : b _l ( vec_set_len [u32] k 64 )
     : *u32 kp ( vec_data [u32] k )
@@ -170,7 +184,7 @@ $ `stdlib/std/bytes.nu`
     = . h state st
     = . h buf ( vec_new [u] )
     = . h total 0
-    = . h k ( __sha256_K )
+    = . h k ( __sha256_k_shared )
     : ( Vec u32 ) sched ( vec_with_cap [u32] 64 )
     : b _m ( vec_set_len [u32] sched 64 )
     = . h m sched
@@ -247,7 +261,7 @@ $ `stdlib/std/bytes.nu`
     }
     ( vec_free [u] tail )
     ( vec_free [u32] . h state )
-    ( vec_free [u32] . h k )
+    // h.k is the shared process-global constant table — never freed.
     ( vec_free [u32] . h m )
     ( nurl_free # s h )
     ^ out
@@ -264,7 +278,7 @@ $ `stdlib/std/bytes.nu`
     = . c state ( vec_clone [u32] . h state )
     = . c buf ( vec_clone [u] . h buf )
     = . c total . h total
-    = . c k ( vec_clone [u32] . h k )
+    = . c k . h k
     = . c m ( vec_clone [u32] . h m )
     ^ ( sha256_final c )
 }

--- a/stdlib/std/p256_field.nu
+++ b/stdlib/std/p256_field.nu
@@ -393,6 +393,183 @@ $ `stdlib/core/vec.nu`
 // (kept: the 9-limb staging cond-sub is gone — add/sub carry in
 // registers now and fold the conditional ±p inline, like the multiply.)
 
+// Montgomery SQUARE: dst ← (a·a·R^-1) mod p. The 16-product schoolbook
+// collapses to 10 — six cross products doubled by one carry-chained
+// shift, plus the four diagonals — followed by the same four rounds of
+// sparse-p Montgomery reduction the multiply runs and the same
+// constant-time conditional subtract. Everything the point formulas and
+// the Fermat inversion spell as `mul x x` comes through here: 37% of a
+// fixed-base comb's field ops are squarings, and an inversion is ~95%.
+// `dst` may alias `a` — the limbs are read into locals first.
+@ _p256_sqr_d P256Scratch scr ( Vec i ) dst ( Vec i ) a → v {
+    : *i ap ( vec_data [i] a )
+    : u64 a0 # u64 . ap 0
+    : u64 a1 # u64 . ap 1
+    : u64 a2 # u64 . ap 2
+    : u64 a3 # u64 . ap 3
+    // ── cross products: r1..r6 = a0a1, a0a2, a0a3(+a1a2), a1a3, a2a3 ──
+    : ~ u64 cr 0
+    : ~ u64 r1 ( nurl_mac_lo a0 a1 0 0 )
+    = cr ( nurl_mac_hi a0 a1 0 0 )
+    : ~ u64 r2 ( nurl_mac_lo a0 a2 0 cr )
+    = cr ( nurl_mac_hi a0 a2 0 cr )
+    : ~ u64 r3 ( nurl_mac_lo a0 a3 0 cr )
+    : ~ u64 r4 ( nurl_mac_hi a0 a3 0 cr )
+    : u64 s3 ( nurl_mac_lo a1 a2 r3 0 )
+    = cr ( nurl_mac_hi a1 a2 r3 0 )
+    = r3 s3
+    : u64 s4 ( nurl_mac_lo a1 a3 r4 cr )
+    : ~ u64 r5 ( nurl_mac_hi a1 a3 r4 cr )
+    = r4 s4
+    : u64 s5 ( nurl_mac_lo a2 a3 r5 0 )
+    : ~ u64 r6 ( nurl_mac_hi a2 a3 r5 0 )
+    = r5 s5
+    // ── double the cross terms, carry chaining into r7 ──
+    : u64 d1 ( nurl_addc_lo r1 r1 0 )
+    = cr ( nurl_addc_hi r1 r1 0 )
+    : u64 d2 ( nurl_addc_lo r2 r2 cr )
+    = cr ( nurl_addc_hi r2 r2 cr )
+    : u64 d3 ( nurl_addc_lo r3 r3 cr )
+    = cr ( nurl_addc_hi r3 r3 cr )
+    : u64 d4 ( nurl_addc_lo r4 r4 cr )
+    = cr ( nurl_addc_hi r4 r4 cr )
+    : u64 d5 ( nurl_addc_lo r5 r5 cr )
+    = cr ( nurl_addc_hi r5 r5 cr )
+    : u64 d6 ( nurl_addc_lo r6 r6 cr )
+    : ~ u64 r7 ( nurl_addc_hi r6 r6 cr )
+    // ── diagonals a0², a1², a2², a3² at the even positions ──
+    : ~ u64 r0 ( nurl_mac_lo a0 a0 0 0 )
+    = cr ( nurl_mac_hi a0 a0 0 0 )
+    = r1 ( nurl_addc_lo d1 cr 0 )
+    = cr ( nurl_addc_hi d1 cr 0 )
+    = r2 ( nurl_mac_lo a1 a1 d2 cr )
+    = cr ( nurl_mac_hi a1 a1 d2 cr )
+    = r3 ( nurl_addc_lo d3 cr 0 )
+    = cr ( nurl_addc_hi d3 cr 0 )
+    = r4 ( nurl_mac_lo a2 a2 d4 cr )
+    = cr ( nurl_mac_hi a2 a2 d4 cr )
+    = r5 ( nurl_addc_lo d5 cr 0 )
+    = cr ( nurl_addc_hi d5 cr 0 )
+    = r6 ( nurl_mac_lo a3 a3 d6 cr )
+    = cr ( nurl_mac_hi a3 a3 d6 cr )
+    // the full square is < 2^512, so this last add cannot overflow.
+    = r7 + r7 cr
+    // ── 4 rounds of Montgomery reduction: m = low word, add m·p, shift ──
+    // Same sparse-p folds as _p256_mul_d; the carry lands in r[i+4] and
+    // ripples upward through an extra top word `ex` (≤ 4 by the 2p bound).
+    : ~ u64 ex 0
+    : ~ u64 m 0
+    // round 0 — m·p added at r0..r3, carry into r4..r7,ex
+    = m r0
+    = cr ( nurl_mac_hi m 18446744073709551615 r0 0 )
+    : u64 u01 ( nurl_mac_lo m 4294967295 r1 cr )
+    = cr ( nurl_mac_hi m 4294967295 r1 cr )
+    = r1 u01
+    : u64 u02 ( nurl_addc_lo r2 cr 0 )
+    = cr ( nurl_addc_hi r2 cr 0 )
+    = r2 u02
+    : u64 u03 ( nurl_mac_lo m 18446744069414584321 r3 cr )
+    = cr ( nurl_mac_hi m 18446744069414584321 r3 cr )
+    = r3 u03
+    : u64 u04 ( nurl_addc_lo r4 cr 0 )
+    = cr ( nurl_addc_hi r4 cr 0 )
+    = r4 u04
+    : u64 u05 ( nurl_addc_lo r5 cr 0 )
+    = cr ( nurl_addc_hi r5 cr 0 )
+    = r5 u05
+    : u64 u06 ( nurl_addc_lo r6 cr 0 )
+    = cr ( nurl_addc_hi r6 cr 0 )
+    = r6 u06
+    : u64 u07 ( nurl_addc_lo r7 cr 0 )
+    = cr ( nurl_addc_hi r7 cr 0 )
+    = r7 u07
+    = ex + ex cr
+    // round 1 — at r1..r4, carry r5..r7,ex
+    = m r1
+    = cr ( nurl_mac_hi m 18446744073709551615 r1 0 )
+    : u64 u11 ( nurl_mac_lo m 4294967295 r2 cr )
+    = cr ( nurl_mac_hi m 4294967295 r2 cr )
+    = r2 u11
+    : u64 u12 ( nurl_addc_lo r3 cr 0 )
+    = cr ( nurl_addc_hi r3 cr 0 )
+    = r3 u12
+    : u64 u13 ( nurl_mac_lo m 18446744069414584321 r4 cr )
+    = cr ( nurl_mac_hi m 18446744069414584321 r4 cr )
+    = r4 u13
+    : u64 u14 ( nurl_addc_lo r5 cr 0 )
+    = cr ( nurl_addc_hi r5 cr 0 )
+    = r5 u14
+    : u64 u15 ( nurl_addc_lo r6 cr 0 )
+    = cr ( nurl_addc_hi r6 cr 0 )
+    = r6 u15
+    : u64 u16 ( nurl_addc_lo r7 cr 0 )
+    = cr ( nurl_addc_hi r7 cr 0 )
+    = r7 u16
+    = ex + ex cr
+    // round 2 — at r2..r5, carry r6..r7,ex
+    = m r2
+    = cr ( nurl_mac_hi m 18446744073709551615 r2 0 )
+    : u64 u21 ( nurl_mac_lo m 4294967295 r3 cr )
+    = cr ( nurl_mac_hi m 4294967295 r3 cr )
+    = r3 u21
+    : u64 u22 ( nurl_addc_lo r4 cr 0 )
+    = cr ( nurl_addc_hi r4 cr 0 )
+    = r4 u22
+    : u64 u23 ( nurl_mac_lo m 18446744069414584321 r5 cr )
+    = cr ( nurl_mac_hi m 18446744069414584321 r5 cr )
+    = r5 u23
+    : u64 u24 ( nurl_addc_lo r6 cr 0 )
+    = cr ( nurl_addc_hi r6 cr 0 )
+    = r6 u24
+    : u64 u25 ( nurl_addc_lo r7 cr 0 )
+    = cr ( nurl_addc_hi r7 cr 0 )
+    = r7 u25
+    = ex + ex cr
+    // round 3 — at r3..r6, carry r7,ex
+    = m r3
+    = cr ( nurl_mac_hi m 18446744073709551615 r3 0 )
+    : u64 u31 ( nurl_mac_lo m 4294967295 r4 cr )
+    = cr ( nurl_mac_hi m 4294967295 r4 cr )
+    = r4 u31
+    : u64 u32 ( nurl_addc_lo r5 cr 0 )
+    = cr ( nurl_addc_hi r5 cr 0 )
+    = r5 u32
+    : u64 u33 ( nurl_mac_lo m 18446744069414584321 r6 cr )
+    = cr ( nurl_mac_hi m 18446744069414584321 r6 cr )
+    = r6 u33
+    : u64 u34 ( nurl_addc_lo r7 cr 0 )
+    = cr ( nurl_addc_hi r7 cr 0 )
+    = r7 u34
+    = ex + ex cr
+    // ── result = r4..r7 (+ex), value < 2p: same ct subtract as the mul ──
+    : u64 d0 ( nurl_subb_lo r4 18446744073709551615 0 )
+    : ~ u64 bb ( nurl_subb_hi r4 18446744073709551615 0 )
+    : u64 e1 ( nurl_subb_lo r5 4294967295 bb )
+    = bb ( nurl_subb_hi r5 4294967295 bb )
+    : u64 e2 ( nurl_subb_lo r6 0 bb )
+    = bb ( nurl_subb_hi r6 0 bb )
+    : u64 e3 ( nurl_subb_lo r7 18446744069414584321 bb )
+    = bb ( nurl_subb_hi r7 18446744069414584321 bb )
+    : i topb - # i ex # i bb
+    : u64 mask ? < topb 0 0 18446744073709551615
+    : u64 imask ^^ mask 18446744073709551615
+    : u64 o0 | & mask d0 & imask r4
+    : u64 o1 | & mask e1 & imask r5
+    : u64 o2 | & mask e2 & imask r6
+    : u64 o3 | & mask e3 & imask r7
+    : *i op ( vec_data [i] dst )
+    = . op 0 # i o0
+    = . op 1 # i o1
+    = . op 2 # i o2
+    = . op 3 # i o3
+}
+
+// dst ← dst^(2^n) — n back-to-back Montgomery squarings.
+@ __p256_sqn P256Scratch scr ( Vec i ) x i n → v {
+    : ~ i k 0
+    ~ < k n { ( _p256_sqr_d scr x x ) = k + k 1 }
+}
+
 // (a + b) mod p, constant-time. a, b < p ⇒ a+b < 2p ⇒ one conditional sub.
 @ p256ct_add ( Vec i ) a ( Vec i ) b → ( Vec i ) {
     : P256Scratch scr ( _p256_scr_new )
@@ -591,34 +768,54 @@ $ `stdlib/core/vec.nu`
 // one scratch. UNLIKE the other `_d` workers, `dst` must NOT alias `a`:
 // `a` is read on every iteration, and `dst` is the running accumulator.
 @ _p256_inv_d P256Scratch scr ( Vec i ) dst ( Vec i ) a → v {
-    // p-2 = ffffffff00000001000000000000000000000000fffffffffffffffffffffffd
-    // Square-and-multiply, MSB→LSB, over the 256-bit exponent's limbs.
-    : ( Vec i ) e ( __p256_pm2 )
-    : ( Vec i ) prod . scr gp
-    ( _p256_one_mont_d scr dst )
-    : ~ i bit 255
-    ~ >= bit 0 {
-        ( _p256_mul_d scr dst dst dst )
-        : i li / bit 64
-        : i bp % bit 64
-        : i b1 & 1 # i >> # u64 ( __ctl e li ) bp
-        ( _p256_mul_d scr prod dst a )
-        // constant-time select prod (if bit) else the running value
-        : i mask - 0 b1
-        : i imask - 0 - 1 b1
-        ( __p256_lmerge_d dst mask imask prod dst )
-        = bit - bit 1
-    }
-    ( vec_free [i] e )
+    // dst ← a^(p−2) — Fermat. The exponent is a PUBLIC curve constant,
+    // so the old bit-scanned square-and-multiply with a constant-time
+    // select (256 S + 256 M, half of them discarded) bought nothing: the
+    // sequence of operations in a fixed addition chain is identical for
+    // every input, only the (public) exponent shapes it. This is the
+    // standard p−2 chain over p = 2^256 − 2^224 + 2^192 + 2^96 − 1:
+    // MSB-first the exponent is [32×1][31×0][1][96×0][94×1][0][1], built
+    // from the all-ones blocks x2..x32 — 255 squarings + 13 multiplies,
+    // all in the dedicated Montgomery squaring. Still branch-free in the
+    // DATA; verified against the old path over random field elements and
+    // by every ECDSA/ECDH KAT in the corpus.
+    : ( Vec i ) x2 ( _mag4 )
+    : ( Vec i ) x4 ( _mag4 )
+    : ( Vec i ) x8 ( _mag4 )
+    : ( Vec i ) x16 ( _mag4 )
+    : ( Vec i ) x32 ( _mag4 )
+    // x2 = a^(2^2−1), x4 = a^(2^4−1), … x32 = a^(2^32−1)
+    ( _p256_sqr_d scr x2 a ) ( _p256_mul_d scr x2 x2 a )
+    ( _p256_sqr_d scr x4 x2 ) ( _p256_sqr_d scr x4 x4 )
+    ( _p256_mul_d scr x4 x4 x2 )
+    ( __p256_cp x8 x4 ) ( __p256_sqn scr x8 4 )
+    ( _p256_mul_d scr x8 x8 x4 )
+    ( __p256_cp x16 x8 ) ( __p256_sqn scr x16 8 )
+    ( _p256_mul_d scr x16 x16 x8 )
+    ( __p256_cp x32 x16 ) ( __p256_sqn scr x32 16 )
+    ( _p256_mul_d scr x32 x32 x16 )
+    // assemble the exponent MSB→LSB
+    ( __p256_cp dst x32 )
+    ( __p256_sqn scr dst 32 ) ( _p256_mul_d scr dst dst a )
+    ( __p256_sqn scr dst 128 ) ( _p256_mul_d scr dst dst x32 )
+    ( __p256_sqn scr dst 32 ) ( _p256_mul_d scr dst dst x32 )
+    ( __p256_sqn scr dst 16 ) ( _p256_mul_d scr dst dst x16 )
+    ( __p256_sqn scr dst 8 ) ( _p256_mul_d scr dst dst x8 )
+    ( __p256_sqn scr dst 4 ) ( _p256_mul_d scr dst dst x4 )
+    ( __p256_sqn scr dst 2 ) ( _p256_mul_d scr dst dst x2 )
+    ( __p256_sqn scr dst 2 ) ( _p256_mul_d scr dst dst a )
+    ( vec_free [i] x2 ) ( vec_free [i] x4 ) ( vec_free [i] x8 )
+    ( vec_free [i] x16 ) ( vec_free [i] x32 )
 }
 
-// p − 2, little-endian 64-bit limbs.
-@ __p256_pm2 → ( Vec i ) {
-    : ( Vec i ) v ( _mag4 )
-    : *i q ( vec_data [i] v )
-    = . q 0 # i 0xFFFFFFFFFFFFFFFD = . q 1 # i 0x00000000FFFFFFFF
-    = . q 2 0 = . q 3 # i 0xFFFFFFFF00000001
-    ^ v
+// 4-limb copy.
+@ __p256_cp ( Vec i ) dst ( Vec i ) a → v {
+    : *i op ( vec_data [i] dst )
+    : *i ap ( vec_data [i] a )
+    = . op 0 . ap 0
+    = . op 1 . ap 1
+    = . op 2 . ap 2
+    = . op 3 . ap 3
 }
 
 @ p256ct_free ( Vec i ) a → v { ( vec_free [i] a ) }
@@ -832,8 +1029,8 @@ $ `stdlib/core/vec.nu`
     : ( Vec i ) alpha . scr g3
     : ( Vec i ) t4 . scr g4
     : ( Vec i ) t5 . scr g5
-    ( _p256_mul_d scr delta zr zr )
-    ( _p256_mul_d scr gamma yr yr )
+    ( _p256_sqr_d scr delta zr )
+    ( _p256_sqr_d scr gamma yr )
     ( _p256_mul_d scr beta xr gamma )
     // alpha = 3·(xr − delta)·(xr + delta)
     ( __p256_sub_d scr t4 xr delta )
@@ -843,11 +1040,11 @@ $ `stdlib/core/vec.nu`
     ( __p256_add_d scr alpha t4 alpha )
     // Z3 = (yr + zr)² − gamma − delta   (before xr/yr are overwritten)
     ( __p256_add_d scr t4 yr zr )
-    ( _p256_mul_d scr t4 t4 t4 )
+    ( _p256_sqr_d scr t4 t4 )
     ( __p256_sub_d scr t4 t4 gamma )
     ( __p256_sub_d scr zr t4 delta )
     // X3 = alpha² − 8·beta
-    ( _p256_mul_d scr t4 alpha alpha )
+    ( _p256_sqr_d scr t4 alpha )
     ( __p256_add_d scr t5 beta beta )
     ( __p256_add_d scr t5 t5 t5 )
     ( __p256_add_d scr delta t5 t5 )
@@ -855,7 +1052,7 @@ $ `stdlib/core/vec.nu`
     // Y3 = alpha·(4·beta − X3) − 8·gamma²
     ( __p256_sub_d scr t4 t5 xr )
     ( _p256_mul_d scr t4 alpha t4 )
-    ( _p256_mul_d scr t5 gamma gamma )
+    ( _p256_sqr_d scr t5 gamma )
     ( __p256_add_d scr t5 t5 t5 )
     ( __p256_add_d scr t5 t5 t5 )
     ( __p256_add_d scr t5 t5 t5 )
@@ -891,7 +1088,7 @@ $ `stdlib/core/vec.nu`
     : ( Vec i ) t . scr gp
     : i inf_mask ( _p256_zmask Z1 )
     // zz = Z1²; u2 = x2·zz; s2 = y2·Z1·zz
-    ( _p256_mul_d scr z3 Z1 Z1 )
+    ( _p256_sqr_d scr z3 Z1 )
     ( _p256_mul_d scr hreg x2 z3 )
     ( _p256_mul_d scr t z3 Z1 )
     ( _p256_mul_d scr rreg y2 t )
@@ -901,9 +1098,9 @@ $ `stdlib/core/vec.nu`
     // Z3 = Z1·H (into its own register — acc stays whole until commit)
     ( _p256_mul_d scr z3 Z1 hreg )
     // hh = H²; V = X1·hh; X3 = R² − H³ − 2V
-    ( _p256_mul_d scr hh hreg hreg )
+    ( _p256_sqr_d scr hh hreg )
     ( _p256_mul_d scr vv X1 hh )
-    ( _p256_mul_d scr x3 rreg rreg )
+    ( _p256_sqr_d scr x3 rreg )
     ( _p256_mul_d scr hh hreg hh )
     ( __p256_sub_d scr x3 x3 hh )
     ( __p256_sub_d scr x3 x3 vv )

--- a/stdlib/std/p256_scalar.nu
+++ b/stdlib/std/p256_scalar.nu
@@ -379,29 +379,68 @@ $ `stdlib/core/vec.nu`
     ^ v
 }
 
-// a^-1 mod n, Fermat: a^(n-2), constant square-and-multiply schedule
-// over the Montgomery field (~256 squarings + the bits n-2 selects).
+// Flat 15-entry window table: entry k (1-based) at [ (k−1)·4, (k−1)·4+4 ).
+@ __sn_tbl_put ( Vec i ) tbl i k ( Vec i ) v → v {
+    : *i tp ( vec_data [i] tbl )
+    : *i vp ( vec_data [i] v )
+    : i base * - k 1 4
+    = . tp + base 0 . vp 0
+    = . tp + base 1 . vp 1
+    = . tp + base 2 . vp 2
+    = . tp + base 3 . vp 3
+}
+
+@ __sn_tbl_cp ( Vec i ) dst ( Vec i ) tbl i k → v {
+    : *i tp ( vec_data [i] tbl )
+    : *i dp ( vec_data [i] dst )
+    : i base * - k 1 4
+    = . dp 0 . tp + base 0
+    = . dp 1 . tp + base 1
+    = . dp 2 . tp + base 2
+    = . dp 3 . tp + base 3
+}
+
+// a^-1 mod n, Fermat: a^(n-2) with a fixed 4-bit window, MSB→LSB.
+// The exponent n−2 is a PUBLIC curve constant, so the schedule — and
+// every branch below, which reads only that constant — is identical for
+// all inputs; the data stays in branch-free Montgomery arithmetic. The
+// old bit-at-a-time ladder cost 256 squarings + ~170 multiplies plus two
+// 4-limb copies per bit; the window costs 14 (table) + 252 squarings +
+// one multiply per non-zero nibble (~59) and no per-bit copies.
 @ p256n_inv_be ( Vec u ) a → ( Vec u ) {
     : ( Vec i ) av ( __sn_from_be_raw a ) ( __sn_reduce av )
     : ( Vec i ) am ( __sn_to_mont av )
-    : ( Vec i ) r ( __sn_one_mont )
     : ( Vec u ) e ( __sn_nm2_be )
-    : ( Vec i ) sq ( __sn_mag4 )
-    : ( Vec i ) pr ( __sn_mag4 )
-    : ~ i bit 255
-    ~ >= bit 0 {
-        ( __sn_mul sq r r )
-        ( __sn_cp r sq )
-        : i byte ( _snbget e - 31 >> bit 3 )
-        ? & 1 >> byte & bit 7 {
-            ( __sn_mul pr r am )
-            ( __sn_cp r pr )
+    // tbl[k] = a^k (Montgomery), k = 1..15
+    : ( Vec i ) tbl ( vec_with_cap [i] 60 )
+    : b _l ( vec_set_len [i] tbl 60 )
+    : ( Vec i ) w ( __sn_mag4 )
+    ( __sn_cp w am )
+    ( __sn_tbl_put tbl 1 w )
+    : ~ i k 2
+    ~ <= k 15 {
+        ( __sn_mul w w am )
+        ( __sn_tbl_put tbl k w )
+        = k + k 1
+    }
+    // first nibble of n−2 is 0xf; then 63 windows of 4 squarings + mul
+    : ( Vec i ) r ( __sn_mag4 )
+    ( __sn_tbl_cp r tbl 15 )
+    : ~ i wi 1
+    ~ < wi 64 {
+        ( __sn_mul r r r ) ( __sn_mul r r r )
+        ( __sn_mul r r r ) ( __sn_mul r r r )
+        : i byte # i ?? ( vec_get [u] e / wi 2 ) { T x → # i x F _ → 0 }
+        : i nib ? == % wi 2 0 >> byte 4 & byte 15
+        ? > nib 0 {
+            ( __sn_tbl_cp w tbl nib )
+            ( __sn_mul r r w )
         } {}
-        = bit - bit 1
+        = wi + wi 1
     }
     : ( Vec i ) out ( __sn_from_mont r )
     : ( Vec u ) o ( __sn_to_be out )
     ( vec_free [i] av ) ( vec_free [i] am ) ( vec_free [i] r )
-    ( vec_free [u] e ) ( vec_free [i] sq ) ( vec_free [i] pr ) ( vec_free [i] out )
+    ( vec_free [u] e ) ( vec_free [i] tbl ) ( vec_free [i] w ) ( vec_free [i] out )
     ^ o
 }

--- a/stdlib/std/x25519.nu
+++ b/stdlib/std/x25519.nu
@@ -370,18 +370,52 @@ $ `stdlib/core/vec.nu`
 }
 
 // io ← io^(p-2) = io^-1  (Fermat inversion, 254 squarings).
+// io ← io^(2^n) — n back-to-back squarings.
+@ _sqn25519 ( Vec i ) io i n → v {
+    : ~ i k 0
+    ~ < k n { ( _S io io ) = k + k 1 }
+}
+
 @ _inv25519 ( Vec i ) io → v {
-    : ( Vec i ) inp ( _gf_copy io )
-    : ( Vec i ) c ( _gf_copy io )
-    : ~ i a 253
-    ~ >= a 0 {
-        ( _S c c )
-        ? & != a 2 != a 4 { ( _M c c inp ) } {}
-        = a - a 1
-    }
-    ( _gf_into io c )
-    ( vec_free [i] inp )
-    ( vec_free [i] c )
+    // io ← io^(p−2), p = 2^255−19 — Fermat, via the standard ref10
+    // addition chain: 254 squarings + 11 multiplies. The old
+    // tweetnacl-style ladder multiplied on every exponent bit — 254 S
+    // + 252 M for the same PUBLIC exponent, so 241 of those multiplies
+    // bought nothing: the schedule depends only on the constant p−2,
+    // and the data path stays branch-free either way. Verified against
+    // the RFC 7748 vectors and the x25519/TLS corpus tests.
+    : ( Vec i ) z ( _gf_copy io )
+    : ( Vec i ) z2 ( _gf_zero )
+    : ( Vec i ) z9 ( _gf_zero )
+    : ( Vec i ) z11 ( _gf_zero )
+    : ( Vec i ) z5 ( _gf_zero )
+    : ( Vec i ) z10 ( _gf_zero )
+    : ( Vec i ) z50 ( _gf_zero )
+    : ( Vec i ) t ( _gf_zero )
+    ( _S z2 z )  // z^2
+    ( _S z9 z2 ) ( _S z9 z9 ) ( _M z9 z9 z )  // z^9
+    ( _M z11 z9 z2 )  // z^11
+    ( _S z5 z11 ) ( _M z5 z5 z9 )  // z^(2^5−1)
+    ( _gf_into z10 z5 ) ( _sqn25519 z10 5 )
+    ( _M z10 z10 z5 )  // z^(2^10−1)
+    ( _gf_into t z10 ) ( _sqn25519 t 10 )
+    ( _M t t z10 )  // z^(2^20−1)
+    ( _gf_into z50 t ) ( _sqn25519 z50 20 )
+    ( _M z50 z50 t )  // z^(2^40−1)
+    ( _sqn25519 z50 10 )
+    ( _M z50 z50 z10 )  // z^(2^50−1)
+    ( _gf_into t z50 ) ( _sqn25519 t 50 )
+    ( _M t t z50 )  // z^(2^100−1)
+    ( _gf_into z10 t ) ( _sqn25519 z10 100 )
+    ( _M z10 z10 t )  // z^(2^200−1)
+    ( _sqn25519 z10 50 )
+    ( _M z10 z10 z50 )  // z^(2^250−1)
+    ( _sqn25519 z10 5 )
+    ( _M z10 z10 z11 )  // z^(2^255−21)
+    ( _gf_into io z10 )
+    ( vec_free [i] z ) ( vec_free [i] z2 ) ( vec_free [i] z9 )
+    ( vec_free [i] z11 ) ( vec_free [i] z5 ) ( vec_free [i] z10 )
+    ( vec_free [i] z50 ) ( vec_free [i] t )
 }
 
 // ── the ladder ────────────────────────────────────────────────────
@@ -576,52 +610,167 @@ $ `stdlib/core/vec.nu`
     ^ v
 }
 
-// p ← p + q, extended twisted-Edwards (a = −1). p may equal q (doubling):
-// every operand is read into the scratch before any of p's coords is set.
-@ __xe_add XEScr sc XEP p XEP q ( Vec i ) d2 → v {
+// ── niels-form comb table + dedicated double/madd (keygen fast path) ──
+//
+// The comb used to run a generic 9-_M complete addition twice per
+// iteration — once as a doubling, once to add a table entry whose Z is
+// 1 by construction. The dedicated shapes below are the ref10/EFD ones:
+// an extended-coordinate doubling (dbl-2008-hwcd, a = −1) at 4M+4S and
+// a mixed addition against a precomputed NIELS entry (y+x, y−x, 2d·t)
+// at 7M. The niels table (16 entries × 15 limbs) is derived ONCE per
+// process from the baked affine table and cached in a global — the old
+// path re-materialised the 320-limb table on every keygen. Benign init
+// race: two first callers may both build; one pointer wins, the losing
+// ~2 KB copy leaks once (same discipline as the P-256 comb tables).
+: ~ i g_xe_ntbl 0
+
+@ __xe_ntbl_build → v {
+    : ( Vec i ) src ( __xe_comb_table )
+    : ( Vec i ) d2 ( __xe_d2 )
+    : ( Vec i ) ntbl ( vec_with_cap [i] 240 )
+    : b _l ( vec_set_len [i] ntbl 240 )
+    : *i np ( vec_data [i] ntbl )
+    : ( Vec i ) x ( _gf_zero )
+    : ( Vec i ) y ( _gf_zero )
+    : ( Vec i ) t ( _gf_zero )
+    : ( Vec i ) yp ( _gf_zero )
+    : ( Vec i ) ym ( _gf_zero )
+    : ( Vec i ) t2d ( _gf_zero )
+    : *i sp ( vec_data [i] src )
+    : *i xp ( vec_data [i] x )
+    : *i yq ( vec_data [i] y )
+    : *i tp ( vec_data [i] t )
+    : *i ypp ( vec_data [i] yp )
+    : *i ymp ( vec_data [i] ym )
+    : *i tdp ( vec_data [i] t2d )
+    : ~ i e 0
+    ~ < e 16 {
+        : i base * e 20
+        : ~ i j 0
+        ~ < j 5 {
+            = . xp j . sp + base j
+            = . yq j . sp + + base 5 j
+            = . tp j . sp + + base 15 j
+            = j + j 1
+        }
+        ( _A yp y x )
+        ( _Z ym y x )
+        ( _M t2d t d2 )
+        : i nb * e 15
+        = j 0
+        ~ < j 5 {
+            = . np + nb j . ypp j
+            = . np + + nb 5 j . ymp j
+            = . np + + nb 10 j . tdp j
+            = j + j 1
+        }
+        = e + e 1
+    }
+    = g_xe_ntbl # i . ntbl ctl
+    ( vec_free [i] src ) ( vec_free [i] d2 )
+    ( vec_free [i] x ) ( vec_free [i] y ) ( vec_free [i] t )
+    ( vec_free [i] yp ) ( vec_free [i] ym ) ( vec_free [i] t2d )
+}
+
+@ __xe_ntbl → ( Vec i ) {
+    ? == g_xe_ntbl 0 { ( __xe_ntbl_build ) } {}
+    ^ @ ( Vec i ) { # s g_xe_ntbl }
+}
+
+// Constant-time read of niels entry `digit` (0..15): all 16 entries
+// scanned, merged under a match mask — 15 limbs each, not the 20 of the
+// extended form (Z = 1 is implicit in the niels shape).
+@ __xe_ntbl_get ( Vec i ) tbl i digit ( Vec i ) yp ( Vec i ) ym ( Vec i ) t2d → v {
+    : *i tb ( vec_data [i] tbl )
+    : *i pp ( vec_data [i] yp )
+    : *i mp ( vec_data [i] ym )
+    : *i dp ( vec_data [i] t2d )
+    : ~ i k 0
+    ~ < k 5 { = . pp k 0 = . mp k 0 = . dp k 0 = k + k 1 }
+    : ~ i e 0
+    ~ < e 16 {
+        : u64 z ^^ # u64 e # u64 digit
+        : i mask - 0 # i >> - z 1 63
+        : i base * e 15
+        : ~ i j 0
+        ~ < j 5 {
+            = . pp j | . pp j & mask . tb + base j
+            = . mp j | . mp j & mask . tb + + base 5 j
+            = . dp j | . dp j & mask . tb + + base 10 j
+            = j + j 1
+        }
+        = e + e 1
+    }
+}
+
+// One carry sweep: limbs (≤ ~2^54) back under 52 bits, top wraps ×19.
+// _Z's SUBTRAHEND must stay below the 2p limb constants (~2^52), so a
+// value built by _A needs this before it may be subtracted; minuends
+// and _M/_S operands tolerate the lazy 2^54 bound as-is.
+@ _gf_carry ( Vec i ) v → v {
+    : *i q ( vec_data [i] v )
+    : ~ i k 0
+    : ~ i c 0
+    ~ < k 4 {
+        = . q k + . q k c
+        = c >> . q k 51
+        = . q k & . q k 2251799813685247
+        = k + k 1
+    }
+    = . q 4 + . q 4 c
+    = c >> . q 4 51
+    = . q 4 & . q 4 2251799813685247
+    = . q 0 + . q 0 * 19 c
+}
+
+// p ← 2·p, extended coordinates (EFD dbl-2008-hwcd, a = −1): 4M + 4S.
+// Scratch registers: a,b,c,e,f,g,h (tt holds the zero for the negation).
+// The −(A+B) negative is taken as (2p − A) + (2p − B): both steps
+// subtract a REDUCED value, which is _Z's contract; C = 2Z² gets one
+// carry sweep before it appears as a subtrahend in F = G − C.
+@ __xe_dbl XEScr sc XEP p → v {
+    ( _S . sc a . p x )  // A = X²
+    ( _S . sc b . p y )  // B = Y²
+    ( _S . sc c . p z )
+    ( _A . sc c . sc c . sc c )
+    ( _gf_carry . sc c )  // C = 2Z², reduced
+    ( _A . sc e . p x . p y )
+    ( _S . sc e . sc e )
+    ( _Z . sc e . sc e . sc a )
+    ( _Z . sc e . sc e . sc b )  // E = (X+Y)² − A − B
+    ( _Z . sc g . sc b . sc a )  // G = B − A   (D = −A folded in)
+    ( _Z . sc f . sc g . sc c )  // F = G − C
+    ( _gf_zero_into . sc tt )
+    ( _Z . sc h . sc tt . sc a )
+    ( _Z . sc h . sc h . sc b )  // H = −(A + B)
+    ( _M . p x . sc e . sc f )
+    ( _M . p y . sc g . sc h )
+    ( _M . p t . sc e . sc h )
+    ( _M . p z . sc f . sc g )
+}
+
+// p ← p + niels(yp, ym, t2d): the ref10 ge_madd shape, 7M, Z2 = 1.
+@ __xe_madd XEScr sc XEP p ( Vec i ) yp ( Vec i ) ym ( Vec i ) t2d → v {
     ( _Z . sc a . p y . p x )
-    ( _Z . sc tt . q y . q x )
-    ( _M . sc a . sc a . sc tt )
-    ( _A . sc b . p x . p y )
-    ( _A . sc tt . q x . q y )
-    ( _M . sc b . sc b . sc tt )
-    ( _M . sc c . p t . q t )
-    ( _M . sc c . sc c d2 )
-    ( _M . sc d . p z . q z )
-    ( _A . sc d . sc d . sc d )
+    ( _M . sc a . sc a ym )  // A = (Y1−X1)·(y2−x2)
+    ( _A . sc b . p y . p x )
+    ( _M . sc b . sc b yp )  // B = (Y1+X1)·(y2+x2)
+    ( _M . sc c . p t t2d )  // C = T1·2d·t2
+    ( _A . sc d . p z . p z )  // D = 2Z1
     ( _Z . sc e . sc b . sc a )
     ( _Z . sc f . sc d . sc c )
     ( _A . sc g . sc d . sc c )
     ( _A . sc h . sc b . sc a )
     ( _M . p x . sc e . sc f )
-    ( _M . p y . sc h . sc g )
+    ( _M . p y . sc g . sc h )
     ( _M . p z . sc g . sc f )
     ( _M . p t . sc e . sc h )
 }
 
-// Constant-time read of entry `digit` (0..15) into dst from the flat baked
-// table (stride 20): all 16 entries scanned, merged under a match mask.
-@ __xe_tbl_get ( Vec i ) tbl i digit XEP dst → v {
-    : *i tb ( vec_data [i] tbl )
-    : *i dx ( vec_data [i] . dst x ) : *i dy ( vec_data [i] . dst y )
-    : *i dz ( vec_data [i] . dst z ) : *i dt ( vec_data [i] . dst t )
-    : ~ i k 0
-    ~ < k 5 { = . dx k 0 = . dy k 0 = . dz k 0 = . dt k 0 = k + k 1 }
-    : ~ i e 0
-    ~ < e 16 {
-        : u64 z ^^ # u64 e # u64 digit
-        : i mask - 0 # i >> - z 1 63
-        : i base * e 20
-        : ~ i j 0
-        ~ < j 5 {
-            = . dx j | . dx j & mask . tb + base j
-            = . dy j | . dy j & mask . tb + + base 5 j
-            = . dz j | . dz j & mask . tb + + base 10 j
-            = . dt j | . dt j & mask . tb + + base 15 j
-            = j + j 1
-        }
-        = e + e 1
-    }
+// Zero a gf in place.
+@ _gf_zero_into ( Vec i ) v → v {
+    : *i q ( vec_data [i] v )
+    = . q 0 0 = . q 1 0 = . q 2 0 = . q 3 0 = . q 4 0
 }
 
 // scalar·B via the comb → 32-byte little-endian Montgomery u (the X25519
@@ -634,15 +783,16 @@ $ `stdlib/core/vec.nu`
     ( _bset sc 0 & ( _x_bget scalar 0 ) 248 )
 
     : XEScr scr ( __xe_scr )
-    : ( Vec i ) d2 ( __xe_d2 )
-    : ( Vec i ) tbl ( __xe_comb_table )
+    : ( Vec i ) tbl ( __xe_ntbl )
     : XEP acc ( __xe_pt )
     : *i ay ( vec_data [i] . acc y ) : *i az ( vec_data [i] . acc z )
     = . ay 0 1 = . az 0 1
-    : XEP selp ( __xe_pt )
+    : ( Vec i ) syp ( _gf_zero )
+    : ( Vec i ) sym ( _gf_zero )
+    : ( Vec i ) std ( _gf_zero )
     : ~ i i 63
     ~ >= i 0 {
-        ( __xe_add scr acc acc d2 )
+        ( __xe_dbl scr acc )
         : ~ i idx 0
         : ~ i j 0
         ~ < j 4 {
@@ -651,8 +801,8 @@ $ `stdlib/core/vec.nu`
             = idx | idx << bit j
             = j + j 1
         }
-        ( __xe_tbl_get tbl idx selp )
-        ( __xe_add scr acc selp d2 )
+        ( __xe_ntbl_get tbl idx syp sym std )
+        ( __xe_madd scr acc syp sym std )
         = i - i 1
     }
 
@@ -665,8 +815,10 @@ $ `stdlib/core/vec.nu`
     ( _M uf num den )
     : ( Vec u ) out ( _pack25519 uf )
 
-    ( __xe_scr_free scr ) ( vec_free [i] d2 ) ( vec_free [i] tbl )
-    ( __xe_pt_free acc ) ( __xe_pt_free selp )
+    // tbl is the shared process-global niels table — never freed here.
+    ( __xe_scr_free scr )
+    ( __xe_pt_free acc )
+    ( vec_free [i] syp ) ( vec_free [i] sym ) ( vec_free [i] std )
     ( vec_free [u] sc ) ( vec_free [i] num ) ( vec_free [i] den ) ( vec_free [i] uf )
     ^ out
 }


### PR DESCRIPTION
## What

Five root fixes on the server-side TLS 1.3 handshake's crypto, found by profiling `bench/http_server.nu` under `oha --disable-keepalive` TLS load. The common theme: costs that bought nothing.

1. **`std/p256_field`: dedicated Montgomery squaring** (`_p256_sqr_d`, 10 products vs the multiply's 16). The point doubling, mixed addition and affine conversions that spelled `mul x x` now use it — 37% of a fixed-base comb's field ops are squarings, and a Fermat inversion is ~95%.
2. **`_p256_inv_d` is a fixed p−2 addition chain** (255 S + 13 M). The old ladder ran 256 S + 256 M with a constant-time select *per bit* — but p−2 is a **public** curve constant, so half of those multiplies were computed in order to be discarded. The data path stays branch-free; only the (public) schedule changed.
3. **`std/p256_scalar`'s k⁻¹** (`p256n_inv_be`) is a fixed 4-bit window over the public n−2 — one multiply per non-zero nibble instead of per set bit, and no per-bit limb copies.
4. **`std/x25519`'s `_inv25519` is the standard ref10 chain** (254 S + 11 M; the tweetnacl-style ladder it replaces multiplied on 252 of 254 steps). A handshake runs two of these.
5. **The X25519 keygen comb walks a niels-form table** — cached, one build per process — with a dedicated extended-coordinate doubling (4M+4S) and ref10 `ge_madd` mixed addition (7M) replacing two generic 9-M complete additions per iteration, and a 15-limb constant-time scan replacing 20 (Z = 1 is implicit in the niels shape). The old path re-materialised the 320-limb table on **every public key**. Same treatment for `std/hash_sha256`'s round-constant table, which was heap-built per `sha256_init` — one of which runs per HMAC leg of the key schedule and per RFC 6979 nonce step.

Dead code removed with the restructure: the generic `__xe_add` / `__xe_tbl_get` pair the comb no longer calls.

## Constant-time discipline

Unchanged where it matters: every value derived from **secret** data still moves through branch-free, mask-merged arithmetic (the comb scans, the ladder, the sign path). The only schedules that became data-dependent depend on public curve constants alone — the same argument ecdsa verify already relies on.

## Measured (local 12-core)

Single-core µs/op (before → after):

| op | before | after |
|---|---|---|
| X25519 keygen (base comb) | 43 | **30** |
| X25519 shared (ladder) | 65 | **61** |
| ECDSA P-256 sign | 99 | **85** |
| P-256 fixed-base comb | 60 | **52** |

End to end: the bench server answers **8.2k → 8.9k TLS handshakes/s** (+9%, `oha -n 8000 -c 20 --disable-keepalive`, success rate 1.0; the rustls peer does 10.9k on the same box).

## Verified

- RFC 7748 test vector, `x25519_base == x25519_base_comb`, DH symmetry over 50 random pairs (ladder vs comb cross-check).
- 500-element differential sweep: `sqr(a) == mul(a,a)` (incl. in-place aliasing), `mul(inv(a), a) == 1`.
- SHA-256 digest matched against Python hashlib after the K-table sharing.
- `./build.sh` — full corpus + bootstrap fixed point green; files `nurlfmt --write` canonical.

## Left open (recorded)

The biggest remaining lever is a ~1.5× **codegen constant** on the 4×64 carry-chain kernels: `_p256_mul_d` compiles to 388 instructions where clang on the equivalent `__int128` C CIOS emits ~250 (152 movs, 12 setb, ~1.8× duplicated adds at IR level). Minimal `nurl_mac_*` chains compile to perfect mul+adc code, so it is function-scale CSE/register-allocation behavior, not the primitives; SLP and inlining were ruled out. Worth more than this whole PR if solved — follow-up material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxLjWgGyferfDAkXCAhZyp