### PR TITLE
Release v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.58.0] — 2026-09-01
 
 ### Changed
 
@@ -112,55 +112,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measured concurrency; TLS c=200 req/s +7.5%, p99 5.21 → 3.12 ms,
   p99.9 9.09 → 5.37 ms. Non-Linux keeps the poll(2) reactor; it gains
   the batched global take unchanged.
-
-### Fixed
-
-- **ECDSA verification truncates a too-long digest instead of reducing it
-  as a full-width integer.** FIPS 186-5 §6.4.1 defines z as the LEFTMOST
-  qlen bits of the digest; the old BigInt path computed
-  `z = int(hash) mod n` over the whole digest, a different value whenever
-  the digest is longer than the curve — so every P-256 + SHA-384
-  signature the rest of the world accepts was rejected here (and an
-  off-standard value would have been accepted in its place). Found while
-  rebuilding the verify path below; pinned against OpenSSL across both
-  curves and five digest widths (SHA-1/256/384 × P-256/P-384) in
-  `compiler/tests/ecdsa_verify_matrix.nu`.
-
-- **`stdlib/ext/json.nu` passes the full JSONTestSuite — 283/283 must-accept /
-  must-reject verdicts correct.** Six `n_` documents parsed clean before, from
-  two roots:
-
-  * **The surrogate-pair lookahead consumed as it peeked.** After `\uD800`,
-    a `\` was swallowed before knowing whether `u` followed — so in
-    `["\uD800\"]` the escape lost its backslash, the stray quote closed the
-    string, and a document whose string never terminates parsed successfully.
-    And when `\u` did follow with malformed hex (`\u`, `\u1`, `\u1x`,
-    `\uDd"`), a code path its own comment called "best-effort recovery"
-    dropped the error a plain `\uZZZZ` raises. The lookahead is now pure —
-    `\u` is consumed only after both bytes matched, and once consumed the
-    four digits must be hex, the rule every other escape lives by. A
-    complete-but-unpaired surrogate stays accepted as U+FFFD (RFC 8259
-    leaves it undefined), and a value that breaks a pair re-enters the
-    pairing loop, so `\uD800` followed by a real pair still decodes the
-    real code point.
-
-  * **`json_parse` takes `s`, so the document ended at the first NUL** —
-    `123\0` truncated to `123` and parsed clean. The parser was already
-    length-based internally; only the entry ran `strlen`. New entries carry
-    the length end to end: `json_parse_n src len` (the root entry — an
-    embedded NUL is an ordinary rejected byte) and `json_parse_bytes buf`
-    for `( Vec u )` payloads (network buffers, `read_file_bytes` results).
-    `json_parse` is now a documented C-string wrapper over `json_parse_n`.
-
-  `tools/json_conformance.sh` runs the full suite against the byte-exact
-  harness (clones JSONTestSuite shallow when absent); the six regressions
-  plus the pairing/NUL semantics are pinned by
-  `compiler/tests/json_surrogate_lookahead.nu`. Parse throughput is
-  unchanged (measured A/B on `bench/json_parse`), and the parser fuzzer's
-  3000-iteration ASan+UBSan pass stays clean.
-
-
-### Changed
 
 - **ECDSA verification left the BigInt field: P-256 verify is 93× faster
   (37 ms → 0.4 ms), P-384 50× (85 ms → 1.7 ms).** Verification is the
@@ -295,6 +246,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `compress_rawdeflate` test freed the whole `!ZInflate CompressErr`
   RESULT value on its failure arms — heap corruption armed in dead
   code, four sites.
+
+### Fixed
+
+- **ECDSA verification truncates a too-long digest instead of reducing it
+  as a full-width integer.** FIPS 186-5 §6.4.1 defines z as the LEFTMOST
+  qlen bits of the digest; the old BigInt path computed
+  `z = int(hash) mod n` over the whole digest, a different value whenever
+  the digest is longer than the curve — so every P-256 + SHA-384
+  signature the rest of the world accepts was rejected here (and an
+  off-standard value would have been accepted in its place). Found while
+  rebuilding the verify path below; pinned against OpenSSL across both
+  curves and five digest widths (SHA-1/256/384 × P-256/P-384) in
+  `compiler/tests/ecdsa_verify_matrix.nu`.
+
+- **`stdlib/ext/json.nu` passes the full JSONTestSuite — 283/283 must-accept /
+  must-reject verdicts correct.** Six `n_` documents parsed clean before, from
+  two roots:
+
+  * **The surrogate-pair lookahead consumed as it peeked.** After `\uD800`,
+    a `\` was swallowed before knowing whether `u` followed — so in
+    `["\uD800\"]` the escape lost its backslash, the stray quote closed the
+    string, and a document whose string never terminates parsed successfully.
+    And when `\u` did follow with malformed hex (`\u`, `\u1`, `\u1x`,
+    `\uDd"`), a code path its own comment called "best-effort recovery"
+    dropped the error a plain `\uZZZZ` raises. The lookahead is now pure —
+    `\u` is consumed only after both bytes matched, and once consumed the
+    four digits must be hex, the rule every other escape lives by. A
+    complete-but-unpaired surrogate stays accepted as U+FFFD (RFC 8259
+    leaves it undefined), and a value that breaks a pair re-enters the
+    pairing loop, so `\uD800` followed by a real pair still decodes the
+    real code point.
+
+  * **`json_parse` takes `s`, so the document ended at the first NUL** —
+    `123\0` truncated to `123` and parsed clean. The parser was already
+    length-based internally; only the entry ran `strlen`. New entries carry
+    the length end to end: `json_parse_n src len` (the root entry — an
+    embedded NUL is an ordinary rejected byte) and `json_parse_bytes buf`
+    for `( Vec u )` payloads (network buffers, `read_file_bytes` results).
+    `json_parse` is now a documented C-string wrapper over `json_parse_n`.
+
+  `tools/json_conformance.sh` runs the full suite against the byte-exact
+  harness (clones JSONTestSuite shallow when absent); the six regressions
+  plus the pairing/NUL semantics are pinned by
+  `compiler/tests/json_surrogate_lookahead.nu`. Parse throughput is
+  unchanged (measured A/B on `bench/json_parse`), and the parser fuzzer's
+  3000-iteration ASan+UBSan pass stays clean.
+
+- **`nurlpkg install swarm-mcp` had been broken since v0.55.0, and eight
+  packages resolved a different dependency from the registry than this
+  tree builds against.** Two v0.55.0 compiler changes reached the
+  published swarm-mcp 0.28.1 tarball and neither had been republished
+  past: #1032 made a closure body that falls off its end drop what it
+  bound, so the package's hand-written free of a map key became the
+  second free (`'ks' is auto-dropped at the end of its scope`), and
+  #1025 closed the print family under one rule, after which
+  `nurl_print_int` no longer ends the line — this package *generates*
+  the NURL kernels it compiles to wasm and they print their result with
+  it, so a toolchain that still compiled 0.28.1 produced unparsable
+  output rather than a refused build. A wrong answer, not a failure. The
+  fixes were already in the tree; only the release was missing.
+  swarm-mcp 0.28.2 is published, its minimum toolchain moves v0.10.12 →
+  v0.55.0, and `tests/shuffle_smoke.sh` passes 5/5 against a real GPU
+  including the 1000-key multi-chunk merge.
+
+  The same sweep pinned every `[dependencies]` requirement across
+  `packages/` to the **major** (`^0`, `^1`). Caret locks the *minor* on
+  0.x, so `gpukit ^0.6` resolved to a 0.6 series while the monorepo
+  builds against 0.7.1 — the same commit building differently from the
+  registry than it does here. That was real in eight packages: grad,
+  tensor, onnx, yoloe, nurllama, mlp, lingbot-map, map-anything (and
+  mlp's `grad ^0.8` against a tree at 0.10). The trade is deliberate and
+  worth saying out loud: `^0` also accepts a 0.x minor that breaks, and
+  when a package really breaks compatibility the answer is to take the
+  major to 1.0, not to narrow the pin again. All 19 packages are
+  republished, and `onnx 0.8.1` installed from the registry now resolves
+  `gpukit 0.7.1`.
+
+  A follow-up caught what the sweep's own scan could not: three packages
+  print their version through a literal that carries the package name
+  next to it (`( nurl_print `lingbot-map 0.9.4\n` )`), which a search for
+  a bare version number never matches — `tools/check_package_version_strings.sh`
+  did. lingbot-map 0.9.6, map-anything 0.4.4 and nurllama 0.17.4 carry
+  the correction, byte-identical to the versions they replace apart from
+  that literal.
 
 ## [0.57.0] — 2026-08-30
 
@@ -17056,7 +17091,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.57.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.58.0...HEAD
+[0.58.0]: https://github.com/nurl-lang/nurl/compare/v0.57.0...v0.58.0
 [0.57.0]: https://github.com/nurl-lang/nurl/compare/v0.56.0...v0.57.0
 [0.56.0]: https://github.com/nurl-lang/nurl/compare/v0.55.0...v0.56.0
 [0.55.0]: https://github.com/nurl-lang/nurl/compare/v0.54.0...v0.55.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-30 · Current release: **0.57.0** · Language: **Grammar
+_Last reviewed: 2026-09-01 · Current release: **0.58.0** · Language: **Grammar
 v2.7** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -87,7 +87,17 @@ What is solid today:
   it is spelled, and `% NotSend` / `% Send` mark the cases a structural
   derivation cannot see either way. It is a sound lint, not a proof:
   [`docs/MEMORY.md`](docs/MEMORY.md) §6.5 states what it does and does
-  not guarantee.
+  not guarantee. Since 0.58.0 the Linux I/O path has no reactor thread:
+  an **idle worker becomes the poller** and blocks in `epoll_wait`
+  itself, so a ready fiber resumes on that worker with no queue hop, no
+  cross-thread wake and no migration (the Go netpoller / tokio driver
+  shape). Sockets register once per fd lifetime, edge-triggered, and
+  readiness that arrives while the fiber computes is banked so the next
+  wait skips the park entirely. The surplus a saturated poller cannot
+  keep spills into a **fair global FIFO** taken in batches, which is
+  what keeps the tail flat under load; non-Linux POSIX keeps the
+  portable `poll(2)` reactor. The contract — a wait may only follow an
+  `EAGAIN` — is in [`docs/ASYNC.md`](docs/ASYNC.md).
 - **Standard library.** A broad pure-NURL stdlib (see the inventory below)
   spanning collections, hashing, serialization, a full HTTP/1.1+2 + WebSocket
   stack, database clients, distributed systems (p2p overlay, CRDTs), MCP, and the Anthropic Claude API.
@@ -135,7 +145,14 @@ A high-level map of what exists. Dates and per-feature detail are in
   conversions. Sized integer/float types with **signedness carried in the
   type representation itself** (`u`/`u16`/`u32`/`u64` distinct from the
   signed types end to end — no flag side-channels); explicit `#` casts with
-  correct `sext`/`zext`/`trunc`/`fpext`/`fptrunc`.
+  correct `sext`/`zext`/`trunc`/`fpext`/`fptrunc`. Since 0.58.0 every value
+  boundary — return and every argument path, including generic
+  instantiations, trait-method dispatch, closure/fn-pointer invocation
+  and `%Trait` dynamic dispatch — ends in a **total-agreement
+  backstop**: after the sanctioned coercions the value's lowered type
+  must equal the declared one, so a pair nobody enumerated is a
+  diagnostic rather than a `call` clang assembles and the callee reads
+  as garbage ([`docs/spec.md` §4.1](docs/spec.md)).
 - Generics: monomorphised generic structs and functions (signedness-aware
   monomorphs, including behind `*`/`?` prefixes), generic nesting
   (`Channel[A]`, `Vec[Thread]`), and generics over `?T` / `!T E`.
@@ -227,8 +244,9 @@ platform-specific shims.
   HTTP/2 CONTINUATION-flood + stream-accounting, and clean cross-thread
   listener shutdown) with regression tests, and its serve path is
   peer-benchmarked against Rust hyper and Node
-  ([`bench/HTTP_RESULTS.md`](bench/HTTP_RESULTS.md): ahead of hyper at
-  low concurrency, an HTTP request served in 2 syscalls).
+  ([`bench/HTTP_RESULTS.md`](bench/HTTP_RESULTS.md): since 0.58.0 ahead
+  of hyper on req/s, p50, p95 *and* p99 at every measured concurrency,
+  an HTTP request served in 2 syscalls).
 - **ext/data services** — `sqlite` (production-hardened), `mqtt` 5.0 client,
   `smtp` (mail submission). Postgres and Redis clients live in the registry
   packages `psql` and `redis` (pure NURL — no libpq, no hiredis).

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -4,7 +4,9 @@ NURL reaches the network through a pure-POSIX socket layer in the C runtime
 (`nurl_tcp_*` / `nurl_udp_*` / `nurl_dns_*`) — no framework, and no libcurl
 at this layer. (The stdlib HTTP *client* `ext/http.nu` and the reverse proxy
 are separate, optional libcurl bridges.) Four primitives, every one
-dual-stack IPv4/IPv6 and integrated with the fiber reactor for async I/O.
+dual-stack IPv4/IPv6 and integrated with the fiber scheduler's I/O layer
+for async I/O — the `epoll` netpoller on Linux, the portable `poll(2)`
+reactor elsewhere (see [`ASYNC.md`](ASYNC.md)).
 
 - **TCP server** — `tcp_listen` / `tcp_listen_tls` + `tcp_accept`, with a full
   HTTP/1.1 server stack on top (`stdlib/ext/http_*` — routing, static files,

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -107,7 +107,11 @@ exists, and the tarball still fails to build for everyone who installs
 it. If no installed compiler is found the gate WARNs and lets the
 publish through rather than passing silently — an unverifiable check
 should say so. `--dry-run` runs all five and uploads nothing (and needs
-no token).
+no token). Know what that gate does **not** cover: a **library** package
+has no `src/main.nu`, so the compile gate returns success without
+compiling anything — `every gate passed` on a library means the manifest
+and the imports agree, not that the code builds. Run `nurlpkg test`
+against a library before publishing it.
 
 `self-update` is the odd one out: it upgrades the **toolchain**, not a
 package, and `nurl upgrade` is its canonical spelling (that is what the

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -475,6 +475,32 @@ not into a field, a binding, an assignment, or a return value; the
 explicit cast `# *T expr` converts intentionally, and `# *T 0` is the
 null pointer.
 
+Those classes are the *named* ones, not the boundary's definition. Since
+0.58.0 every value boundary — return, and every argument path — ends
+with a **total-agreement backstop**: after the sanctioned coercions
+above (integer and float widths, the enum wrap, the FFI NULL/handle
+`inttoptr` bridge), the value's lowered LLVM type must **equal** the
+declared one, pointer-beside-pointer excepted, since opaque pointers
+are one LLVM type. A pair that matches no branch is a diagnostic, not a
+hole. This matters because the bad instruction *assembles*:
+`ret { i1, i64 } %o` out of an `i64` function, or
+`call i64 @f({ i1, i64 } %v)` against `declare i64 @f(i64)`, are both
+accepted by clang — a call carries its own signature — and the callee
+reads whichever bytes the ABI left in the register. Garbage, not a
+crash. The backstop covers the aggregate-shaped types the pairwise
+list never named (option, result, slice and closure values beside
+scalars, pointers and named structs), a `void` expression used as an
+argument, and an FFI pointer passed where an integer parameter is
+declared (a silent `ptrtoint` of the string's *address*; write `# i x`
+to mean it, while `( free 0 )` and handle-to-pointer stay legal). It
+runs on **every** call path, not only direct calls to non-generic
+functions: generic instantiations, trait-method dispatch, closure and
+fn-pointer invocations, and `%Trait` dynamic dispatch each check their
+assembled arguments against the callee's declared roster. A closure
+returned where its own *result* type is declared is the `^ f( r )`
+C-style-call typo, and the diagnostic names the parenthesised prefix
+form to write instead.
+
 A **condition** (`?` / `~`) must be `b` or an integer (tested non-zero).
 A float, pointer/string, enum, or aggregate condition is rejected with
 the comparison to write instead — none of them has a truth value.

--- a/packages/README.md
+++ b/packages/README.md
@@ -21,8 +21,8 @@ on `$PATH`).
 
 ```toml
 [dependencies]
-onnx  = { path = "../onnx", version = "^0.4.2" }   # monorepo path + registry version
-chart = "^0.1.1"                                     # registry-only, shorthand
+onnx  = { path = "../onnx", version = "^0" }   # monorepo path + registry version
+chart = "^0"                                  # registry-only, shorthand
 ```
 
 `path` drives local/monorepo builds (resolved by symlink; `nurlpkg install`
@@ -59,15 +59,23 @@ segment — the everyday choice:
 | `^0.2.3` | `>=0.2.3 <0.3.0` | `0.2.x >= 0.2.3`, not `0.3.0` |
 | `^0.0.3` | `>=0.0.3 <0.0.4` | only `0.0.3` |
 
-For a `0.x` package caret locks the **minor** (`^0.2.3` won't jump to `0.3.0`),
-so every `0.x` package here pins deps with `^` and bumps its **minor** on a
-breaking change, **patch** on a fix.
+For a `0.x` package caret locks the **minor** (`^0.2.3` won't jump to
+`0.3.0`), and every `0.x` package here bumps its **minor** on a breaking
+change, **patch** on a fix.
 
 **`~` (tilde)** allows patch-level moves only: `~1.2.3` ⇒ `>=1.2.3 <1.3.0`,
 `~1.2` ⇒ `>=1.2.0 <1.3.0`, `~1` ⇒ `>=1.0.0 <2.0.0`.
 
-**Convention:** depend with `^<version>` (newest compatible); a bare `1.2.3`
-pins exactly — use it only when you must. The engine is
+**Convention (since 0.58.0):** depend on the **major** — `^0`, `^1` —
+not on a full version. `^0.6` locks the minor, so a package requiring
+`gpukit ^0.6` resolved a 0.6 series from the registry while the monorepo
+built it against 0.7.1: the same commit, built two different ways
+depending on where its dependency came from. Every `[dependencies]`
+requirement under `packages/` now names the major only. The trade is
+deliberate and worth saying out loud — `^0` also accepts a `0.x` minor
+that breaks, and when a package really breaks compatibility the answer
+is to take its major to 1.0, not to narrow the pin again. A bare
+`1.2.3` pins exactly; use it only when you must. The engine is
 `stdlib/ext/semver.nu`.
 
 ## `nq/` — a jq-lite JSON query tool (installable program)
@@ -106,7 +114,7 @@ md2html -f README.md --full      # complete styled page
 
 # …or depend on the renderer library:
 #   [dependencies]
-#   md2html = "^0.1"
+#   md2html = "^0"
 #   $ `deps/md2html/src/markdown.nu`
 #   : String html ( md_to_html ( string_data src ) )
 ```
@@ -132,7 +140,7 @@ chart line -f temps.txt --height 12                      # line plot from a file
 
 # …or depend on the renderer library:
 #   [dependencies]
-#   chart = "^0.1"
+#   chart = "^0"
 #   $ `deps/chart/src/chart.nu`
 #   : String spark ( chart_sparkline values )
 ```
@@ -160,7 +168,7 @@ lsmdb compact                        # merge tables, reclaim space
 
 # …or depend on the store itself:
 #   [dependencies]
-#   lsmdb = "^0.1"
+#   lsmdb = "^0"
 #   $ `deps/lsmdb/src/lsmdb.nu`
 #   : !*Lsm String db ( lsm_open `/var/db/things` )
 ```


### PR DESCRIPTION
Release v0.58.0

Minor, on the usual rule: the compiler now rejects code it used to accept.
Both value boundaries — return and every argument path — were batteries of
pairwise checks, so every pair nobody enumerated fell through to the emitter
and assembled anyway (`ret { i1, i64 }` out of an i64 function; a call whose
own signature disagrees with the callee's). Each boundary now ends with a
total-agreement backstop: after the sanctioned coercions the value's lowered
type must equal the declared one. It closed the aggregate shapes, generic
instantiations, trait-method dispatch, closure/fn-ptr and dyn-trait calls,
FFI pointer-into-integer, and a void argument — and immediately found four
armed double-frees in the tree's own compress test.

The performance half is the whole serve path. On Linux the I/O reactor thread
is gone: an idle worker becomes the poller and a ready fiber resumes on it,
with the surplus spilling into a fair global FIFO so the tail stays flat under
saturation (c=200 p99 3.09 -> 2.17 ms at higher throughput; TLS p99 5.21 ->
3.12). NURL's HTTP facade now leads its tokio/hyper peer on req/s, p50, p95
and p99 at every measured concurrency. Crypto: ECDSA verify left the BigInt
field (P-256 93x, P-384 50x, on the new std/p384_field), the handshake dropped
costs that bought nothing (+9% handshakes/s), and the wide-arithmetic pairs
stopped splitting before they could fuse (P-256 -25..-30%).

Also in: full JSONTestSuite conformance — the surrogate lookahead consumed as
it peeked and `json_parse` ended the document at the first NUL, so
`json_parse_n` / `json_parse_bytes` carry the length end to end. And a
too-long digest is now truncated per FIPS 186-5 rather than reduced, which is
why P-256 + SHA-384 signatures the rest of the world accepts were rejected
here.

The registry half is #1041: `nurlpkg install swarm-mcp` had been broken since
v0.55.0 (0.28.2 published), and every packages/ dependency now pins the MAJOR
— `gpukit ^0.6` had been resolving a 0.6 series from the registry while this
tree built against 0.7.1. That PR wrote only its own package changelogs, so
the section here is written at release time.

Docs audited rather than assumed. `docs/spec.md` §4 still described the
boundary as a list of named coercion classes — the exact framing #1042
replaced — so it now states the backstop law. `packages/README.md` still told
readers to depend with `^<version>` and said every package here pins that way,
both false as of #1041. `docs/TOOLING.md` said publish typechecks src/main.nu
without saying the gate returns success for a library that has none.
`docs/NETWORKING.md` still called the async path "the fiber reactor".
ROADMAP's concurrency, type-system and HTTP paragraphs each stopped one
release short. docs/ASYNC.md and docs/CRYPTO.md landed with their PRs.

Verified: bootstrap fixed point, full test suite, 102 examples, and the gate
battery — windows goldens, golden twins, diagnostic anchors, diagnostic
coverage, strict-arity, stdlib symbols, nolibc symbols, installer sync,
package version strings, package imports, builtins doc, windows paths.
`tools/gen-site-facts.sh` reads 0.58.0 from the new heading.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XE8RbUYsrztCRSEeNJGQ9x
