### PR TITLE
http: write the response head and body as one sendmsg — no body copy into the wire buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The HTTP server no longer copies the response body into the
+  connection's wire buffer.** `__write_response` serialises only the
+  head (status line, headers, blank line) into `wire` and writes head
+  and body as two segments of one message with the new
+  `tcp_write_all2` — a single `sendmsg(2)` with a two-entry iovec
+  (`nurl_tcp_write2` in the runtime; `WSASend` on Windows), so small
+  responses keep their one-syscall cost. That concat was the second
+  full copy of every response body (the first is
+  `response_set_body_*`); the open-loop torture harness
+  (`bench/http_torture`) had put it at roughly half of the 1 MB
+  per-request CPU gap to hyper. On TLS the record layer now cuts
+  records straight from the head/body pair (`tls_server_write2`,
+  `tls_write2`) with the same record boundaries as before.
+  `response_serialize_to` / `response_serialize` are unchanged for
+  other callers (proxy, WebSocket handshake); the new
+  `response_serialize_head_to` is the head-only half.
+- `tcp_write_all`, `tcp_write_str` and `tcp_write_all_async` now share
+  one send loop each (blocking / fiber) with `tcp_write_all2` instead
+  of three hand-copied ones; the short-count / EAGAIN / SO_SNDTIMEO
+  rules are unchanged and live in one place in the runtime too
+  (`nurl__tcp_short_send`).
+
+### Fixed
+
+- **Single-worker fiber scheduler crashed the first time a fiber landed
+  on the global run queue.** `nurl__rq_take_global_batch` takes
+  `len / worker_count + 1` fibers; with one worker that is `len + 1`,
+  the walk stepped past the last fiber and dereferenced NULL. Every
+  `NURL_WORKERS=1` run — and every one-CPU container using the per-core
+  default — hit it under the first real load. The share is now capped
+  at the queue length.
+
 ## [0.58.0] — 2026-09-01
 
 ### Changed

--- a/bench/http_torture/TORTURE_RESULTS.md
+++ b/bench/http_torture/TORTURE_RESULTS.md
@@ -2,86 +2,86 @@
 
 Open-loop, coordinated-omission corrected (`oha -q --latency-correction`). Server pinned to cores `0-5`, generator to `6-11`. Both peers serve byte-identical bodies. MODE=**full**.
 
-- Host: `Linux 7.0.0-30-generic` — Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz (6 cores pinned to the server, 6 to the generator)
-- NURL: `v0.57.0-23-g259400a3-dirty`  ·  oha: `oha 1.8.0`
+- Host: `Linux 7.0.0-30-generic` — Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz
+- NURL: `v0.58.0-1-gbbaa3646-dirty`  ·  oha: `oha 1.8.0`
 - Sustainable capacity = highest offered rate with achieved ≥ 97% of target and p99 ≤ 50 ms.
 
 ### Body 1k — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 168 000 | 0.779/8.465/21.310 | 1.020/45.488/79.241 | 1.424/92.601/110.330 |
-| RUST | 168 000 | 0.887/8.868/47.005 | 1.110/55.377/95.853 | 1.261/80.584/105.362 |
+| NURL | 192 000 | 0.811/8.261/28.709 | 1.114/64.142/96.992 | 1.881/111.539/133.070 |
+| RUST | 192 000 | 0.957/20.050/46.970 | 1.130/87.576/119.026 | 2.042/136.371/149.653 |
 
 ### Body 16k — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 100 000 | 0.694/3.014/10.663 | 0.989/25.509/48.551 | 1.959/49.966/64.952 |
-| RUST | 120 000 | 0.863/16.767/48.082 | 1.152/22.403/47.157 | 1.807/114.979/124.604 |
+| NURL | 124 000 | 0.746/9.059/42.540 | 1.062/19.916/50.366 | 2.089/107.729/126.069 |
+| RUST | 116 000 | 0.907/15.767/53.909 | 1.094/23.761/52.437 | 1.509/104.022/130.995 |
 
 ### Body 1m — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 1 500 | 1.701/4.690/7.474 | 1.816/5.157/13.467 | 1.912/5.088/11.476 |
-| RUST | 3 250 | 1.331/2.763/4.839 | 1.237/2.465/7.040 | 1.004/6.050/23.682 |
+| NURL | 2 250 | 1.463/3.978/5.716 | 1.705/3.742/5.456 | 1.760/3.934/12.590 |
+| RUST | 3 000 | 1.335/2.688/3.605 | 1.381/2.559/5.383 | 1.245/2.408/7.406 |
 
 ### Body 1k — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 2351360 | 59.18 | 25.17 |
-| RUST | 2351340 | 63.16 | 26.86 |
+| NURL | 2687340 | 65.59 | 24.41 |
+| RUST | 2687340 | 66.26 | 24.66 |
 
 ### Body 16k — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 1399640 | 57.41 | 41.02 |
-| RUST | 1679540 | 60.26 | 35.88 |
+| NURL | 1735600 | 61.25 | 35.29 |
+| RUST | 1623520 | 60.29 | 37.14 |
 
 ### Body 1m — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 21000 | 27.80 | 1323.81 |
-| RUST | 45480 | 36.99 | 813.32 |
+| NURL | 31480 | 35.79 | 1136.91 |
+| RUST | 41980 | 38.67 | 921.15 |
 
 ### Body 1k — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 42 732 | 2.249/4.929/7.203 | 1.0000 |
-| RUST | 45 791 | 2.136/3.882/6.142 | 1.0000 |
+| NURL | 44 387 | 2.194/4.005/6.449 | 1.0000 |
+| RUST | 46 620 | 2.104/3.743/5.851 | 1.0000 |
 
 ### Body 16k — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 41 026 | 2.354/4.876/7.467 | 1.0000 |
-| RUST | 44 070 | 2.226/3.992/6.506 | 1.0000 |
+| NURL | 42 384 | 2.307/4.089/6.448 | 1.0000 |
+| RUST | 44 846 | 2.192/3.836/6.032 | 1.0000 |
 
 ### Body 1m — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 1 505 | 59.794/169.878/214.200 | 1.0000 |
-| RUST | 2 617 | 37.225/64.576/87.937 | 1.0000 |
+| NURL | 1 924 | 49.930/96.557/127.046 | 1.0000 |
+| RUST | 2 749 | 35.820/53.817/71.250 | 1.0000 |
 
 ### Slowloris — 200 trickle clients held open, fast-client latency meanwhile (16k)
 
 | Server | fast-client req/s | p50/p99 (ms) | survived |
 |---|--:|--:|:--:|
-| NURL | 118 279 | 0.139/0.591 | yes |
-| RUST | 141 595 | 0.118/0.432 | yes |
+| NURL | 125 020 | 0.134/0.503 | yes |
+| RUST | 145 582 | 0.116/0.415 | yes |
 
 ### Keep-alive scale — 2000 concurrent keep-alive connections (1k body)
 
 | Server | conns | req/s | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|--:|
-| NURL | 2000 | 171 994 | 11.026/21.803/31.676 | 1.0000 |
-| RUST | 2000 | 170 705 | 11.263/21.900/32.763 | 1.0000 |
+| NURL | 2000 | 178 421 | 10.819/19.454/26.152 | 1.0000 |
+| RUST | 2000 | 174 374 | 11.190/20.651/29.592 | 1.0000 |
 
 ### TLS 1.3 session resumption — does a reconnect skip the full handshake?
 
@@ -94,13 +94,13 @@ Open-loop, coordinated-omission corrected (`oha -q --latency-correction`). Serve
 
 | Server | req/s | p50/p99/p99.9 (ms) | ok | errors |
 |---|--:|--:|--:|--:|
-| NURL | 79 999 | 0.985/1011.032/2031.960 | 1.0000 | 7 (RSS 3096→26712 KiB) |
-| RUST | 95 999 | 1.183/657.577/1478.105 | 1.0000 | 3 (RSS 4500→9656 KiB) |
+| NURL | 99 199 | 1.066/729.250/1514.766 | 1.0000 | 4 (RSS 3108→11672 KiB) |
+| RUST | 92 799 | 1.083/501.461/1392.449 | 1.0000 | 8 (RSS 4572→9448 KiB) |
 
 ---
 
 ### Reading these numbers
 
-- **1 KB capacity is generator-bound, not a server ceiling.** When both servers report the *same* sustainable rate for 1 KB, that is `oha` on `6-11` hitting its own generation limit, not the servers saturating — the honest 1 KB conclusion is "both faster than this host can drive," i.e. a tie at the floor of the generator's ceiling.
-- **The gap grows with body size** (1 KB → 16 KB → 1 MB), which is the signature of a per-byte data-path cost, not a fixed per-request one. The CPU-per-request rows at 1 MB show it directly (NURL 1324 µs/req vs Rust 813 µs/req).
-- **The soak tail is largely environmental.** A 600 s run on a shared workstation is exposed to system scheduling the 20 s load-level runs are not, and coordinated-omission correction back-charges every hiccup — which is why *both* servers show an inflated soak p99 (NURL 1011 ms, Rust 658 ms). Compare the two servers to each other, and read the **RSS delta** as the server-specific signal: NURL grows more (24 MB vs 5 MB) but bounded — per-connection wire-buffer high-water, freed at connection close.
+- **1 KB capacity is generator-bound, not a server ceiling.** When both servers report the *same* sustainable rate for 1 KB, that is `oha` on 6-11 hitting its own generation limit, not the servers saturating — the honest 1 KB conclusion is "both faster than this host can drive," i.e. a tie at the floor of the generator's ceiling.
+- **Read the body-size axis as the data path.** A difference that grows from 1 KB to 16 KB to 1 MB is a per-byte cost, not a per-request one; the CPU-per-request rows make it visible directly. The first such cost found by this harness — the response body being copied into the connection's wire buffer before the write — was removed (head and body now leave in one `sendmsg`); what remains at 1 MB is the inbound copy `response_set_body_bytes` makes of the handler's buffer, which hyper's `Bytes::clone` does not pay.
+- **The soak tail is largely environmental.** A 600 s run on a shared workstation is exposed to system scheduling the 20 s load-level runs are not, and coordinated-omission correction back-charges every hiccup — which is why *both* servers show a inflated soak p99. Compare the two servers to each other, and read the **RSS delta** as the server-specific signal (bounded per-connection buffer high-water, freed at connection close).

--- a/bench/http_torture/run_torture.sh
+++ b/bench/http_torture/run_torture.sh
@@ -362,7 +362,7 @@ main() {
   add "### Reading these numbers"
   add ""
   add "- **1 KB capacity is generator-bound, not a server ceiling.** When both servers report the *same* sustainable rate for 1 KB, that is \`oha\` on ${GEN_CORES} hitting its own generation limit, not the servers saturating — the honest 1 KB conclusion is \"both faster than this host can drive,\" i.e. a tie at the floor of the generator's ceiling."
-  add "- **The gap grows with body size** (1 KB → 16 KB → 1 MB), which is the signature of a per-byte data-path cost, not a fixed per-request one. The CPU-per-request rows at 1 MB show it directly."
+  add "- **Read the body-size axis as the data path.** A difference that grows from 1 KB to 16 KB to 1 MB is a per-byte cost, not a per-request one; the CPU-per-request rows make it visible directly. The first such cost found by this harness — the response body being copied into the connection's wire buffer before the write — was removed (head and body now leave in one \`sendmsg\`); what remains at 1 MB is the inbound copy \`response_set_body_bytes\` makes of the handler's buffer, which hyper's \`Bytes::clone\` does not pay."
   add "- **The soak tail is largely environmental.** A 600 s run on a shared workstation is exposed to system scheduling the 20 s load-level runs are not, and coordinated-omission correction back-charges every hiccup — which is why *both* servers show a inflated soak p99. Compare the two servers to each other, and read the **RSS delta** as the server-specific signal (bounded per-connection buffer high-water, freed at connection close)."
   printf '%s' "$report" > "$HT/TORTURE_RESULTS.md"
   say ""; say "report -> $HT/TORTURE_RESULTS.md   (scratch: $SCRATCH)"

--- a/compiler/tests/net_write_pair.nu
+++ b/compiler/tests/net_write_pair.nu
@@ -1,0 +1,165 @@
+// net_write_pair.nu — the two-segment write path behind the HTTP server:
+// `response_serialize_head_to` + `tcp_write_all2` (head and body as one
+// message through one sendmsg) must put exactly the bytes on the wire
+// that the single-buffer `response_serialize` + `tcp_write_all` did.
+//
+// Round-trip over a real loopback socket, blocking (off-fiber) path:
+//   1. Listen on 127.0.0.1:18766.
+//   2. Spawn a python3 client that connects, SLEEPS before reading (so
+//      the 3 MB body fills the socket buffer and the send loop has to
+//      continue from short counts, across the head/body boundary), then
+//      reads to EOF and prints total length + sha256 of the stream.
+//   3. Server accepts and writes two responses with tcp_write_all2:
+//      a 3 MB octet-stream (head in the wire buffer, body still in the
+//      response — the pair path) and a 204 with an EMPTY body (the
+//      one-segment-empty path), then closes.
+//   4. Checks that head‖body is byte-identical to response_serialize,
+//      and that the client saw the whole stream.
+// requires: live fibers python3
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/process.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/http_response.nu`
+
+@ python_client_src → s {
+    ^ `import socket,sys,time,hashlib
+s = socket.create_connection(('127.0.0.1', 18766), timeout=10.0)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 16384)
+time.sleep(0.4)
+h = hashlib.sha256()
+n = 0
+while True:
+  chunk = s.recv(65536)
+  if not chunk: break
+  h.update(chunk)
+  n += len(chunk)
+s.close()
+sys.stdout.write('%d %s' % (n, h.hexdigest()[:16]))
+`
+}
+
+@ print_label_str s label s value → v {
+    ( nurl_print label )
+    ( nurl_print `=` )
+    ( nurl_print value )
+    ( nurl_print `\n` )
+}
+
+@ print_label_bool s label b v → v {
+    ( nurl_print label )
+    ( nurl_print `=` )
+    ( nurl_print ? v `T` `F` )
+    ( nurl_print `\n` )
+}
+
+// Print header bytes with CR/LF made visible, as http_response_builder does.
+@ dump_head ( Vec u ) bytes → v {
+    : i n ( vec_len [u] bytes )
+    : *u data ( vec_data [u] bytes )
+    : ~ i k 0
+    ~ < k n {
+        : i ib # i . data k
+        ? == ib 13 { ( nurl_print `\\r` ) } {}
+        ? == ib 10 { ( nurl_print `\\n\n` ) } {}
+        ? & != ib 13 != ib 10 {
+            : String tmp ( string_with_cap 1 )
+            ( string_push_char tmp ib )
+            ( nurl_print ( string_data tmp ) )
+            ( string_free tmp )
+        } {}
+        = k + k 1
+    }
+}
+
+// Deterministic 3 MB body: byte k = (7k + 3) mod 256.
+@ make_body i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] v # u & + * k 7 3 255 )
+        = k + k 1
+    }
+    ^ v
+}
+
+// T when head‖body == full, bytewise.
+@ pair_equals_full ( Vec u ) head ( Vec u ) body ( Vec u ) full → b {
+    : ( Vec u ) joined ( vec_with_cap [u] + ( vec_len [u] head ) ( vec_len [u] body ) )
+    ( bytes_extend_bytes joined head )
+    ( bytes_extend_bytes joined body )
+    : b eq ( bytes_eq joined full )
+    ( vec_free [u] joined )
+    ^ eq
+}
+
+@ write_pair TcpConn conn s label HttpResponse r ( Vec u ) wire → v {
+    ( vec_clear [u] wire )
+    ( response_serialize_head_to r wire )
+    ( nurl_print `── ` ) ( nurl_print label ) ( nurl_print ` head ──\n` )
+    ( dump_head wire )
+    : ( Vec u ) full ( response_serialize r )
+    ( print_label_bool `head_plus_body_equals_serialize` ( pair_equals_full wire . r body full ) )
+    ( vec_free [u] full )
+    : !v NetErr wr ( tcp_write_all2 conn wire . r body )
+    ?? wr {
+        T _ → ( print_label_str `write` `OK` )
+        F e → ( print_label_str `write` ( net_err_name e ) )
+    }
+    ( http_response_free r )
+}
+
+@ main → i {
+    : !TcpListener NetErr lr ( tcp_listen_with_backlog `127.0.0.1` 18766 4 )
+    ?? lr {
+        T listener → {
+            : s pyclient ( python_client_src )
+            : s shell_cmd `rm -f /tmp/net_write_pair_client.out /tmp/net_write_pair_client.part; { python3 -c "$NURL_PYCLIENT" > /tmp/net_write_pair_client.part 2> /tmp/net_write_pair_client.err; mv /tmp/net_write_pair_client.part /tmp/net_write_pair_client.out; } >/dev/null 2>&1 &`
+            : !v IoErr _es ( env_set `NURL_PYCLIENT` pyclient )
+            : !Output ProcessErr bg ( process_run_shell shell_cmd )
+            ?? bg {
+                T bgo → ( output_free bgo )
+                F e → ( print_label_str `bg_spawn` ( process_err_name e ) )
+            }
+
+            : !TcpConn NetErr ar ( tcp_accept listener )
+            ?? ar {
+                T conn → {
+                    : ( Vec u ) wire ( vec_with_cap [u] 256 )
+
+                    // Response 1: 3 MB body — head in `wire`, body borrowed from r.
+                    : ( Vec u ) body ( make_body 3145728 )
+                    : HttpResponse r1 ( response_new 200 )
+                    ( response_set_header r1 `Content-Type` `application/octet-stream` )
+                    ( response_set_body_bytes r1 body )
+                    ( vec_free [u] body )
+                    ( write_pair conn `big` r1 wire )
+
+                    // Response 2: empty body — the one-segment path of the pair.
+                    : HttpResponse r2 ( response_status_only 204 )
+                    ( write_pair conn `empty` r2 wire )
+
+                    ( vec_free [u] wire )
+                    ( tcp_close_conn conn )
+                }
+                F e → ( print_label_str `accept` ( net_err_name e ) )
+            }
+
+            ( tcp_close_listener listener )
+
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 400); do [ -f /tmp/net_write_pair_client.out ] && break; sleep 0.05; done; cat /tmp/net_write_pair_client.out 2>/dev/null` )
+            ?? wait_r {
+                T wo → {
+                    ( print_label_str `client_saw` ( output_stdout wo ) )
+                    ( output_free wo )
+                }
+                F e → ( print_label_str `wait_client` ( process_err_name e ) )
+            }
+        }
+        F e → ( print_label_str `listen` ( net_err_name e ) )
+    }
+    ^ 0
+}

--- a/compiler/tests/outputs/net_write_pair.txt
+++ b/compiler/tests/outputs/net_write_pair.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+── big head ──
+HTTP/1.1 200 OK\r\n
+Content-Type: application/octet-stream\r\n
+Content-Length: 3145728\r\n
+\r\n
+head_plus_body_equals_serialize=T
+write=OK
+── empty head ──
+HTTP/1.1 204 No Content\r\n
+Content-Length: 0\r\n
+\r\n
+head_plus_body_equals_serialize=T
+write=OK
+client_saw=3145858 f6ed35dbf2e0240c

--- a/stdlib/ext/http_response.nu
+++ b/stdlib/ext/http_response.nu
@@ -246,6 +246,23 @@ $ `stdlib/ext/json.nu`
 // Caller clears the buffer between responses; this only appends.
 @ response_serialize_to HttpResponse r ( Vec u ) out → v {
     ( vec_reserve [u] out + 64 ( vec_len [u] . r body ) )
+    ( response_serialize_head_to r out )
+    // memcpy fast path — generic `vec_extend [u]` does a per-element
+    // copy that's the dominant cost for large response bodies
+    // (e.g. 330 KB base64 wasm payload). Replaced 2026-05-27 after
+    // profiling nurlapi /build_wasm showed ~2.5 s of the 3 s total
+    // wall-time was spent in this single byte-by-byte loop.
+    ( bytes_extend_bytes out . r body )
+}
+
+// Serialise only the HEAD — status line, headers, the blank line —
+// appending into `out`. The body stays where it is: the server writes
+// head and body as two segments of one message (`tcp_write_all2`, a
+// single sendmsg), which removes what used to be a full copy of every
+// response body into the wire buffer. Content-Length still describes
+// `r.body`, so the head is only valid paired with that body.
+@ response_serialize_head_to HttpResponse r ( Vec u ) out → v {
+    ( vec_reserve [u] out 256 )
 
     // ── Status line: "HTTP/1.1 <code> <reason>\r\n" ──
     ( bytes_extend_str out `HTTP/1.1 ` )
@@ -276,14 +293,8 @@ $ `stdlib/ext/json.nu`
         ( bytes_extend_str out `\r\n` )
     } {}
 
-    // ── Blank line + body ──
+    // ── Blank line ──
     ( bytes_extend_str out `\r\n` )
-    // memcpy fast path — generic `vec_extend [u]` does a per-element
-    // copy that's the dominant cost for large response bodies
-    // (e.g. 330 KB base64 wasm payload). Replaced 2026-05-27 after
-    // profiling nurlapi /build_wasm showed ~2.5 s of the 3 s total
-    // wall-time was spent in this single byte-by-byte loop.
-    ( bytes_extend_bytes out . r body )
 }
 
 // Case-insensitive header presence check. Direct *Header iteration —

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -553,14 +553,21 @@ $ `stdlib/ext/http_response.nu`
 // connection-level scratch buffer (owned by _serve_keepalive_loop):
 // serialising into it instead of a fresh Vec saves an allocate/free
 // pair per response on the keep-alive hot path.
+//
+// Only the HEAD is serialised into `wire`; the body is written from
+// the response itself as the second segment of one `tcp_write_all2`
+// (a single sendmsg on plaintext). Copying the body into `wire` used to
+// be the second full copy of every response body — measured at 1 MB it
+// was about half of the per-request CPU gap to hyper, which writes its
+// body slice by reference.
 
 @ __write_response TcpConn conn HttpResponse r b force_close ( Vec u ) wire → !v NetErr {
     ? force_close {
         ( response_set_header r `Connection` `close` )
     } {}
     ( vec_clear [u] wire )
-    ( response_serialize_to r wire )
-    : !v NetErr wr ( tcp_write_all conn wire )
+    ( response_serialize_head_to r wire )
+    : !v NetErr wr ( tcp_write_all2 conn wire . r body )
     ( http_response_free r )
     ^ wr
 }

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -738,6 +738,7 @@ typedef SOCKET nurl_sockfd_t;
 #    define nurl_close_sock(fd) closesocket(fd)
 #  else
 #    include <sys/socket.h>
+#    include <sys/uio.h>            /* struct iovec — nurl_tcp_write2 */
 #    include <netinet/in.h>
 #    include <netinet/tcp.h>        /* TCP_NODELAY on accepted conns */
 #    include <arpa/inet.h>
@@ -1356,6 +1357,76 @@ long long nurl_tcp_read(long long handle, const char *buf, long long n) {
     return -1;
 }
 
+/* What a send() that moved nothing means for the write loop around it.
+ * Shared by nurl_tcp_write and nurl_tcp_write2 so the two cannot drift.
+ *
+ * SO_SNDTIMEO (set by nurl_tcp_set_timeout for the keep-alive idle
+ * deadline) also caps every blocking send(): when a SLOW-BUT-ALIVE
+ * client (a phone on WiFi pulling a 50 MB model) drains the socket
+ * more slowly than we fill it, send() can spend the whole window
+ * waiting for buffer space and fail with EAGAIN — which used to be
+ * treated as fatal, cutting the response mid-body. A send timeout
+ * is only a DEAD peer if there is no progress across consecutive
+ * windows: retry zero-progress timeouts up to twice (≈2-3× the
+ * idle deadline of total stall), and let any progress reset the
+ * allowance (the caller zeroes *stalls on progress). */
+enum { NURL_SEND_FAIL = 0, NURL_SEND_RETRY = 1, NURL_SEND_PROGRESS = 2 };
+static int nurl__tcp_short_send(NurlTcp *h, long long wn, long long total,
+                                int *stalls) {
+#ifdef _WIN32
+    /* WSAETIMEDOUT only fires on BLOCKING sockets (SO_SNDTIMEO);
+     * the async path's would-block is WSAEWOULDBLOCK and must
+     * still return immediately for the reactor. */
+    int we = WSAGetLastError();
+    if (wn < 0 && we == WSAETIMEDOUT && ++*stalls <= 2) return NURL_SEND_RETRY;
+    /* Would-block on a non-blocking socket is PROGRESS, not
+     * failure — see the POSIX branch below for why -1 here
+     * corrupts the caller's stream. */
+    if (wn < 0 && we == WSAEWOULDBLOCK && total > 0) {
+        h->err_kind = NURL_NET_ERR_OK;
+        return NURL_SEND_PROGRESS;
+    }
+    h->err_kind = nurl__net_map_wsa(we, NURL_NET_ERR_WRITE);
+#else
+    int err = errno;
+    /* On POSIX a SO_SNDTIMEO expiry and a nonblocking would-block
+     * are both EAGAIN — only retry on BLOCKING sockets, so the
+     * fiber reactor's park-on-EAGAIN contract stays intact. */
+    if (wn < 0 && (err == EAGAIN ||
+#  if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+                   err == EWOULDBLOCK ||
+#  endif
+                   0)) {
+        int fl = fcntl(h->fd, F_GETFL, 0);
+        if (fl >= 0 && !(fl & O_NONBLOCK) && ++*stalls <= 2) return NURL_SEND_RETRY;
+        /* NON-BLOCKING would-block after a PARTIAL send: those
+         * bytes are already on the wire, so this is progress,
+         * and the count is the only record of it. Returning -1
+         * threw it away — the async wrapper in std/net.nu then
+         * parked on the reactor and retried from its own `sent`,
+         * which had never advanced, so it re-sent the buffer
+         * from the front. The peer got the prefix again instead
+         * of the continuation, and since callers frame their
+         * writes (relay.nu's 5-byte type+length header), reading
+         * the announced length spliced a repeat into the middle
+         * of the message: a frame of exactly the right size with
+         * the wrong bytes, and every frame after it garbage.
+         * Measured before the fix: a 1.1 MB relay frame put
+         * 37.7 MB on the wire, ~17 copies of its own prefix.
+         * Loopback hid it completely — the peer drains as fast
+         * as we fill, so send() never blocks and the whole
+         * buffer goes in one call. Report the count; -1 is for
+         * "nothing was written". */
+        if (total > 0) {
+            h->err_kind = NURL_NET_ERR_OK;
+            return NURL_SEND_PROGRESS;
+        }
+    }
+    h->err_kind = nurl__net_map_errno(err, NURL_NET_ERR_WRITE);
+#endif
+    return NURL_SEND_FAIL;
+}
+
 long long nurl_tcp_write(long long handle, const char *buf, long long n) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return -1;
@@ -1370,17 +1441,7 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
     }
     if (h->timeo_dirty && !h->nonblock) nurl__tcp_apply_timeo(h);
     long long total = 0;
-    /* SO_SNDTIMEO (set by nurl_tcp_set_timeout for the keep-alive idle
-     * deadline) also caps every blocking send(): when a SLOW-BUT-ALIVE
-     * client (a phone on WiFi pulling a 50 MB model) drains the socket
-     * more slowly than we fill it, send() can spend the whole window
-     * waiting for buffer space and fail with EAGAIN — which used to be
-     * treated as fatal, cutting the response mid-body. A send timeout
-     * is only a DEAD peer if there is no progress across consecutive
-     * windows: retry zero-progress timeouts up to twice (≈2-3× the
-     * idle deadline of total stall), and let any progress reset the
-     * allowance. */
-    int stalls = 0;
+    int stalls = 0;   /* see nurl__tcp_short_send */
     while (total < n) {
         long long want = n - total;
 #ifdef _WIN32
@@ -1398,57 +1459,104 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
         } while (wn < 0 && errno == EINTR);
 #endif
         if (wn <= 0) {
+            int verdict = nurl__tcp_short_send(h, (long long)wn, total, &stalls);
+            if (verdict == NURL_SEND_RETRY) continue;
+            return verdict == NURL_SEND_PROGRESS ? total : -1;
+        }
+        stalls = 0;
+        total += (long long)wn;
+    }
+    h->err_kind = NURL_NET_ERR_OK;
+    return total;
+}
+
+/* Two-segment write: `head` then `body` leave through ONE sendmsg(2) /
+ * WSASend call, so a response head and its body do not have to be
+ * concatenated into a single buffer first. That concat was the HTTP
+ * server's second full copy of every response body (the first being
+ * response_set_body_*) — at 1 MB per response it was ~half the CPU
+ * gap to hyper, which writes its body slice by reference.
+ *
+ * Contract is nurl_tcp_write's, over the logical concatenation
+ * head‖body: returns the number of bytes written across BOTH segments
+ * (head first), which may be short; -1 with err_kind set when nothing
+ * was written. Either segment may be empty — with one empty segment
+ * this is exactly nurl_tcp_write (same send() call), so a caller that
+ * always goes through this entry point pays nothing for the generality. */
+long long nurl_tcp_write2(long long handle, const char *b1, long long n1,
+                          const char *b2, long long n2) {
+    NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
+    if (!h) return -1;
+    if (n1 < 0) n1 = 0;
+    if (n2 < 0) n2 = 0;
+    if (n1 == 0) return nurl_tcp_write(handle, b2, n2);
+    if (n2 == 0) return nurl_tcp_write(handle, b1, n1);
+    if (h->fd == NURL_INVALID_SOCK) {
+        h->err_kind = NURL_NET_ERR_CLOSED;
+        return -1;
+    }
+    if (!b1 || !b2) {
+        h->err_kind = NURL_NET_ERR_WRITE;
+        return -1;
+    }
+    if (h->timeo_dirty && !h->nonblock) nurl__tcp_apply_timeo(h);
+    long long n = n1 + n2;
+    long long total = 0;
+    int stalls = 0;
+    while (total < n) {
+        /* Re-point the vector at whatever is still unsent. */
 #ifdef _WIN32
-            /* WSAETIMEDOUT only fires on BLOCKING sockets (SO_SNDTIMEO);
-             * the async path's would-block is WSAEWOULDBLOCK and must
-             * still return immediately for the reactor. */
-            int we = WSAGetLastError();
-            if (wn < 0 && we == WSAETIMEDOUT && ++stalls <= 2) continue;
-            /* Would-block on a non-blocking socket is PROGRESS, not
-             * failure — see the POSIX branch below for why -1 here
-             * corrupts the caller's stream. */
-            if (wn < 0 && we == WSAEWOULDBLOCK && total > 0) {
-                h->err_kind = NURL_NET_ERR_OK;
-                return total;
-            }
-            h->err_kind = nurl__net_map_wsa(we, NURL_NET_ERR_WRITE);
+        WSABUF bufs[2];
+        DWORD cnt = 0, sent = 0;
+        if (total < n1) {
+            long long r1 = n1 - total;
+            bufs[cnt].buf = (char*)b1 + total;
+            bufs[cnt].len = (ULONG)(r1 > 0x40000000 ? 0x40000000 : r1);
+            cnt++;
+            bufs[cnt].buf = (char*)b2;
+            bufs[cnt].len = (ULONG)(n2 > 0x40000000 ? 0x40000000 : n2);
+            cnt++;
+        } else {
+            long long r2 = n - total;
+            bufs[cnt].buf = (char*)b2 + (total - n1);
+            bufs[cnt].len = (ULONG)(r2 > 0x40000000 ? 0x40000000 : r2);
+            cnt++;
+        }
+        long long wn = WSASend(h->fd, bufs, cnt, &sent, 0, NULL, NULL) == 0
+                     ? (long long)sent : -1;
 #else
-            /* On POSIX a SO_SNDTIMEO expiry and a nonblocking would-block
-             * are both EAGAIN — only retry on BLOCKING sockets, so the
-             * fiber reactor's park-on-EAGAIN contract stays intact. */
-            if (wn < 0 && (errno == EAGAIN ||
-#  if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
-                           errno == EWOULDBLOCK ||
+        struct iovec iov[2];
+        int cnt = 0;
+        if (total < n1) {
+            iov[cnt].iov_base = (void*)(b1 + total);
+            iov[cnt].iov_len  = (size_t)(n1 - total);
+            cnt++;
+            iov[cnt].iov_base = (void*)b2;
+            iov[cnt].iov_len  = (size_t)n2;
+            cnt++;
+        } else {
+            iov[cnt].iov_base = (void*)(b2 + (total - n1));
+            iov[cnt].iov_len  = (size_t)(n - total);
+            cnt++;
+        }
+        struct msghdr msg;
+        memset(&msg, 0, sizeof msg);
+        msg.msg_iov    = iov;
+        msg.msg_iovlen = cnt;
+        ssize_t wn;
+        do {
+            wn = sendmsg(h->fd, &msg,
+#  ifdef MSG_NOSIGNAL
+                         MSG_NOSIGNAL);
+#  else
+                         0);
 #  endif
-                           0)) {
-                int fl = fcntl(h->fd, F_GETFL, 0);
-                if (fl >= 0 && !(fl & O_NONBLOCK) && ++stalls <= 2) continue;
-                /* NON-BLOCKING would-block after a PARTIAL send: those
-                 * bytes are already on the wire, so this is progress,
-                 * and the count is the only record of it. Returning -1
-                 * threw it away — the async wrapper in std/net.nu then
-                 * parked on the reactor and retried from its own `sent`,
-                 * which had never advanced, so it re-sent the buffer
-                 * from the front. The peer got the prefix again instead
-                 * of the continuation, and since callers frame their
-                 * writes (relay.nu's 5-byte type+length header), reading
-                 * the announced length spliced a repeat into the middle
-                 * of the message: a frame of exactly the right size with
-                 * the wrong bytes, and every frame after it garbage.
-                 * Measured before the fix: a 1.1 MB relay frame put
-                 * 37.7 MB on the wire, ~17 copies of its own prefix.
-                 * Loopback hid it completely — the peer drains as fast
-                 * as we fill, so send() never blocks and the whole
-                 * buffer goes in one call. Report the count; -1 is for
-                 * "nothing was written". */
-                if (total > 0) {
-                    h->err_kind = NURL_NET_ERR_OK;
-                    return total;
-                }
-            }
-            h->err_kind = nurl__net_map_errno(errno, NURL_NET_ERR_WRITE);
+        } while (wn < 0 && errno == EINTR);
 #endif
-            return -1;
+        if (wn <= 0) {
+            int verdict = nurl__tcp_short_send(h, (long long)wn, total, &stalls);
+            if (verdict == NURL_SEND_RETRY) continue;
+            return verdict == NURL_SEND_PROGRESS ? total : -1;
         }
         stalls = 0;
         total += (long long)wn;
@@ -2584,6 +2692,20 @@ long long nurl_tcp_read(long long h, const char *buf, long long n) {
 long long nurl_tcp_write(long long h, const char *buf, long long n) {
     return nurl__ni_tcp_write(h, buf, n);
 }
+/* The bridge has no vectored write, and adding an import would refuse
+ * to instantiate every module on a host that predates it. Compose it
+ * from two writes under nurl_tcp_write2's contract: the count covers
+ * both segments, and a short first segment is a short total. */
+long long nurl_tcp_write2(long long h, const char *b1, long long n1,
+                          const char *b2, long long n2) {
+    if (n1 < 0) n1 = 0;
+    if (n2 < 0) n2 = 0;
+    if (n1 == 0) return nurl__ni_tcp_write(h, b2, n2);
+    long long w1 = nurl__ni_tcp_write(h, b1, n1);
+    if (w1 < n1 || n2 == 0) return w1;
+    long long w2 = nurl__ni_tcp_write(h, b2, n2);
+    return w2 < 0 ? w1 : w1 + w2;
+}
 void nurl_tcp_close(long long h)    { nurl__ni_tcp_close(h); }
 void nurl_tcp_shutdown(long long h) { nurl__ni_tcp_shutdown(h); }
 long long nurl_tcp_err_kind(long long h) { return nurl__ni_tcp_err_kind(h); }
@@ -2693,6 +2815,10 @@ long long nurl_tcp_read(long long h, const char *buf, long long n) {
 }
 long long nurl_tcp_write(long long h, const char *buf, long long n) {
     (void)h; (void)buf; (void)n; return -1;
+}
+long long nurl_tcp_write2(long long h, const char *b1, long long n1,
+                          const char *b2, long long n2) {
+    (void)h; (void)b1; (void)n1; (void)b2; (void)n2; return -1;
 }
 void nurl_tcp_close(long long h) { (void)h; }
 void nurl_tcp_shutdown(long long h) { (void)h; }
@@ -3848,6 +3974,12 @@ static NurlFiber *nurl__rq_take_global_batch(NurlWorker *w) {
     }
     int n = len / nurl__sched.worker_count + 1;
     if (n > 16) n = 16;
+    /* The share formula exceeds the queue when there is ONE worker
+     * (len/1 + 1 = len + 1): the walk below then steps past the last
+     * fiber and dereferences NULL. That is every single-core deploy —
+     * NURL_WORKERS=1 or a one-CPU container with the per-core default —
+     * the first time a fiber lands on the global queue. */
+    if (n > len) n = len;
     NurlFiber *head = nurl__sched.global_head;
     NurlFiber *tail = head;
     for (int i = 1; i < n; i++) tail = tail->next;

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -11,6 +11,7 @@
 //   ( tcp_accept          TcpListener l )                   → ! TcpConn NetErr
 //   ( tcp_read_chunk      TcpConn c i max )                 → ! ( Vec u ) NetErr
 //   ( tcp_write_all       TcpConn c ( Vec u ) bytes )       → ! v NetErr
+//   ( tcp_write_all2      TcpConn c ( Vec u ) head ( Vec u ) body ) → ! v NetErr
 //   ( tcp_write_str       TcpConn c s text )                → ! v NetErr
 //   ( tcp_close_listener  TcpListener l )                   → v
 //   ( tcp_close_conn      TcpConn c )                       → v
@@ -700,6 +701,15 @@ $ `stdlib/std/pkey.nu`
     ?? r { T _ → ^ @ !v NetErr { T 0 } F _ → ^ @ !v NetErr { F # NetErr NetWrite } }
 }
 
+// Two-buffer TLS write: the record layer seals `head`‖`body` into
+// records straight from the two buffers (see tls_server_write2), so the
+// plaintext is never joined into one buffer first.
+@ __tls_write_net2 TcpConn c ( Vec u ) head ( Vec u ) body → !v NetErr {
+    : *TlsConn tc # *TlsConn ( __conn_tlsptr c )
+    : !v TlsErr r ? == . c kind 2 ( tls_server_write2 tc head body ) ( tls_write2 tc head body )
+    ?? r { T _ → ^ @ !v NetErr { T 0 } F _ → ^ @ !v NetErr { F # NetErr NetWrite } }
+}
+
 // with a clean peer shutdown. Caller frees the Vec on the Ok path.
 @ tcp_read_chunk TcpConn c i max → !( Vec u ) NetErr {
     ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_read_net c max ) } {}
@@ -796,35 +806,45 @@ $ `stdlib/std/pkey.nu`
 
 // ── Writing ────────────────────────────────────────────────────────
 
-@ tcp_write_all TcpConn c ( Vec u ) bytes → !v NetErr {
-    ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_write_net c bytes ) } {}
-    // Context-aware dispatch — see tcp_accept's note.
-    : i fcur ( nurl_fiber_current )
-    ? != fcur 0 { ^ ( tcp_write_all_async c bytes ) } {}
-    : s rp . c raw
-    : i raw # i rp
-    : i total ( vec_len [u] bytes )
+// Two-segment send: `b1[0..n1)` then `b2[0..n2)` through ONE
+// sendmsg(2)/WSASend, returning the count written across both (short
+// counts allowed; -1 = nothing written, err_kind set). With one segment
+// empty it is exactly nurl_tcp_write. Declared here rather than in the
+// compiler preamble, like the other stdlib-only runtime entry points.
+& `c` @ nurl_tcp_write2 i conn s b1 i n1 s b2 i n2 → i
+
+// The one blocking send loop behind tcp_write_all, tcp_write_str and
+// tcp_write_all2: writes the logical concatenation `p1[0..n1)‖p2[0..n2)`
+// to the raw handle, re-pointing the pair at the unsent remainder after
+// every short count. A single buffer is the pair with `n2 == 0`.
+//
+// write(2) on a blocking socket is NOT all-or-nothing: it returns as soon
+// as it has copied SOME bytes into the send buffer, and with SO_SNDTIMEO
+// set (tcp_set_timeout) it returns a short count when the timer fires with
+// the peer's window full. Writing once and reporting success left the rest
+// of the buffer unsent, and — because the frame header had already
+// announced the full length — DESYNCED the stream: the peer's next
+// read_exact spliced the tail of one frame onto the head of the next and
+// handed up a frame of the right length with the wrong bytes. Loopback
+// hides it (the receiver drains as fast as the sender fills, so one write
+// takes everything); a real network path with an autotuned 64 KiB initial
+// send buffer does not, past a few hundred KiB. Loop until it is all gone,
+// exactly as the async twin below does.
+@ __tcp_write_pair_sync i raw s p1 i n1 s p2 i n2 → !v NetErr {
+    : i total + n1 n2
     ? <= total 0 { ^ @ !v NetErr { T 0 } } {}
-    : *u p ( vec_data [u] bytes )
-    : s pbuf # s p
-    // write(2) on a blocking socket is NOT all-or-nothing: it returns as soon
-    // as it has copied SOME bytes into the send buffer, and with SO_SNDTIMEO
-    // set (tcp_set_timeout) it returns a short count when the timer fires with
-    // the peer's window full. Writing once and reporting success left the rest
-    // of the buffer unsent, and — because the frame header had already
-    // announced the full length — DESYNCED the stream: the peer's next
-    // read_exact spliced the tail of one frame onto the head of the next and
-    // handed up a frame of the right length with the wrong bytes. Loopback
-    // hides it (the receiver drains as fast as the sender fills, so one write
-    // takes everything); a real network path with an autotuned 64 KiB initial
-    // send buffer does not, past a few hundred KiB. Loop until it is all gone,
-    // exactly as tcp_write_all_async already does.
     : ~ i sent 0
     : ~ i idle 0
     ~ < sent total {
-        : i remaining - total sent
-        : s slice # s + # i pbuf sent
-        : i wn ( nurl_tcp_write raw slice remaining )
+        : ~ s a p1
+        : ~ i an - n1 sent
+        : ~ i bn n2
+        ? < sent n1 { = a # s + # i p1 sent } {
+            = a # s + # i p2 - sent n1
+            = an - total sent
+            = bn 0
+        }
+        : i wn ( nurl_tcp_write2 raw a an p2 bn )
         ? > wn 0 { = sent + sent wn = idle 0 } {
             : i ek ( nurl_tcp_err_kind raw )
             // ek 7 is EAGAIN / SO_SNDTIMEO. The peer is still connected and
@@ -840,6 +860,37 @@ $ `stdlib/std/pkey.nu`
     ^ @ !v NetErr { T 0 }
 }
 
+@ tcp_write_all TcpConn c ( Vec u ) bytes → !v NetErr {
+    ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_write_net c bytes ) } {}
+    // Context-aware dispatch — see tcp_accept's note.
+    : i fcur ( nurl_fiber_current )
+    ? != fcur 0 { ^ ( tcp_write_all_async c bytes ) } {}
+    : s rp . c raw
+    : i raw # i rp
+    : *u p ( vec_data [u] bytes )
+    ^ ( __tcp_write_pair_sync raw # s p ( vec_len [u] bytes ) # s 0 0 )
+}
+
+// Write `head` then `body` as ONE logical message. On the plaintext
+// path both segments leave in a single sendmsg(2), so a caller that
+// keeps a message head and its payload in separate buffers (the HTTP
+// server: serialised head in the connection's wire buffer, body still
+// in the response) pays neither the concat copy nor a second syscall.
+// On TLS the record layer seals the pair straight from the two buffers.
+// Both inputs are BORROWED, as for tcp_write_all.
+@ tcp_write_all2 TcpConn c ( Vec u ) head ( Vec u ) body → !v NetErr {
+    ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_write_net2 c head body ) } {}
+    : s rp . c raw
+    : i raw # i rp
+    : *u hp ( vec_data [u] head )
+    : i hn ( vec_len [u] head )
+    : *u bp ( vec_data [u] body )
+    : i bn ( vec_len [u] body )
+    : i fcur ( nurl_fiber_current )
+    ? != fcur 0 { ^ ( __tcp_write_pair_async raw # s hp hn # s bp bn ) } {}
+    ^ ( __tcp_write_pair_sync raw # s hp hn # s bp bn )
+}
+
 // Convenience: write a NUL-terminated `s` (the typical HTTP header /
 // status-line case). The bytes [0..len) are sent — the trailing NUL is
 // NOT transmitted.
@@ -852,27 +903,11 @@ $ `stdlib/std/pkey.nu`
     } {}
     : s rp . c raw
     : i raw # i rp
-    : i total ( nurl_str_len text )
-    ? <= total 0 { ^ @ !v NetErr { T 0 } } {}
-    // Same short-write rule as tcp_write_all — see the note there. Status
-    // lines and headers are small enough that one write almost always takes
-    // them, which is exactly why a partial one here would be a rare,
-    // load-dependent corruption rather than an outright failure.
-    : ~ i sent 0
-    : ~ i idle 0
-    ~ < sent total {
-        : i remaining - total sent
-        : s slice # s + # i text sent
-        : i wn ( nurl_tcp_write raw slice remaining )
-        ? > wn 0 { = sent + sent wn = idle 0 } {
-            : i ek ( nurl_tcp_err_kind raw )
-            ? | == ek 7 == wn 0 {
-                = idle + idle 1
-                ? > idle 2400 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
-            } { ^ @ !v NetErr { F ( _net_err_of ek ) } }
-        }
-    }
-    ^ @ !v NetErr { T 0 }
+    // Same short-write rule as tcp_write_all — see __tcp_write_pair_sync.
+    // Status lines and headers are small enough that one write almost
+    // always takes them, which is exactly why a partial one here would be
+    // a rare, load-dependent corruption rather than an outright failure.
+    ^ ( __tcp_write_pair_sync raw text ( nurl_str_len text ) # s 0 0 )
 }
 
 // ── Phase 6 — fiber-aware async TCP wrappers ───────────────────────
@@ -1036,12 +1071,18 @@ $ `stdlib/std/async_ffi.nu`
 @ tcp_write_all_async TcpConn c ( Vec u ) bytes → !v NetErr {
     : s rp . c raw
     : i raw # i rp
+    : *u p ( vec_data [u] bytes )
+    ^ ( __tcp_write_pair_async raw # s p ( vec_len [u] bytes ) # s 0 0 )
+}
+
+// The non-blocking twin of __tcp_write_pair_sync: same pair-of-segments
+// contract, parking the fiber on the reactor instead of blocking in the
+// kernel when the socket would block.
+@ __tcp_write_pair_async i raw s p1 i n1 s p2 i n2 → !v NetErr {
     ( nurl_tcp_set_nonblock raw 1 )
     : i fd ( nurl_tcp_get_fd raw )
-    : i total ( vec_len [u] bytes )
+    : i total + n1 n2
     ? <= total 0 { ^ @ !v NetErr { T 0 } } {}
-    : *u p ( vec_data [u] bytes )
-    : s pbuf # s p
     : ~ i sent 0
     // Once ANY byte of this buffer is on the wire, giving up is not an
     // option the caller can recover from. Callers frame their writes
@@ -1060,9 +1101,15 @@ $ `stdlib/std/async_ffi.nu`
     // is the only correct way out of a partial frame.
     : ~ i idle 0
     ~ < sent total {
-        : i remaining - total sent
-        : s slice # s + # i pbuf sent
-        : i n ( nurl_tcp_write raw slice remaining )
+        : ~ s a p1
+        : ~ i an - n1 sent
+        : ~ i bn n2
+        ? < sent n1 { = a # s + # i p1 sent } {
+            = a # s + # i p2 - sent n1
+            = an - total sent
+            = bn 0
+        }
+        : i n ( nurl_tcp_write2 raw a an p2 bn )
         ? > n 0 {
             = sent + sent n
             = idle 0

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -382,6 +382,19 @@ $ `stdlib/std/async_ffi.nu`
 @ __send_encrypted * TlsConn c i content_type ( Vec u ) content → !v TlsErr {
     : ( Vec u ) inner ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
     ( _tls_cat inner content )
+    ^ ( __send_inner_encrypted c content_type inner )
+}
+
+// Same record, plaintext = bytes [lo, hi) of `head`‖`body`, assembled
+// straight from the two buffers (tls_write2's per-record step).
+@ __send_encrypted_pair * TlsConn c i content_type ( Vec u ) head ( Vec u ) body i lo i hi → !v TlsErr {
+    : ( Vec u ) inner ( _tls_pair_slice head body lo hi )
+    ^ ( __send_inner_encrypted c content_type inner )
+}
+
+// Seal `inner` (plaintext WITHOUT the type byte yet; consumed here) as
+// one TLS 1.3 record under the client write keys and send it.
+@ __send_inner_encrypted * TlsConn c i content_type ( Vec u ) inner → !v TlsErr {
     ( vec_push [u] inner # u content_type )
     : i total + ( vec_len [u] inner ) 16
     : ( Vec u ) aad ( vec_with_cap [u] 5 )
@@ -1158,6 +1171,56 @@ $ `stdlib/std/async_ffi.nu`
         : ~ ! v TlsErr w @ !v TlsErr { T 0 }
         ? == . c version 12 { = w ( __send_record_12 c 23 part ) } { = w ( __send_encrypted c 23 part ) }
         ( vec_free [u] part )
+        ?? w { T _ → {} F e → { ^ @ !v TlsErr { F e } } }
+        = off hi
+    }
+    ^ @ !v TlsErr { T 0 }
+}
+
+// Bytes [lo, hi) of the logical concatenation `head`‖`body`, as a fresh
+// Vec — the record cutter behind tls_write2 / tls_server_write2. One
+// memcpy per source touched; a range inside a single source is one.
+// One spare byte of capacity: the sealers push the inner content-type
+// byte onto this same Vec, and that must not be a reallocation.
+@ _tls_pair_slice ( Vec u ) head ( Vec u ) body i lo i hi → ( Vec u ) {
+    : i hn ( vec_len [u] head )
+    : i bn ( vec_len [u] body )
+    : ~ i a lo
+    : ~ i z hi
+    ? < a 0 { = a 0 } {}
+    ? > z + hn bn { = z + hn bn } {}
+    ? < z a { = z a } {}
+    : ( Vec u ) out ( vec_with_cap [u] + 1 - z a )
+    ? < a hn {
+        : i h_hi ? < z hn z hn
+        : *u hp ( vec_data [u] head )
+        ( bytes_extend_raw out # s + # i hp a - h_hi a )
+    } {}
+    ? > z hn {
+        : i b_lo ? > a hn - a hn 0
+        : *u bp ( vec_data [u] body )
+        ( bytes_extend_raw out # s + # i bp b_lo - - z hn b_lo )
+    } {}
+    ^ out
+}
+
+// Two-buffer variant of tls_write (client side of tcp_write_all2):
+// records are cut from `head`‖`body` without joining the two first.
+// TLS 1.3 assembles each record's plaintext straight from the pair;
+// TLS 1.2 hands the AEAD a plaintext Vec, so it cuts one per record
+// (the same one bytes_slice cut before).
+@ tls_write2 * TlsConn c ( Vec u ) head ( Vec u ) body → !v TlsErr {
+    : i n + ( vec_len [u] head ) ( vec_len [u] body )
+    : ~ i off 0
+    ~ < off n {
+        : ~ i hi + off 16384
+        ? > hi n { = hi n } {}
+        : ~ ! v TlsErr w @ !v TlsErr { T 0 }
+        ? == . c version 12 {
+            : ( Vec u ) part ( _tls_pair_slice head body off hi )
+            = w ( __send_record_12 c 23 part )
+            ( vec_free [u] part )
+        } { = w ( __send_encrypted_pair c 23 head body off hi ) }
         ?? w { T _ → {} F e → { ^ @ !v TlsErr { F e } } }
         = off hi
     }

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -60,6 +60,21 @@ $ `stdlib/std/aes_gcm.nu`
 @ __srv_enc_rec_to * TlsConn c ( Vec u ) out i content_type ( Vec u ) content → v {
     : ( Vec u ) inner ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
     ( _tls_cat inner content )
+    ( __srv_seal_inner_to c out content_type inner )
+}
+
+// Same record, plaintext taken as bytes [lo, hi) of `head`‖`body` — the
+// inner plaintext is assembled straight from the two buffers (one copy,
+// exactly what the single-buffer path pays), so tls_server_write2 does
+// not cut an intermediate slice per record.
+@ __srv_enc_rec_pair_to * TlsConn c ( Vec u ) out i content_type ( Vec u ) head ( Vec u ) body i lo i hi → v {
+    : ( Vec u ) inner ( _tls_pair_slice head body lo hi )
+    ( __srv_seal_inner_to c out content_type inner )
+}
+
+// Seal `inner` (plaintext WITHOUT the type byte yet; consumed here) as
+// one TLS 1.3 record under the server write keys, appended to `out`.
+@ __srv_seal_inner_to * TlsConn c ( Vec u ) out i content_type ( Vec u ) inner → v {
     ( vec_push [u] inner # u content_type )
     : i total + ( vec_len [u] inner ) 16
     : ( Vec u ) aad ( vec_with_cap [u] 5 )
@@ -730,6 +745,27 @@ $ `stdlib/std/aes_gcm.nu`
         : !v TlsErr w ( __srv_send_enc c 23 part )
         ( vec_free [u] part )
         ?? w { T _ → {} F e → { ^ @ !v TlsErr { F e } } }
+        = off hi
+    }
+    ^ @ !v TlsErr { T 0 }
+}
+
+// Two-buffer variant for net.nu's tcp_write_all2: records are cut from
+// the logical concatenation `head`‖`body` (see _tls_pair_slice), so the
+// HTTP server's response head and body are never joined into one
+// plaintext buffer first. Record boundaries are identical to
+// tls_server_write over the joined bytes — same wire, one copy less.
+@ tls_server_write2 * TlsConn c ( Vec u ) head ( Vec u ) body → !v TlsErr {
+    : i n + ( vec_len [u] head ) ( vec_len [u] body )
+    : ~ i off 0
+    ~ < off n {
+        : ~ i hi + off 16384
+        ? > hi n { = hi n } {}
+        : ( Vec u ) rec ( vec_new [u] )
+        ( __srv_enc_rec_pair_to c rec 23 head body off hi )
+        : b w ( _tls_sock_write . c fd rec )
+        ( vec_free [u] rec )
+        ? w {} { ^ @ !v TlsErr { F # TlsErr TlsWrite } }
         = off hi
     }
     ^ @ !v TlsErr { T 0 }

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -827,6 +827,18 @@ $ `stdlib/net/dnsclient.nu`
     ^ rc
 }
 
+// Two-segment write (std/net.nu's `tcp_write_all2` → head + body in one
+// call). The sans-IO stack has no scatter/gather send, so it is two
+// writes under nurl_tcp_write2's contract: the count spans both
+// segments, head first, and a short head is a short total.
+@ nurl_tcp_write2 i conn s b1 i n1 s b2 i n2 → i {
+    ? <= n1 0 { ^ ( nurl_tcp_write conn b2 n2 ) } {}
+    : i w1 ( nurl_tcp_write conn b1 n1 )
+    ? | < w1 n1 <= n2 0 { ^ w1 } {}
+    : i w2 ( nurl_tcp_write conn b2 n2 )
+    ^ ? < w2 0 w1 + w1 w2
+}
+
 @ nurl_reactor_wait_read i fd i timeout_ms → i { ^ ( __wait fd 0 timeout_ms ) }
 
 @ nurl_reactor_wait_write i fd i timeout_ms → i { ^ ( __wait fd 1 timeout_ms ) }


### PR DESCRIPTION
## Summary

Stage 1 of the plan behind the HTTP torture findings: the HTTP server no longer copies the response body into the connection's wire buffer before writing it.

`__write_response` now serialises only the head (status line, headers, blank line) into `wire` and writes head and body as two segments of one message via the new `tcp_write_all2` — a single `sendmsg(2)` with a two-entry iovec (`nurl_tcp_write2` in the runtime; `WSASend` on Windows). Small responses keep their one-syscall cost; large ones lose a full `memcpy` of the body per request.

That concat was the second full copy of every response body (the first is `response_set_body_*`, Stage 2). The open-loop harness in `bench/http_torture` had put it at roughly half of the 1 MB per-request CPU gap to hyper.

### What changed

- **runtime** (`stdlib/runtime_ffi.c`): `nurl_tcp_write2(h, b1, n1, b2, n2)` — same contract as `nurl_tcp_write` over the logical concatenation; one empty segment degrades to exactly the old `send()`. The short-count / EAGAIN / `SO_SNDTIMEO` rules moved into one shared helper (`nurl__tcp_short_send`) so the two entry points cannot drift. WASM net bridge composes two writes (no new import, so older hosts still instantiate); WASI stub; unikernel `sockets.nu` shim composes.
- **net.nu**: `tcp_write_all`, `tcp_write_str`, `tcp_write_all_async` and the new `tcp_write_all2` share one blocking loop and one fiber loop (`__tcp_write_pair_sync` / `__tcp_write_pair_async`) instead of three hand-copied ones.
- **TLS**: `tls_server_write2` / `tls_write2` cut records straight from the head/body pair (`_tls_pair_slice`), same record boundaries as before; the sealers now take the assembled inner plaintext (`__srv_seal_inner_to`, `__send_inner_encrypted`) so the pair path pays the same single copy the single-buffer path does.
- **http_response.nu**: `response_serialize_head_to` (head only). `response_serialize` / `response_serialize_to` unchanged for the proxy, WebSocket handshake and tests.
- **http_server.nu**: `__write_response` → head into `wire`, then `tcp_write_all2 conn wire . r body`.
- **Fix found on the way**: the fiber scheduler crashed with one worker (`NURL_WORKERS=1`, or any one-CPU container with the per-core default) the first time a fiber landed on the global run queue — `nurl__rq_take_global_batch` took `len / worker_count + 1 = len + 1` fibers and walked off the list. Capped at `len`.
- New test `compiler/tests/net_write_pair.nu`: 3 MB body + empty body over loopback with a slow reader (forces short counts across the head/body boundary), client-side sha256 checked against an independently computed value; head‖body proven byte-identical to `response_serialize`.

### Verification

- `./build.sh` (bootstrap fixed point + full suite) green; `./build.sh --san` + `run_san_tests.sh`: 904 PASS, 0 SAN_FAIL; `tools/check_mingw_cross.sh` ok; `unikernel/demos/httpd.nu` links with the shim.
- `strace`: one `sendmsg` per response, `iov = {82, 16384}` for `/16k`; the 14-byte body is also one syscall.
- 14-byte bench (`bench/http_server.nu`), ABAB interleaved ×4, server on cores 0-5 / `oha` on 6-11, medians old → new: http C=50 −0.6 %, C=200 −1.5 % (samples overlap), https C=50 −0.1 %, C=200 +0.6 %, conn/s and handshakes/s ±0.2 %. The residual is the iovec import in `sendmsg` on a 94-byte response.
- `bench/http_torture`, MODE=full, same host as the committed baseline (i7-5930K, server 0-5 / generator 6-11):

| Cell | before | after | Rust (same run) |
|---|--:|--:|--:|
| 1 KB sustainable req/s | 168 000 (generator-bound tie) | 192 000 (generator-bound tie) | 192 000 |
| 1 KB CPU µs/req | 25.2 | 24.4 | 24.7 |
| 16 KB sustainable req/s | 100 000 | **124 000** | 116 000 |
| 16 KB CPU µs/req | 41.0 | **35.3** | 37.1 |
| 1 MB sustainable req/s | 1 500 | **2 250** | 3 000 |
| 1 MB CPU µs/req | 1 324 | **1 137** | 921 |
| keep-alive 2000 conns, req/s | 171 994 | 178 421 | 174 374 |

16 KB went from 1.2× behind to ahead of hyper at lower CPU per request; the 1 MB gap went from 2.17× to 1.33×. What remains at 1 MB is the inbound copy (`response_set_body_bytes`), which is Stage 2 (borrowed body). Churn, slowloris and TLS resumption are unchanged (resumption is Stage 3).

`TORTURE_RESULTS.md` is refreshed from a clean full run (all sizes, all dimensions) on this tree; a first full run had its 1 KB rows disturbed by a git hook running on the host mid-ramp and was discarded rather than spliced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw
