### PR TITLE
tls: send psk_key_exchange_modes in every ClientHello; issue tickets only when it was sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TLS 1.3 resumption did not interoperate with rustls.** RFC 8446
+  §4.2.9 forbids a server from sending a `NewSessionTicket` to a client
+  that did not send `psk_key_exchange_modes`; the NURL client sent that
+  extension only when it was already offering a ticket, so rustls — which
+  obeys the rule — never issued one and a NURL client never resumed
+  against a Rust server (openssl and the NURL server were lenient, which
+  hid it). The client now sends `psk_key_exchange_modes` (`psk_dhe_ke`)
+  in every ClientHello, and the NURL server issues a ticket only to a
+  client that sent it. Verified in all four directions (NURL/openssl
+  client × NURL/rustls/openssl server).
+
 ### Added
 
 - **The HTTP client resumes TLS sessions on its own.** `ext/http_pure.nu`

--- a/bench/http_torture/README.md
+++ b/bench/http_torture/README.md
@@ -36,9 +36,12 @@ numbers are.
 
 ## Fairness
 
-- Both servers are pinned to the **same** cores (`SRV_CORES`, default `0-5`);
-  the load generator to disjoint cores (`GEN_CORES`, default `6-11`), so the
-  generator never steals the server's CPU and vice versa.
+- Both servers are pinned to the **same** cores (`SRV_CORES`); the load
+  generator to disjoint cores (`GEN_CORES`), so the generator never steals
+  the server's CPU and vice versa. The defaults split the online CPUs in
+  half (`0-5` / `6-11` on a 12-thread host, `0-1` / `2-3` on a 4-vCPU
+  runner); the NURL server sizes its worker pool by that affinity mask,
+  exactly as tokio does.
 - Both peers serve **byte-identical bodies** (`/` = 14 B, `/1k`, `/16k`,
   `/1m`), each built once at startup and handed to a response per request.
   The NURL peer is the `packages/http` HttpApp facade in `http_app_async`
@@ -70,3 +73,15 @@ The report is written to `TORTURE_RESULTS.md`; the scratch directory
 `server.nu` is the NURL peer; `rust/` the hyper peer; `slowloris.py` and
 `tls_resume.py` are the two probes bash can't express; `lib.py` extracts
 the oha JSON fields.
+
+## Whose numbers are in `TORTURE_RESULTS.md`
+
+The committed table is whatever the **`http-torture` GitHub Action** last
+wrote: a full run on an `ubuntu-latest` runner (4 vCPUs — servers on
+cores 0-1, the generator on 2-3), committed to `main` the same way
+`bench/HTTP_RESULTS.md` and `bench/PQ_RESULTS.md` are. Its header names
+the host and links the run. Absolute numbers there are a fraction of a
+workstation's; read the two servers against each other on the same
+cores. Workstation runs (12 threads, servers on 0-5 / generator on 6-11)
+are posted in the pull requests that changed the numbers (#1053, #1054,
+#1055), not committed. When citing a cell, say which host produced it.

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -674,21 +674,27 @@ $ `stdlib/std/async_ffi.nu`
         ( vec_free [u] alp )
     } {}
 
-    // ── resumption offer (RFC 8446 §4.2.9 + §4.2.11) ──
-    // psk_key_exchange_modes: psk_dhe_ke only — a resumed handshake still
-    // runs a fresh (EC)DHE, so a ticket that leaks later never decrypts a
-    // recording of this connection. pre_shared_key MUST be the last
-    // extension: its binder is an HMAC over the ClientHello up to (not
-    // including) the binders list, so everything else has to be in place
-    // first. The binder bytes here are a placeholder the caller overwrites
-    // once it has hashed the truncated hello (see _psk_binder_over).
+    // ── resumption (RFC 8446 §4.2.9 + §4.2.11) ──
+    // psk_key_exchange_modes goes in EVERY hello, offer or not: it is
+    // how a client says it can resume, and §4.2.9 forbids a server from
+    // sending a NewSessionTicket to a client that did not send it —
+    // rustls obeys, so without this the client never received a ticket
+    // from the Rust peer (openssl and our own server were lenient, which
+    // hid it). psk_dhe_ke only — a resumed handshake still runs a fresh
+    // (EC)DHE, so a ticket that leaks later never decrypts a recording of
+    // this connection.
+    : ( Vec u ) modes ( vec_new [u] )
+    ( vec_push [u] modes # u 1 )  // list length
+    ( vec_push [u] modes # u 1 )  // psk_dhe_ke
+    ( _tls_u16 ext 45 )
+    ( _blk16 ext modes )
+    ( vec_free [u] modes )
+    // pre_shared_key MUST be the last extension: its binder is an HMAC
+    // over the ClientHello up to (not including) the binders list, so
+    // everything else has to be in place first. The binder bytes here
+    // are a placeholder the caller overwrites once it has hashed the
+    // truncated hello (see _psk_binder_over).
     ? > ( vec_len [u] psk_id ) 0 {
-        : ( Vec u ) modes ( vec_new [u] )
-        ( vec_push [u] modes # u 1 )  // list length
-        ( vec_push [u] modes # u 1 )  // psk_dhe_ke
-        ( _tls_u16 ext 45 )
-        ( _blk16 ext modes )
-        ( vec_free [u] modes )
         : ( Vec u ) psk ( vec_new [u] )
         ( _tls_u16 psk + ( vec_len [u] psk_id ) 6 )  // identities: u16 len + id + u32 age
         ( _blk16 psk psk_id )

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -184,6 +184,22 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_free [u] age_add ) ( vec_free [u] body ) ( vec_free [u] msg )
 }
 
+// Did the ClientHello carry psk_key_exchange_modes with psk_dhe_ke? A
+// server MUST NOT send a NewSessionTicket to a client that did not
+// (RFC 8446 §4.2.9) — the client is saying it cannot resume, and a
+// strict one may treat an unsolicited ticket as an error.
+@ __srv_client_can_resume ( Vec u ) ch i es i ee → b {
+    : i modes ( __srv_find_ext ch es ee 45 )
+    ? < modes 0 { ^ F } {}
+    : i mlen ( _t_bget ch modes )
+    : ~ i mk 0
+    ~ < mk mlen {
+        ? == ( _t_bget ch + + modes 1 mk ) 1 { ^ T } {}
+        = mk + mk 1
+    }
+    ^ F
+}
+
 // The resumption offer in a ClientHello, if it is one we can honour: a
 // ticket of ours, offered with psk_dhe_ke, whose binder verifies over the
 // hello truncated before the binders list (RFC 8446 §4.2.11.2). Appends
@@ -669,6 +685,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) psk ( vec_new [u] )
     : i psk_sel ( __srv_psk_offer ch es ee psk )
     ? >= psk_sel 0 { = . c resumed 1 } {}
+    : b can_resume ( __srv_client_can_resume ch es ee )
 
     // ── server ephemeral + shared secret ──
     //
@@ -836,8 +853,9 @@ $ `stdlib/std/aes_gcm.nu`
     ( _set_keys c 1 c_ap )
     = . c established 1
 
-    // A ticket for next time, first thing under the application keys.
-    ? == finok 1 { ( __srv_issue_ticket c ) } {}
+    // A ticket for next time, first thing under the application keys —
+    // only for a client that said it can resume (§4.2.9).
+    ? & == finok 1 can_resume { ( __srv_issue_ticket c ) } {}
 
     // free scratch / handshake secrets
     ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( vec_free [u] eph )


### PR DESCRIPTION
## Summary

The NURL client never resumed a TLS 1.3 session against **rustls**. RFC 8446 §4.2.9 forbids a server from sending a `NewSessionTicket` to a client that did not send `psk_key_exchange_modes`; the NURL client sent that extension only when it was already *offering* a ticket, so against a rustls server — which obeys the rule — the first connection got no ticket and nothing ever resumed. openssl's `s_server` and the NURL server issued tickets regardless, which is why every earlier probe passed.

- **Client**: `psk_key_exchange_modes` (`psk_dhe_ke`) goes in every ClientHello.
- **Server**: a ticket is issued only to a client that sent it (§4.2.9 compliance; a strict client may treat an unsolicited ticket as an error).

Verified in all four directions with the same probe program (two connections, second must report `second_resumed=T` and the server must see it as resumed):

| client → server | before | after |
|---|:--:|:--:|
| NURL → rustls (the Rust peer) | no ticket | **resumed** |
| NURL → openssl `s_server -tls1_3` | resumed | resumed |
| openssl `s_client` → NURL (harness probe) | Reused | Reused |
| NURL → NURL | resumed | resumed |

Also: the harness README now says whose numbers the committed `TORTURE_RESULTS.md` holds (the Action's 4-vCPU runner; workstation runs are in the PRs) and that the core split is derived from `nproc`.

### Verification

`./build.sh` (bootstrap fixed point + full suite) green; `./build.sh --san` + `run_san_tests.sh`: 908 PASS, 0 SAN_FAIL. TLS corpus tests (`tls_resume`, `http_client_resume`, `http_server_tls*`, `tls_pq_*`, `tls_large_record`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw
