### PR TITLE
vec: borrowed views; http: a response body that is not copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Borrowed Vec views and a zero-copy HTTP response body.**
+  `vec_borrow_raw [A] p n` makes a `Vec` handle over the caller's
+  buffer: reads see it in place, the first growth detaches into an owned
+  copy (copy-on-write), and `vec_free` releases only the handle
+  (`cap == -1` marks a view; grow / set_len / shrink_to_fit / free /
+  free_with honour it); `vec_borrow_into [A] v p n` re-points an existing
+  handle — the form a struct field needs, since struct values travel by
+  copy and only the shared control block reaches the caller.
+  `response_set_body_borrowed r p n` and
+  `response_set_body_borrowed_bytes r v` put a precomputed buffer on a
+  response without copying it — the remaining full copy of every large
+  response body after the wire-buffer copy was removed. The contract is
+  the caller's: the buffer outlives the write. Test:
+  `compiler/tests/vec_borrowed.nu`.
+
 ### Changed
 
 - **The HTTP server no longer copies the response body into the

--- a/bench/http_torture/TORTURE_RESULTS.md
+++ b/bench/http_torture/TORTURE_RESULTS.md
@@ -3,85 +3,85 @@
 Open-loop, coordinated-omission corrected (`oha -q --latency-correction`). Server pinned to cores `0-5`, generator to `6-11`. Both peers serve byte-identical bodies. MODE=**full**.
 
 - Host: `Linux 7.0.0-30-generic` — Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz
-- NURL: `v0.58.0-1-gbbaa3646-dirty`  ·  oha: `oha 1.8.0`
+- NURL: `v0.58.0-5-ge2efeda0`  ·  oha: `oha 1.8.0`
 - Sustainable capacity = highest offered rate with achieved ≥ 97% of target and p99 ≤ 50 ms.
 
 ### Body 1k — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 192 000 | 0.811/8.261/28.709 | 1.114/64.142/96.992 | 1.881/111.539/133.070 |
-| RUST | 192 000 | 0.957/20.050/46.970 | 1.130/87.576/119.026 | 2.042/136.371/149.653 |
+| NURL | 176 000 | 0.779/7.549/30.526 | 0.990/51.232/87.295 | 1.226/94.339/121.908 |
+| RUST | 176 000 | 0.926/11.640/38.521 | 1.109/80.595/109.294 | 1.319/92.428/119.136 |
 
 ### Body 16k — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 124 000 | 0.746/9.059/42.540 | 1.062/19.916/50.366 | 2.089/107.729/126.069 |
-| RUST | 116 000 | 0.907/15.767/53.909 | 1.094/23.761/52.437 | 1.509/104.022/130.995 |
+| NURL | 124 000 | 0.773/16.315/51.710 | 1.027/36.873/71.754 | 1.866/96.719/120.109 |
+| RUST | 124 000 | 0.913/11.536/35.500 | 1.162/29.947/50.343 | 1.925/121.636/138.335 |
 
 ### Body 1m — sustainable capacity & tail under load
 
 | Server | Sustainable req/s | 50% p50/p99/p99.9 (ms) | 80% p50/p99/p99.9 | 95% p50/p99/p99.9 |
 |---|--:|--:|--:|--:|
-| NURL | 2 250 | 1.463/3.978/5.716 | 1.705/3.742/5.456 | 1.760/3.934/12.590 |
-| RUST | 3 000 | 1.335/2.688/3.605 | 1.381/2.559/5.383 | 1.245/2.408/7.406 |
+| NURL | 3 000 | 1.384/3.418/5.251 | 1.498/3.337/6.335 | 1.413/3.206/5.312 |
+| RUST | 3 000 | 1.334/2.762/5.241 | 1.353/2.483/6.620 | 1.251/2.449/7.434 |
 
 ### Body 1k — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 2687340 | 65.59 | 24.41 |
-| RUST | 2687340 | 66.26 | 24.66 |
+| NURL | 2463360 | 61.15 | 24.82 |
+| RUST | 2463280 | 65.24 | 26.49 |
 
 ### Body 16k — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 1735600 | 61.25 | 35.29 |
-| RUST | 1623520 | 60.29 | 37.14 |
+| NURL | 1735540 | 59.81 | 34.46 |
+| RUST | 1735520 | 62.58 | 36.06 |
 
 ### Body 1m — CPU seconds per request (server-side)
 
 | Server | req served | CPU s (utime+stime) | µs / request |
 |---|--:|--:|--:|
-| NURL | 31480 | 35.79 | 1136.91 |
-| RUST | 41980 | 38.67 | 921.15 |
+| NURL | 41980 | 38.22 | 910.43 |
+| RUST | 41980 | 38.94 | 927.58 |
 
 ### Body 1k — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 44 387 | 2.194/4.005/6.449 | 1.0000 |
-| RUST | 46 620 | 2.104/3.743/5.851 | 1.0000 |
+| NURL | 44 229 | 2.206/3.972/6.286 | 1.0000 |
+| RUST | 46 557 | 2.107/3.755/5.805 | 1.0000 |
 
 ### Body 16k — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 42 384 | 2.307/4.089/6.448 | 1.0000 |
-| RUST | 44 846 | 2.192/3.836/6.032 | 1.0000 |
+| NURL | 42 220 | 2.301/4.566/6.869 | 1.0000 |
+| RUST | 44 932 | 2.191/3.762/5.608 | 1.0000 |
 
 ### Body 1m — connection churn (no keep-alive, fresh conn/request)
 
 | Server | req/s (churn) | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|
-| NURL | 1 924 | 49.930/96.557/127.046 | 1.0000 |
-| RUST | 2 749 | 35.820/53.817/71.250 | 1.0000 |
+| NURL | 2 718 | 35.988/60.934/82.559 | 1.0000 |
+| RUST | 2 748 | 35.900/52.501/66.895 | 1.0000 |
 
 ### Slowloris — 200 trickle clients held open, fast-client latency meanwhile (16k)
 
 | Server | fast-client req/s | p50/p99 (ms) | survived |
 |---|--:|--:|:--:|
-| NURL | 125 020 | 0.134/0.503 | yes |
-| RUST | 145 582 | 0.116/0.415 | yes |
+| NURL | 128 762 | 0.131/0.488 | yes |
+| RUST | 146 157 | 0.116/0.429 | yes |
 
 ### Keep-alive scale — 2000 concurrent keep-alive connections (1k body)
 
 | Server | conns | req/s | p50/p99/p99.9 (ms) | ok |
 |---|--:|--:|--:|--:|
-| NURL | 2000 | 178 421 | 10.819/19.454/26.152 | 1.0000 |
-| RUST | 2000 | 174 374 | 11.190/20.651/29.592 | 1.0000 |
+| NURL | 2000 | 179 451 | 10.766/19.001/27.127 | 1.0000 |
+| RUST | 2000 | 174 203 | 11.209/20.035/31.719 | 1.0000 |
 
 ### TLS 1.3 session resumption — does a reconnect skip the full handshake?
 
@@ -94,8 +94,8 @@ Open-loop, coordinated-omission corrected (`oha -q --latency-correction`). Serve
 
 | Server | req/s | p50/p99/p99.9 (ms) | ok | errors |
 |---|--:|--:|--:|--:|
-| NURL | 99 199 | 1.066/729.250/1514.766 | 1.0000 | 4 (RSS 3108→11672 KiB) |
-| RUST | 92 799 | 1.083/501.461/1392.449 | 1.0000 | 8 (RSS 4572→9448 KiB) |
+| NURL | 99 199 | 1.030/657.126/1461.691 | 1.0000 | 2 (RSS 3148→13924 KiB) |
+| RUST | 99 199 | 1.184/668.219/1457.522 | 1.0000 | 5 (RSS 4712→9572 KiB) |
 
 ---
 

--- a/bench/http_torture/run_torture.sh
+++ b/bench/http_torture/run_torture.sh
@@ -46,9 +46,9 @@ OHA="${OHA:-$HOME/.cargo/bin/oha}"; [ -x "$OHA" ] || OHA="$(command -v oha || tr
 PY="$HT/lib.py"
 
 if [ "$MODE" = full ]; then
-  RAMP_SEC=5; MEAS_SEC=20; SOAK_SEC=600; CONNS=400
+  RAMP_SEC=5; MEAS_SEC=20; SOAK_SEC=600; CONNS=400; SETTLE_SEC="${SETTLE_SEC:-120}"
 else
-  RAMP_SEC=3; MEAS_SEC=6;  SOAK_SEC=20;  CONNS=200
+  RAMP_SEC=3; MEAS_SEC=6;  SOAK_SEC=20;  CONNS=200; SETTLE_SEC="${SETTLE_SEC:-5}"
 fi
 
 NB="$SCRATCH/nurl_torture.bin"
@@ -340,6 +340,16 @@ declare -A CAP_STORE
 
 main() {
   build
+  # Let the box settle before the first cell. The build just above is an
+  # all-core LTO compile plus a cargo build, and whatever ran before this
+  # script (a test suite, a sanitizer run) may have left the CPU hot: two
+  # full runs on the reference host had their FIRST cell — NURL, 1 KB —
+  # collapse to ~40 % of its clean capacity with the tail in the seconds,
+  # while the same binary sustained the clean rate minutes later and the
+  # peer, measured next, was unaffected. A cool-down costs two minutes;
+  # a biased first cell costs the run.
+  say "[settle] ${SETTLE_SEC}s idle before the first measurement"
+  sleep "$SETTLE_SEC"
   local host kern cpu
   host="$(uname -sr)"; cpu="$(LC_ALL=C lscpu | awk -F: '/Model name/{gsub(/^ +/,"",$2);print $2;exit}')"
   add "# HTTP torture — NURL vs Rust (hyper/rustls)"

--- a/bench/http_torture/server.nu
+++ b/bench/http_torture/server.nu
@@ -7,10 +7,12 @@
 //   GET /16k  → exactly  16384 bytes
 //   GET /1m   → exactly 1048576 bytes
 //
-// Each sized body is built ONCE at startup and copied into the response
-// per request — the same shape the Rust peer uses (a precomputed Bytes
-// cloned per response), so the measurement compares the servers, not two
-// body-construction strategies.
+// Each sized body is built ONCE at startup and the response BORROWS it
+// per request (`response_set_body_borrowed_bytes` — no copy) — the same
+// shape the Rust peer uses (a precomputed Bytes cloned per response, a
+// refcount bump), so the measurement compares the servers, not two
+// body-construction strategies. The bodies are main's locals and outlive
+// every request, which is exactly the borrowed-body contract.
 //
 // Args mirror bench/http_server.nu:
 //   (no args)                     → plaintext on 127.0.0.1:18080
@@ -36,7 +38,7 @@ $ `packages/http/src/http.nu`
 @ __sized i status ( Vec u ) body → HttpResponse {
     : HttpResponse r ( response_new status )
     ( response_set_header r `Content-Type` `application/octet-stream` )
-    ( response_set_body_bytes r body )
+    ( response_set_body_borrowed_bytes r body )
     ^ r
 }
 

--- a/compiler/tests/outputs/vec_borrowed.txt
+++ b/compiler/tests/outputs/vec_borrowed.txt
@@ -1,0 +1,34 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+view_len_1000=T
+view_cap_is_len=T
+view_data_is_source=T
+view_eq_source=T
+view_get_7=T
+set_len_grow_refused=T
+set_len_shrink_ok=T
+view_len_500=T
+view_len_still_500=T
+source_intact_after_view_free=T
+cow_len_1001=T
+cow_detached=T
+cow_kept_prefix=T
+cow_source_len_1000=T
+clear_extend_len_2=T
+clear_extend_detached=T
+clear_extend_source_byte0_still_0=T
+shrink_noop_on_view=T
+shrink_after_detach_cap_len=T
+empty_view_len_0=T
+empty_view_grows=T
+into_len_1000=T
+into_data_is_source=T
+into_again_len_10=T
+into_empty_len_0=T
+borrowed_body_is_source=T
+borrowed_wire_eq_owned=T
+wire_len_gt_body=T
+replaced_body_owned=T
+source_intact_after_response_free=T

--- a/compiler/tests/vec_borrowed.nu
+++ b/compiler/tests/vec_borrowed.nu
@@ -1,0 +1,127 @@
+// vec_borrowed.nu — borrowed Vec views (`vec_borrow_raw`) and the
+// borrowed HTTP response body built on them.
+//
+// A borrowed view reads the caller's buffer in place, detaches into an
+// owned copy on the first growth (copy-on-write), and its free releases
+// only the handle. Each of those is checked against the SOURCE buffer,
+// which must survive every operation on the view unchanged — under the
+// sanitizer run this is also the proof that no view ever frees memory
+// it does not own.
+//
+// Determinism: no clock, no socket, no env. ASan-clean.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/http_response.nu`
+
+@ label s name b v → v {
+    ( nurl_print name )
+    ( nurl_print `=` )
+    ( nurl_print ? v `T` `F` )
+    ( nurl_print `\n` )
+}
+
+// 0,1,2,…,n-1 mod 256
+@ ramp i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] v # u & k 255 )
+        = k + k 1
+    }
+    ^ v
+}
+
+@ main → i {
+    : ( Vec u ) src ( ramp 1000 )
+    : *u sp ( vec_data [u] src )
+
+    // ── read-through: same bytes, no copy ──
+    : ( Vec u ) view ( vec_borrow_raw [u] sp 1000 )
+    ( label `view_len_1000` == ( vec_len [u] view ) 1000 )
+    ( label `view_cap_is_len` == ( vec_cap [u] view ) 1000 )
+    ( label `view_data_is_source` == # i ( vec_data [u] view ) # i sp )
+    ( label `view_eq_source` ( bytes_eq view src ) )
+    ( label `view_get_7` ?? ( vec_get [u] view 7 ) { T x → == # i x 7 F → F } )
+
+    // ── set_len: shrink allowed, growth refused ──
+    ( label `set_len_grow_refused` ! ( vec_set_len [u] view 1001 ) )
+    ( label `set_len_shrink_ok` ( vec_set_len [u] view 500 ) )
+    ( label `view_len_500` == ( vec_len [u] view ) 500 )
+    : b _r ( vec_set_len [u] view 1000 )  // refused: extent is 500 now
+    ( label `view_len_still_500` == ( vec_len [u] view ) 500 )
+    ( vec_free [u] view )
+    ( label `source_intact_after_view_free` & == ( vec_len [u] src ) 1000 == # i . sp 999 231 )
+
+    // ── copy-on-write: push detaches, source untouched ──
+    : ( Vec u ) v2 ( vec_borrow_raw [u] sp 1000 )
+    ( vec_push [u] v2 # u 42 )
+    ( label `cow_len_1001` == ( vec_len [u] v2 ) 1001 )
+    ( label `cow_detached` != # i ( vec_data [u] v2 ) # i sp )
+    ( label `cow_kept_prefix` ?? ( vec_get [u] v2 999 ) { T x → == # i x 231 F → F } )
+    ( label `cow_source_len_1000` == ( vec_len [u] src ) 1000 )
+    ( vec_free [u] v2 )
+
+    // ── clear + extend (the compressing-middleware shape) ──
+    : ( Vec u ) v3 ( vec_borrow_raw [u] sp 1000 )
+    ( vec_clear [u] v3 )
+    ( bytes_extend_str v3 `gz` )
+    ( label `clear_extend_len_2` == ( vec_len [u] v3 ) 2 )
+    ( label `clear_extend_detached` != # i ( vec_data [u] v3 ) # i sp )
+    ( label `clear_extend_source_byte0_still_0` == # i . sp 0 0 )
+    ( vec_free [u] v3 )
+
+    // ── shrink_to_fit on a view is a no-op; on a detached one it works ──
+    : ( Vec u ) v4 ( vec_borrow_raw [u] sp 10 )
+    ( vec_shrink_to_fit [u] v4 )
+    ( label `shrink_noop_on_view` == # i ( vec_data [u] v4 ) # i sp )
+    ( vec_reserve [u] v4 100 )
+    ( vec_shrink_to_fit [u] v4 )
+    ( label `shrink_after_detach_cap_len` == ( vec_cap [u] v4 ) 10 )
+    ( vec_free [u] v4 )
+
+    // ── empty / null views are ordinary empty owned Vecs ──
+    : ( Vec u ) v5 ( vec_borrow_raw [u] sp 0 )
+    ( label `empty_view_len_0` == ( vec_len [u] v5 ) 0 )
+    ( vec_push [u] v5 # u 1 )
+    ( label `empty_view_grows` == ( vec_len [u] v5 ) 1 )
+    ( vec_free [u] v5 )
+
+    // ── vec_borrow_into: an owned handle becomes a view, its old buffer released ──
+    : ( Vec u ) v6 ( ramp 300 )
+    ( vec_borrow_into [u] v6 sp 1000 )
+    ( label `into_len_1000` == ( vec_len [u] v6 ) 1000 )
+    ( label `into_data_is_source` == # i ( vec_data [u] v6 ) # i sp )
+    ( vec_borrow_into [u] v6 sp 10 )  // view → view: nothing to free
+    ( label `into_again_len_10` == ( vec_len [u] v6 ) 10 )
+    ( vec_push [u] v6 # u 9 )  // detach
+    ( vec_borrow_into [u] v6 sp 0 )  // owned → empty owned
+    ( label `into_empty_len_0` == ( vec_len [u] v6 ) 0 )
+    ( vec_free [u] v6 )
+
+    // ── borrowed response body: identical wire bytes, nothing foreign freed ──
+    : HttpResponse owned ( response_new 200 )
+    ( response_set_header owned `Content-Type` `application/octet-stream` )
+    ( response_set_body_bytes owned src )
+    : HttpResponse borrowed ( response_new 200 )
+    ( response_set_header borrowed `Content-Type` `application/octet-stream` )
+    ( response_set_body_borrowed_bytes borrowed src )
+    ( label `borrowed_body_is_source` == # i ( vec_data [u] . borrowed body ) # i sp )
+    : ( Vec u ) w1 ( response_serialize owned )
+    : ( Vec u ) w2 ( response_serialize borrowed )
+    ( label `borrowed_wire_eq_owned` ( bytes_eq w1 w2 ) )
+    ( label `wire_len_gt_body` > ( vec_len [u] w2 ) 1000 )
+    ( vec_free [u] w1 )
+    ( vec_free [u] w2 )
+    // replacing a borrowed body with an owned one, and back, frees only what is owned
+    ( response_set_body_str borrowed `x` )
+    ( label `replaced_body_owned` != # i ( vec_data [u] . borrowed body ) # i sp )
+    ( response_set_body_borrowed borrowed sp 1000 )
+    ( http_response_free borrowed )
+    ( http_response_free owned )
+    ( label `source_intact_after_response_free` & == ( vec_len [u] src ) 1000 == # i . sp 500 244 )
+
+    ( vec_free [u] src )
+    ^ 0
+}

--- a/stdlib/core/vec.nu
+++ b/stdlib/core/vec.nu
@@ -31,6 +31,22 @@
 // API:
 //   ( vec_new [A] )                → ( Vec A )   empty, no alloc
 //   ( vec_with_cap [A] n )         → ( Vec A )   preallocated
+//   ( vec_borrow_raw [A] p n )     → ( Vec A )   BORROWED view of p[0..n):
+//                                                reads see the caller's
+//                                                buffer, the first growth
+//                                                detaches into an owned
+//                                                copy (copy-on-write), and
+//                                                vec_free releases only the
+//                                                handle — never p. Caller
+//                                                keeps p alive and stable
+//                                                for as long as the view
+//                                                is read. Element writes
+//                                                (vec_set/swap/…) before a
+//                                                detach go THROUGH to p.
+//   ( vec_borrow_into [A] v p n )  → v          re-point an EXISTING handle
+//                                                (e.g. a struct field) at
+//                                                p[0..n) as a view, freeing
+//                                                what it owned
 //   ( vec_zeroed [A] n )           → ( Vec A )   n zero-filled elements,
 //                                                len == n, one calloc
 //   ( vec_len [A] v )              → i          current length
@@ -120,10 +136,32 @@
     ^ ( nurl_peek ctl 2 )
 }
 
+// A borrowed view (vec_borrow_raw) keeps cap == -1: the buffer is not
+// ours to grow, shrink or free. Every path that would touch the
+// allocation checks this first; readers never need to.
+@ __vec_is_borrowed s ctl → b {
+    ^ < ( __vec_cap_raw ctl ) 0
+}
+
 // Grow the underlying buffer so that cap >= need. Uses nurl_realloc;
 // safe to call when the current data pointer is null (cap == 0).
 @ __vec_grow [A] s ctl i need → v {
     : i cap ( __vec_cap_raw ctl )
+    ? < cap 0 {
+        // Borrowed view: the first growth DETACHES — copy the live
+        // elements into a fresh owned buffer and leave the source
+        // untouched. From here on this is an ordinary owned Vec.
+        : i len ( __vec_len_raw ctl )
+        : ~ i new_cap 4
+        ~ < new_cap need { = new_cap * new_cap 2 }
+        ~ < new_cap len { = new_cap * new_cap 2 }
+        : s fresh ( nurl_alloc * Z A new_cap )
+        : i copy_bytes * Z A len
+        ? > copy_bytes 0 { ( nurl_memcpy fresh ( __vec_data_raw ctl ) copy_bytes ) } {}
+        ( nurl_poke ctl 0 # i fresh )
+        ( nurl_poke ctl 2 new_cap )
+        ^
+    } {}
     ? < cap need {
         : ~ i new_cap ? == cap 0 4 cap
         ~ < new_cap need { = new_cap * new_cap 2 }
@@ -175,6 +213,61 @@
     ^ @ ( Vec A ) { ctl }
 }
 
+// A BORROWED view of `p[0..n)`: a Vec handle whose data pointer is the
+// caller's buffer. Reads (`vec_len`, `vec_data`, `vec_get`, iteration,
+// `bytes_extend_bytes`, the socket writers …) work unchanged and see the
+// caller's bytes with no copy. The first operation that needs capacity
+// (`vec_push`, `vec_extend`, `vec_reserve`, …) detaches: it copies the
+// live elements into a fresh owned buffer and the handle becomes an
+// ordinary owned Vec (copy-on-write). `vec_free` on an undetached view
+// releases only the 24-byte handle, never `p`.
+//
+// The contract is the caller's: `p` must stay alive and unchanged for as
+// long as the view is read — the borrow checker cannot see through a
+// raw pointer. Element writes made through the view before it detaches
+// (`vec_set`, `vec_swap`, `vec_reverse`, raw `vec_data` stores) land in
+// `p`, exactly like two handles on one buffer do today.
+//
+// Why: the HTTP server's large-body path. A handler serving a
+// precomputed buffer (a static asset, an mmap, a cache entry) used to
+// pay a full copy of it into the response (`response_set_body_bytes`);
+// hyper's `Bytes::clone` is a refcount bump. With a view the response
+// body is the caller's buffer and the write path reads it in place.
+// `n <= 0` (or a null `p`) is an ordinary empty owned Vec.
+@ vec_borrow_raw [A] * A p i n → ( Vec A ) {
+    : s ctl ( nurl_zalloc 24 )
+    ( __vec_point_at ctl # i p n )
+    ^ @ ( Vec A ) { ctl }
+}
+
+// Re-point an EXISTING handle at `p[0..n)` as a borrowed view, releasing
+// whatever buffer it owned. This is how a Vec that lives in a struct
+// field becomes a view: struct values travel by copy, so assigning a
+// fresh handle into `. r body` inside a helper would change only the
+// helper's copy and leave the caller holding a freed one — the control
+// block is the shared thing, so it is the control block that changes.
+@ vec_borrow_into [A] ( Vec A ) v * A p i n → v {
+    : s ctl . v ctl
+    : s data ( __vec_data_raw ctl )
+    : i ctl_end + # i ctl 24
+    ? & ! ( __vec_is_borrowed ctl ) & != 0 # i data != # i data ctl_end { ( nurl_free data ) } {}
+    ( __vec_point_at ctl # i p n )
+}
+
+// Write a borrowed view into a control block; an empty or null range is
+// the empty owned state (data 0, len 0, cap 0).
+@ __vec_point_at s ctl i p i n → v {
+    ? & > n 0 != 0 p {
+        ( nurl_poke ctl 0 p )
+        ( nurl_poke ctl 1 n )
+        ( nurl_poke ctl 2 -1 )
+    } {
+        ( nurl_poke ctl 0 0 )
+        ( nurl_poke ctl 1 0 )
+        ( nurl_poke ctl 2 0 )
+    }
+}
+
 // `n` zero-filled elements in ONE allocation, with `len` already at n —
 // the calloc-shaped sibling of `vec_with_cap`. Reaching the same state
 // by pushing a zero n times costs n bounds checks, n length stores and
@@ -201,8 +294,12 @@
     ^ ( __vec_len_raw . v ctl )
 }
 
+// For a borrowed view the capacity is its length: nothing beyond the
+// live elements may be written without detaching.
 @ vec_cap [A] ( Vec A ) v → i {
-    ^ ( __vec_cap_raw . v ctl )
+    : s ctl . v ctl
+    ? ( __vec_is_borrowed ctl ) { ^ ( __vec_len_raw ctl ) } {}
+    ^ ( __vec_cap_raw ctl )
 }
 
 @ vec_is_empty [A] ( Vec A ) v → b {
@@ -312,7 +409,8 @@
 @ vec_set_len [A] ( Vec A ) v i n → b {
     ? < n 0 { ^ F } {}
     : s ctl . v ctl
-    : i cap ( __vec_cap_raw ctl )
+    // A borrowed view can only shrink: its writable extent is its length.
+    : i cap ? ( __vec_is_borrowed ctl ) ( __vec_len_raw ctl ) ( __vec_cap_raw ctl )
     ? > n cap { ^ F } {}
     ( nurl_poke ctl 1 n )
     ^ T
@@ -406,6 +504,8 @@
 // (cap → 0, data → null). Otherwise the buffer is realloc'd down to len.
 @ vec_shrink_to_fit [A] ( Vec A ) v → v {
     : s ctl . v ctl
+    // Not our buffer to resize or free.
+    ? ( __vec_is_borrowed ctl ) { ^ } {}
     : i len ( __vec_len_raw ctl )
     : i cap ( __vec_cap_raw ctl )
     ? == len 0 {
@@ -486,12 +586,14 @@
 @ vec_free [A] ( Vec A ) v → v {
     : s ctl . v ctl
     : s data ( __vec_data_raw ctl )
+    // A borrowed view (vec_borrow_raw) never owned its buffer: release
+    // the handle only.
     // `string_from_bytes_packed` (core/string.nu) lays the data
     // buffer immediately after the 24-byte ctl in a single alloc.
     // Detect that case (data == ctl + 24) and skip the separate
     // buffer-free — both regions live in the one block freed below.
     : i ctl_end + # i ctl 24
-    ? & != 0 # i data != # i data ctl_end { ( nurl_free data ) } {}
+    ? & ! ( __vec_is_borrowed ctl ) & != 0 # i data != # i data ctl_end { ( nurl_free data ) } {}
     ( nurl_free ctl )
 }
 
@@ -505,6 +607,9 @@
     : s ctl . v ctl
     : i len ( __vec_len_raw ctl )
     : s data ( __vec_data_raw ctl )
+    // A borrowed view owns neither the elements nor the buffer: no
+    // drops, handle only.
+    ? ( __vec_is_borrowed ctl ) { ( nurl_free ctl ) ^ } {}
     ? != 0 # i data {
         : *A buf # *A data
         : ~ i i 0

--- a/stdlib/ext/http_response.nu
+++ b/stdlib/ext/http_response.nu
@@ -12,6 +12,8 @@
 //   ( response_add_header  HttpResponse r s name s value ) → v
 //   ( response_set_body_str   HttpResponse r s text )      → v
 //   ( response_set_body_bytes HttpResponse r ( Vec u ) )   → v
+//   ( response_set_body_borrowed HttpResponse r *u p i n )  → v   no copy; p outlives the write
+//   ( response_set_body_borrowed_bytes HttpResponse r ( Vec u ) ) → v   no copy; Vec outlives the write
 //   ( response_set_body_json  HttpResponse r Json j )      → v
 //
 //   ( response_text     i status s text )          → HttpResponse
@@ -146,6 +148,34 @@ $ `stdlib/ext/json.nu`
 @ response_set_body_bytes HttpResponse r ( Vec u ) bytes → v {
     ( vec_clear [u] . r body )
     ( vec_extend [u] . r body bytes )
+}
+
+// Make `p[0..n)` the body WITHOUT copying it: the body becomes a
+// borrowed view (`vec_borrow_raw`) of the caller's buffer, the server
+// writes it in place, and `http_response_free` releases only the view,
+// never `p`. This is the large-body fast path — a precomputed asset, a
+// cache entry, an mmap — where the copy `response_set_body_bytes` makes
+// was the whole per-byte cost of the response.
+//
+// Contract (the borrow checker cannot see through a raw pointer, so it
+// is yours): `p` stays alive and unchanged until the response has been
+// written — in a handler that means a buffer that outlives the request,
+// such as one owned by the app for its whole run. Anything that later
+// appends to the body (a compressing middleware, say) detaches the view
+// into an owned copy first; nothing ever frees `p` through the response.
+@ response_set_body_borrowed HttpResponse r * u p i n → v {
+    // In place, through the body's control block — `r` is a by-value
+    // struct here, so a fresh handle assigned to `. r body` would reach
+    // only this copy (the sanitizer run caught exactly that: the caller
+    // kept a freed handle).
+    ( vec_borrow_into [u] . r body p n )
+}
+
+// Same, borrowing the live range of an existing `( Vec u )`. The caller
+// keeps `bytes` alive and does not mutate or free it until the response
+// has been written.
+@ response_set_body_borrowed_bytes HttpResponse r ( Vec u ) bytes → v {
+    ( response_set_body_borrowed r ( vec_data [u] bytes ) ( vec_len [u] bytes ) )
 }
 
 // JSON convenience: serialises `j`, copies into the body, and sets


### PR DESCRIPTION
## Summary

Stage 2 of the plan behind the HTTP torture findings (stacked on #1050): a response can now carry a caller-owned body **without copying it**.

After #1050 the server writes the body from the response in place, so the only remaining full copy of a large response body was the inbound one — `response_set_body_bytes` copying the handler's buffer into `r.body`. hyper does not pay it (`Bytes::clone` is a refcount bump).

### What changed

- **`core/vec.nu` — borrowed views.** `vec_borrow_raw [A] p n` makes a `Vec` handle over the caller's buffer. Every reader (`vec_len`, `vec_data`, `vec_get`, iteration, `bytes_extend_bytes`, the socket writers, the 13 places in stdlib that read `. r body`) works unchanged and sees the caller's bytes in place. The first operation that needs capacity (`vec_push`, `vec_extend`, `vec_reserve`, …) **detaches**: it copies the live elements into a fresh owned buffer and the handle becomes an ordinary owned Vec (copy-on-write). `vec_free` / `vec_free_with` on an undetached view release only the 24-byte handle. A view is marked by `cap == -1` in the control block, following the precedent of the packed-string layout that `__vec_grow` / `vec_free` already special-case; `vec_cap` and `vec_set_len` treat the length as the writable extent and `vec_shrink_to_fit` is a no-op on a view.
- `vec_borrow_into [A] v p n` re-points an existing handle at a buffer, releasing what it owned. That is the form a struct field needs: struct values travel by copy, so a helper that assigned a fresh handle into `. r body` changed only its own copy and left the caller holding a freed one. The -O2 test passed that version by luck (the 24-byte control block was recycled by the very next allocation); the sanitizer corpus caught it, and the fix is to change the shared control block in place.
- **`http_response.nu`** — `response_set_body_borrowed r p n` and `response_set_body_borrowed_bytes r v`. Owned bodies stay the default; borrowed is opt-in for the pattern that needs it (a precomputed asset, a cache entry, an mmap). The lifetime contract is the caller's and is documented at both setters: the buffer outlives the write. A middleware that appends to the body (compression) detaches the view first; nothing ever frees the caller's buffer through the response.
- No discriminator was added to `HttpResponse`: putting the borrow in the Vec keeps every existing body reader correct without touching it, and puts the copy-on-write decision at the one place growth is decided.
- `bench/http_torture/server.nu` serves its precomputed bodies borrowed — now the same shape as the Rust peer's cloned `Bytes`.
- Test `compiler/tests/vec_borrowed.nu` (26 checks): read-through, `set_len` shrink/grow, copy-on-write on push and on clear+extend with the source proven intact, `shrink_to_fit`, empty views, and a borrowed response body whose wire bytes equal the owned one's — with the source buffer read after every free. Under ASan this is the proof that a view never frees memory it does not own.

### Verification

- `./build.sh` (bootstrap fixed point + full suite) green; `./build.sh --san` + `run_san_tests.sh`: 905 PASS, 0 SAN_FAIL.
- Torture server: byte-exact bodies on plaintext and TLS for 14 B / 1 KB / 16 KB / 1 MB, keep-alive and a slow reader.
- `bench/http_torture`, MODE=full, same host as the committed numbers (i7-5930K, server cores 0-5 / generator 6-11), after #1050 → this PR:

| Cell | after #1050 | this PR | hyper (same run) |
|---|--:|--:|--:|
| 1 KB sustainable req/s | 192 000 (tie) | 176 000 (tie) | 176 000 |
| 16 KB sustainable req/s | 124 000 | 124 000 | 124 000 |
| 1 MB sustainable req/s | 2 250 | **3 000** | 3 000 |
| 1 KB CPU µs/req | 24.4 | 24.8 | 26.5 |
| 16 KB CPU µs/req | 35.3 | 34.5 | 36.1 |
| 1 MB CPU µs/req | 1 137 | **910** | 928 |
| 1 MB churn (fresh conn/req) req/s | 1 924 | **2 718** | 2 748 |
| keep-alive 2000 conns, req/s | 178 421 | 179 451 | 174 203 |

The 1 MB gap is gone: sustainable rate equal to hyper's, CPU per request below it; the 1 MB churn cell went from 30 % behind to parity. Sustainable capacity is now a tie at every body size (1 KB is the generator's ceiling; both servers hit it together, at 176k this run vs 192k in the previous — run-to-run machine state, both peers move together). Still behind: connection churn at 1 KB / 16 KB (~5 %), the slowloris cell (~12 %), and TLS resumption (next PR).

### Harness

`SETTLE_SEC` (120 s in full mode) idles the box between the harness's own build step and the first cell. Two full runs on this host had their first cell — NURL, 1 KB — collapse to ~40 % of its clean capacity with the tail in the seconds, while the same binary sustained the clean rate minutes later and the peer, measured next, was unaffected; both runs had started right after a sanitizer corpus. The committed table is from a run with the settle; the two biased runs were discarded rather than spliced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw
