### PR TITLE
runtime: size the worker pool by what the process may run on, not by the machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The fiber scheduler sized its default worker pool by the machine's
+  online CPU count, not by what the process may run on.** A server
+  pinned with `taskset` to 6 of 12 hardware threads got 12 workers on 6
+  cores; measured at 20 connections that was 0.75 context switches and
+  0.2 CPU migrations per request (124k req/s, p50 0.135 ms) against
+  153k at p50 0.115 ms with six workers. The default (`NURL_WORKERS`
+  unset or 0, `http_app_async a 0`) now comes from
+  `nurl_available_parallelism()`: the affinity mask (`sched_getaffinity`
+  / `GetProcessAffinityMask`) capped by the cgroup v1/v2 CPU quota —
+  what Rust's `available_parallelism()` returns and what the tokio peer
+  sizes itself by. `sys_available_parallelism` exposes it;
+  `sys_cpu_count` still reports the hardware count.
 - The reactor accept path took three `fcntl(2)` per connection (the
   normalise-to-blocking check, then the first async wrapper's GET+SET to
   flip it back) — a third of everything the async server asked the

--- a/docs/ASYNC.md
+++ b/docs/ASYNC.md
@@ -132,7 +132,11 @@ handshake fails is now one failed connection; a plain-TCP probe against
 a TLS port used to take the whole accept loop down with it.
 
 `packages/http` exposes this as **`http_app_async n`** — fiber per
-connection, `n` worker pthreads, `0` meaning one per core.
+connection, `n` worker pthreads, `0` meaning one per CPU the *process*
+may run on — the affinity mask (`taskset`, cpusets) capped by the
+container's cgroup CPU quota (`sys_available_parallelism`), not the
+machine's CPU count; a pool larger than that only time-slices against
+itself.
 
 ## 4. Semantics worth knowing
 

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -4377,6 +4377,83 @@ void nurl_fiber_join(long long fiber) {
 
 /* ── Worker loop ─────────────────────────────────────────────────── */
 
+#if defined(__linux__)
+#include <sched.h>   /* sched_getaffinity, CPU_COUNT (under _GNU_SOURCE) */
+/* ceil(quota / period) from a cgroup cpu limit, or 0 when unlimited or
+ * unreadable. v2: one file "cpu.max" = "<quota|max> <period>"; v1: two
+ * files cpu.cfs_quota_us (-1 = none) and cpu.cfs_period_us. */
+static long long nurl__cgroup_cpu_limit(void) {
+    char buf[64];
+    FILE *f = fopen("/sys/fs/cgroup/cpu.max", "r");
+    if (f) {
+        long long quota = 0, period = 0;
+        int ok = fscanf(f, "%lld %lld", &quota, &period) == 2;
+        fclose(f);
+        if (ok && quota > 0 && period > 0) return (quota + period - 1) / period;
+        /* "max <period>" fails the %lld on "max": unlimited */
+        return 0;
+    }
+    f = fopen("/sys/fs/cgroup/cpu/cpu.cfs_quota_us", "r");
+    if (!f) f = fopen("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "r");
+    if (f) {
+        long long quota = -1, period = 0;
+        if (!fgets(buf, sizeof buf, f)) buf[0] = 0;
+        fclose(f);
+        quota = atoll(buf);
+        if (quota <= 0) return 0;
+        FILE *p = fopen("/sys/fs/cgroup/cpu/cpu.cfs_period_us", "r");
+        if (!p) p = fopen("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "r");
+        if (!p) return 0;
+        if (!fgets(buf, sizeof buf, p)) buf[0] = 0;
+        fclose(p);
+        period = atoll(buf);
+        if (period <= 0) return 0;
+        return (quota + period - 1) / period;
+    }
+    return 0;
+}
+#endif
+
+/* HOSTED ONLY (this file is the half a freestanding target does not
+ * have; the unikernel's cooperative runtime never sizes a pool).
+ * How many threads can run at once FOR THIS PROCESS — the number the
+ * fiber scheduler sizes its worker pool by. Not the machine's CPU count:
+ * a process pinned with taskset/cpuset to 6 of 12 hardware threads, or
+ * capped by a container's cgroup CPU quota, gets exactly that many
+ * runnable threads, and every worker beyond it is a thread the kernel
+ * has to time-slice against a sibling. Measured on the reference host
+ * (12 hardware threads, server pinned to cores 0-5): the online count
+ * gave 12 workers on 6 cores — 0.75 context switches and 0.2 CPU
+ * migrations PER REQUEST at 20 connections, 124k req/s at p50 0.135 ms;
+ * six workers gave 153k at p50 0.115 ms with 50x fewer migrations. This
+ * is what Rust's std::thread::available_parallelism() returns, and thus
+ * what the tokio peer sizes itself by. Falls back to nurl_cpu_count. */
+long long nurl_available_parallelism(void) {
+    long long n = nurl_cpu_count();
+#if defined(__linux__)
+    {
+        cpu_set_t set;
+        CPU_ZERO(&set);
+        if (sched_getaffinity(0, sizeof set, &set) == 0) {
+            long long c = (long long)CPU_COUNT(&set);
+            if (c > 0 && c < n) n = c;
+        }
+        long long q = nurl__cgroup_cpu_limit();
+        if (q > 0 && q < n) n = q;
+    }
+#elif defined(_WIN32)
+    {
+        DWORD_PTR pmask = 0, smask = 0;
+        if (GetProcessAffinityMask(GetCurrentProcess(), &pmask, &smask) && pmask) {
+            long long c = 0;
+            while (pmask) { c += (long long)(pmask & 1); pmask >>= 1; }
+            if (c > 0 && c < n) n = c;
+        }
+    }
+#endif
+    return n > 0 ? n : 1;
+}
+
 /* xorshift32 — branch-free victim picker. */
 static unsigned nurl__rng_next(unsigned *st) {
     unsigned x = *st;
@@ -4541,7 +4618,11 @@ void nurl_runtime_init(long long worker_count) {
         const char *env = getenv("NURL_WORKERS");
         if (env && *env) wc = (int)nurl__parse_ul(env, NULL);
         if (wc <= 0) {
-            long n = sysconf(_SC_NPROCESSORS_ONLN);
+            /* One worker per thread this PROCESS may run — the affinity
+             * mask and the cgroup quota, not the machine's CPU count
+             * (see nurl_available_parallelism in runtime_core.c for the
+             * measurement that made the difference visible). */
+            long long n = nurl_available_parallelism();
             wc = (n > 0) ? (int)n : 2;
         }
     }

--- a/stdlib/std/sysinfo.nu
+++ b/stdlib/std/sysinfo.nu
@@ -24,6 +24,8 @@ $ `stdlib/core/string.nu`
 
 & `c` @ nurl_cpu_count → i
 
+& `c` @ nurl_available_parallelism → i
+
 : i SYS_SYSNAME 0
 : i SYS_NODENAME 1
 : i SYS_RELEASE 2
@@ -52,4 +54,14 @@ $ `stdlib/core/string.nu`
 @ sys_cpu_count → i {
     : i n ( nurl_cpu_count )
     ^ ? < n 1 1 n
+}
+
+// How many threads THIS PROCESS can run at once: the affinity mask
+// (taskset / cpuset) capped by a container's cgroup CPU quota — what
+// the fiber scheduler sizes its worker pool by when NURL_WORKERS is
+// unset, and what Rust's available_parallelism() reports. sys_cpu_count
+// is the machine's hardware count regardless of such limits.
+@ sys_available_parallelism → i {
+    : i n ( nurl_available_parallelism )
+    ^ ? > n 0 n 1
 }


### PR DESCRIPTION
## Summary

The fiber scheduler's default worker count (`NURL_WORKERS` unset or `0`, `http_app_async a 0`) was the machine's online CPU count, whatever the process is actually allowed to run on. The torture harness pins the server to cores 0-5 of a 12-thread host, so every NURL number in the torture series was measured with **12 workers on 6 cores**, while the tokio peer — sized by `std::thread::available_parallelism()`, which honours the affinity mask — ran 6.

Measured at 20 connections on `/16k`:

| workers on 6 cores | req/s | p50 | context switches / 4 s | CPU migrations / 4 s |
|---|--:|--:|--:|--:|
| 12 (old default) | 123 682 | 0.135 ms | 374 233 | 103 052 |
| 6 (`NURL_WORKERS=6`) | 153 074 | 0.115 ms | 173 957 | 2 330 |
| hyper/rustls | 145 266 | 0.116 ms | 131 807 | 1 694 |

That oversubscribed pool **is** the low-concurrency gap the slowloris cell had been attributed to (the same numbers reproduce with no trickle clients at all), and most of the churn CPU gap: with the fix NURL is ahead on churn req/s (39.8k vs 38.5k), CPU per connection +9 % instead of +12 %. At c=1 NURL was already faster than hyper (p50 0.058 vs 0.100 ms).

### Change

- `nurl_available_parallelism()` (runtime_core.c): the affinity mask (`sched_getaffinity` on Linux, `GetProcessAffinityMask` on Windows) capped by the cgroup v1/v2 CPU quota (`cpu.max`, `cpu.cfs_quota_us`/`cpu.cfs_period_us`), falling back to the online count. The same answer Rust's std gives.
- The scheduler default uses it. `NURL_WORKERS=n` still overrides.
- `sys_available_parallelism` in `std/sysinfo.nu` exposes it; `sys_cpu_count` still reports the hardware count. `docs/ASYNC.md` says which is which.

### Verification

- `./build.sh` (bootstrap fixed point + full suite) green; `./build.sh --san` + `run_san_tests.sh`: SAN_RESULT.
- 40 async / HTTP server / websocket / net / TLS / sysinfo tests pass locally; under `taskset -c 0-5` the server now starts 6 workers (7 threads), not 12.
- TORTURE_NOTE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw
