### PR TITLE
tls: certificate selection by the client's signature_algorithms — an ML-DSA leaf beside the classical one, on TCP and QUIC; http 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Certificate selection by the client's `signature_algorithms`
+  (RFC 8446 §4.4.2.2) — a post-quantum certificate beside a classical
+  one.** The pure-NURL TLS 1.3 server can now hold two identities: the
+  EC P-256 / RSA leaf it always had and an ML-DSA (FIPS 204) leaf, and
+  shows each ClientHello the one it can verify — the ML-DSA leaf to a
+  client listing `mldsaNN`, the classical leaf to everything else — so
+  deploying a post-quantum certificate never turns a client away. The
+  choice is made once, on the shared handshake state, so it covers TCP
+  TLS and the QUIC handshake (HTTP/3) alike. `tls_accept_dual_alpn`
+  (`std/tls_server.nu`); `tcp_listen_tls_dual host port backlog cert key
+  pq_cert pq_key alpn` (`std/net.nu`), which refuses a non-ML-DSA key in
+  the PQ slot with `NetTlsKeyLoad`; `quic_creds_set_pq` /
+  `http3_creds_add_pq` for QUIC; `tls_cv_scheme conn` /
+  `tcp_tls_sig_scheme conn` report the scheme a connection was signed
+  with, on both ends. `_load_tls_creds` auto-detects an ML-DSA PKCS#8
+  key (keytype 2), so `tcp_listen_tls` with an ML-DSA pair alone serves
+  it directly. Test: `tls_cert_select.nu` (offline selection against
+  the RFC 9001 A.2 ClientHello with and without `mldsa65`, level
+  mismatch, no second identity; end to end from PEM files).
+- **http 0.5.0:** `http_app_set_pq_cert a cert key` — the second
+  identity for `http_app_listen_tls`, applied to HTTP/1.1, HTTP/2 and
+  HTTP/3 on that listener; the README gains a Capabilities table
+  (protocols, key exchange, authentication, how each is chosen).
+
+### Fixed
+
+- **`ec_p256_priv_from_pem` / `rsa_priv_from_pem` accepted any PKCS#8
+  key.** Neither checked the AlgorithmIdentifier: an ML-DSA PKCS#8 key
+  was sliced into a 32-byte "P-256 scalar" and accepted, so the TLS
+  listener's key auto-detection could never reach the ML-DSA parser.
+  Both now require their own OID (id-ecPublicKey / rsaEncryption).
+
 - **HTTP/3 (RFC 9114) over a pure-NURL QUIC (RFC 9000/9001/9002) — on
   every TLS listener.** `http_app_listen_tls` now also binds its host:port
   over UDP and serves HTTP/3 there through the same routes and handler,

--- a/compiler/tests/outputs/tls_cert_select.txt
+++ b/compiler/tests/outputs/tls_cert_select.txt
@@ -1,0 +1,16 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+classical_ch_ecdsa   ok
+mldsa_ch_mldsa65     ok
+level_mismatch_ecdsa ok
+no_pq_configured     ok
+pq_key_must_be_mldsa ok
+dual_handshake       ok
+dual_scheme_mldsa65  ok
+dual_group_is_pq     ok
+dual_cv_verifies     ok
+mldsa_only_pem       ok
+server_saw_mldsa65   ok
+served_both          ok

--- a/compiler/tests/tls_cert_select.nu
+++ b/compiler/tests/tls_cert_select.nu
@@ -1,0 +1,279 @@
+// tls_cert_select.nu — one listener, two identities, the client decides.
+//
+// tls_pq_certificate.nu showed a handshake with an ML-DSA leaf. It also
+// showed the cost: a client that cannot verify ML-DSA has nothing to
+// connect to. Every deployment that wants a post-quantum certificate has
+// the same problem — no browser or curl older than 2025 can use it —
+// and RFC 8446 §4.4.2.2 already has the answer: a server holds one leaf
+// per key type and picks, per ClientHello, the one whose scheme the
+// client listed in signature_algorithms. OpenSSL does this across a
+// context's certificates; this is the pure-NURL server doing it.
+//
+// The selection lives in `__srv_pick_cert` on the shared `SrvHs`, so
+// the TCP listener (`tcp_listen_tls_dual`) and the QUIC handshake
+// (`quic_creds_set_pq`) get it from the same lines. What is asserted:
+//
+//   message level (offline, RFC 9001 A.2 ClientHello as the fixture)
+//     classical_ch_ecdsa     a client listing only classical schemes is
+//                            shown the EC leaf and ecdsa_secp256r1_sha256
+//     mldsa_ch_mldsa65       the same hello with mldsa65 added is shown
+//                            the ML-DSA leaf and signs with mldsa65
+//     level_mismatch_ecdsa   a client listing only mldsa44 is NOT shown an
+//                            ML-DSA-65 leaf — the scheme must match the
+//                            parameter set, not the family
+//     no_pq_configured       with a single identity the mldsa hello still
+//                            gets the classical leaf (nothing to choose)
+//     cert_msg_is_ec / _pq   the Certificate message really carries the
+//                            chain the scheme claims
+//
+//   end to end, from PEM files through std/net.nu
+//     dual_handshake         tcp_listen_tls_dual + the NURL client (which
+//                            offers mldsa65): the connection is signed
+//                            with mldsa65 over the hybrid group, the
+//                            signature verifies against the certificate,
+//                            and the SERVER side reports the same scheme
+//                            (tcp_tls_sig_scheme)
+//     mldsa_only_pem         an ML-DSA key handed to plain tcp_listen_tls
+//                            is auto-detected (keytype 2)
+//     pq_key_must_be_mldsa   a classical key in the PQ slot is refused
+//                            with NetTlsKeyLoad, not served as a second
+//                            ECDSA identity
+//
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/pkey.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/std/tls.nu`
+$ `stdlib/std/tls_server.nu`
+$ `stdlib/std/tls_verify.nu`
+$ `stdlib/std/net.nu`
+
+: ~ i g_served 0
+: ~ i g_srv_scheme 0
+
+@ chk s label b ok → b {
+    ( nurl_print label )
+    ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ^ ok
+}
+
+@ hx s raw → ( Vec u ) {
+    ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) }
+}
+
+// The RFC 9001 Appendix A.2 ClientHello: x25519 share, ALPN "alpn",
+// signature_algorithms 0403 0503 0603 0203 0804 0805 0806 — classical
+// only, as every client before 2025 sends.
+@ client_hello → ( Vec u ) {
+    ^ ( hx `010000ed0303ebf8fa56f12939b9584a3896472ec40bb863cfd3e86804fe3a47f06a2b69484c00000413011302010000c000000010000e00000b6578616d706c652e636f6dff01000100000a00080006001d0017001800100007000504616c706e000500050100000000003300260024001d00209370b2c9caa47fbabaf4559fedba753de171fa71f50f1ce15d43e994ec74d748002b0003020304000d0010000e0403050306030203080408050806002d00020101001c00024001003900320408ffffffffffffffff05048000ffff07048000ffff0801100104800075300901100f088394c8f03e51570806048000ffff` )
+}
+
+// The same hello with its signature_algorithms body replaced by `algs`
+// (a list of u16 schemes, wire order), lengths fixed up.
+@ client_hello_with_sigalgs ( Vec u ) algs → ( Vec u ) {
+    : ( Vec u ) ch ( client_hello )
+    : ( Vec u ) out ( vec_new [u] )
+    : i sidlen ( _t_bget ch 38 )
+    : i p1 + 39 sidlen
+    : i cslen ( _rdint ch p1 2 )
+    : i p2 + + p1 2 cslen
+    : i complen ( _t_bget ch p2 )
+    : i p3 + + p2 1 complen
+    : i extlen ( _rdint ch p3 2 )
+    : i es + p3 2
+    : i ee + es extlen
+    : ( Vec u ) head ( bytes_slice ch 4 p3 )
+    : ( Vec u ) exts ( vec_new [u] )
+    : ~ i p es
+    ~ < + p 4 ee {
+        : i t ( _rdint ch p 2 )
+        : i l ( _rdint ch + p 2 2 )
+        ? == t 13 {
+            : ( Vec u ) body ( vec_new [u] )
+            ( _blk16 body algs )
+            ( _tls_u16 exts 13 )
+            ( _blk16 exts body )
+            ( vec_free [u] body )
+        } {
+            : ( Vec u ) e ( bytes_slice ch p + + p 4 l )
+            ( bytes_extend_bytes exts e )
+            ( vec_free [u] e )
+        }
+        = p + + p 4 l
+    }
+    : ( Vec u ) body ( vec_new [u] )
+    ( bytes_extend_bytes body head )
+    ( _blk16 body exts )
+    ( vec_push [u] out # u 1 )
+    ( _u24 out ( vec_len [u] body ) )
+    ( bytes_extend_bytes out body )
+    ( vec_free [u] body )
+    ( vec_free [u] exts )
+    ( vec_free [u] head )
+    ( vec_free [u] ch )
+    ^ out
+}
+
+// The certificate_list length inside the Certificate(11) message of a
+// server first flight, or -1 when there is none.
+@ cert_list_len ( Vec u ) out → i {
+    : ~ i off 0
+    : ~ i found -1
+    ~ & < + off 4 ( vec_len [u] out ) == found -1 {
+        : i mt ( _t_bget out off )
+        : i ml ( _rdint out + off 1 3 )
+        ? == mt 11 { = found ( _rdint out + off 5 3 ) } {}
+        = off + + off 4 ml
+    }
+    ^ found
+}
+
+// One offline ClientHello against a handshake with (or without) the
+// second identity; returns the scheme the server chose, and reports the
+// Certificate message's chain length through `clen`.
+@ offline_pick ( Vec u ) ec_chain ( Vec u ) ec_priv ( Vec u ) pq_chain ( Vec u ) pq_sk b with_pq ( Vec u ) ch → i {
+    : ( Vec u ) e ( vec_new [u] )
+    : ( Vec u ) prefs ( tls_alpn_pack `alpn` )
+    : *SrvHs hs ( _srv_hs_new ec_chain 0 ec_priv e e e 0 prefs )
+    ? with_pq { ( _srv_hs_set_pq hs pq_chain 65 pq_sk ) } {}
+    : i rc ( _srv_hs_client_hello hs ch )
+    : ~ i scheme -1
+    ? == rc 0 {
+        = scheme ( _srv_hs_sig_scheme hs )
+        : i clen ( cert_list_len . hs out_hs )
+        : i want ? == scheme 2309 ( vec_len [u] pq_chain ) ( vec_len [u] ec_chain )
+        ? != clen want { = scheme - 0 scheme } {}
+    } {}
+    ( _srv_hs_free hs )
+    ( vec_free [u] prefs ) ( vec_free [u] e )
+    ^ scheme
+}
+
+@ main → i {
+    : ~ b all T
+
+    // ── two identities: an EC P-256 leaf and an ML-DSA-65 leaf ──
+    : X509SelfSigned ec ( x509_selfsigned_p256 `localhost` 1 )
+    : X509SelfSigned ml ( x509_selfsigned_mldsa 65 `localhost` 1 )
+    : ~ ( Vec u ) ec_chain ( vec_new [u] )
+    : ~ ( Vec u ) ec_priv ( vec_new [u] )
+    : ~ ( Vec u ) ml_chain ( vec_new [u] )
+    : ~ ( Vec u ) ml_sk ( vec_new [u] )
+    ?? ( pem_to_der ( string_data . ec cert_pem ) ) {
+        T der → { ( vec_free [u] ec_chain ) = ec_chain ( tls_cert_entry der ) ( vec_free [u] der ) }
+        F _ → { ( chk `ec_cert_der         ` F ) ^ 1 }
+    }
+    ?? ( ec_p256_priv_from_pem ( string_data . ec key_pem ) ) {
+        T k → { ( vec_free [u] ec_priv ) = ec_priv k }
+        F _ → { ( chk `ec_key_pem          ` F ) ^ 1 }
+    }
+    ?? ( pem_to_der ( string_data . ml cert_pem ) ) {
+        T der → { ( vec_free [u] ml_chain ) = ml_chain ( tls_cert_entry der ) ( vec_free [u] der ) }
+        F _ → { ( chk `ml_cert_der         ` F ) ^ 1 }
+    }
+    ?? ( mldsa_priv_from_pem ( string_data . ml key_pem ) ) {
+        T k → { ( vec_free [u] ml_sk ) = ml_sk ( bytes_slice . k sk 0 ( vec_len [u] . k sk ) ) ( mldsa_priv_free k ) }
+        F _ → { ( chk `ml_key_pem          ` F ) ^ 1 }
+    }
+
+    // ── message level ──
+    : ( Vec u ) ch_classical ( client_hello )
+    : ( Vec u ) algs_pq ( hx `090504030804` )  // mldsa65, ecdsa_secp256r1_sha256, rsa_pss_rsae_sha256
+    : ( Vec u ) ch_pq ( client_hello_with_sigalgs algs_pq )
+    : ( Vec u ) algs_44 ( hx `09040403` )  // mldsa44 only, plus ecdsa
+    : ( Vec u ) ch_44 ( client_hello_with_sigalgs algs_44 )
+
+    = all & all ( chk `classical_ch_ecdsa  ` == ( offline_pick ec_chain ec_priv ml_chain ml_sk T ch_classical ) 1027 )
+    = all & all ( chk `mldsa_ch_mldsa65    ` == ( offline_pick ec_chain ec_priv ml_chain ml_sk T ch_pq ) 2309 )
+    = all & all ( chk `level_mismatch_ecdsa` == ( offline_pick ec_chain ec_priv ml_chain ml_sk T ch_44 ) 1027 )
+    = all & all ( chk `no_pq_configured    ` == ( offline_pick ec_chain ec_priv ml_chain ml_sk F ch_pq ) 1027 )
+
+    ( vec_free [u] ch_44 ) ( vec_free [u] algs_44 )
+    ( vec_free [u] ch_pq ) ( vec_free [u] algs_pq )
+    ( vec_free [u] ch_classical )
+
+    // ── end to end, from PEM files ──
+    : s ecf `/tmp/nurl_certsel_ec.pem`
+    : s eck `/tmp/nurl_certsel_ec.key`
+    : s mlf `/tmp/nurl_certsel_ml.pem`
+    : s mlk `/tmp/nurl_certsel_ml.key`
+    ?? ( write_file ecf ( string_data . ec cert_pem ) ) { T _ → {} F _e → { ( chk `write               ` F ) ^ 1 } }
+    ?? ( write_file eck ( string_data . ec key_pem ) ) { T _ → {} F _e → { ( chk `write               ` F ) ^ 1 } }
+    ?? ( write_file mlf ( string_data . ml cert_pem ) ) { T _ → {} F _e → { ( chk `write               ` F ) ^ 1 } }
+    ?? ( write_file mlk ( string_data . ml key_pem ) ) { T _ → {} F _e → { ( chk `write               ` F ) ^ 1 } }
+
+    // A classical key in the PQ slot is a configuration error, refused
+    // before the socket is even bound.
+    ?? ( tcp_listen_tls_dual `127.0.0.1` 18914 16 ecf eck ecf eck `` ) {
+        T l → { = all ( chk `pq_key_must_be_mldsa` F ) ( tcp_close_listener l ) }
+        F e → { = all & all ( chk `pq_key_must_be_mldsa` != 0 ( nurl_str_eq ( net_err_name e ) `NetTlsKeyLoad` ) ) }
+    }
+
+    // dual: EC + ML-DSA-65 on one listener; ML-DSA-only on another.
+    : !TcpListener NetErr lr ( tcp_listen_tls_dual `127.0.0.1` 18914 16 ecf eck mlf mlk `` )
+    : ~ b have_l F
+    ?? lr { T _l → { = have_l T } F _e → {} }
+    ? ! have_l { ( chk `listen_dual         ` F ) ^ 1 } {}
+    : TcpListener l ?? lr { T x → x F _e → { ^ 1 } }
+    : !TcpListener NetErr lr2 ( tcp_listen_tls `127.0.0.1` 18915 mlf mlk )
+    : ~ b have_l2 F
+    ?? lr2 { T _l → { = have_l2 T } F _e → {} }
+    ? ! have_l2 { ( chk `listen_mldsa_only   ` F ) ^ 1 } {}
+    : TcpListener l2 ?? lr2 { T x → x F _e → { ^ 1 } }
+
+    : ( @ v ) server \ → v {
+        ?? ( tcp_accept l ) {
+            T conn → { = g_served + g_served 1 = g_srv_scheme ( tcp_tls_sig_scheme conn ) ( tcp_close_conn conn ) }
+            F _e → { = g_served + g_served 1 }
+        }
+        ?? ( tcp_accept l2 ) {
+            T conn → { = g_served + g_served 1 ( tcp_close_conn conn ) }
+            F _e → { = g_served + g_served 1 }
+        }
+    }
+    : !Thread ThreadErr st ( thread_spawn server )
+    ?? st {
+        T t → {
+            ( sleep_ms 200 )
+            // The NURL client offers mldsa65 first, so the dual listener
+            // must show it the ML-DSA leaf.
+            ?? ( tls_connect_insecure `127.0.0.1` 18914 `localhost` ) {
+                T c → {
+                    = all & all ( chk `dual_handshake      ` T )
+                    = all & all ( chk `dual_scheme_mldsa65 ` == ( tls_cv_scheme c ) 2309 )
+                    = all & all ( chk `dual_group_is_pq    ` ( tls_is_post_quantum c ) )
+                    = all & all ( chk `dual_cv_verifies    ` ( tls_cv_verify . c cert_msg . c cv_scheme . c cv_sig . c th_cert ) )
+                    ( tls_close c )
+                }
+                F _e → { = all ( chk `dual_handshake      ` F ) }
+            }
+            ?? ( tls_connect_insecure `127.0.0.1` 18915 `localhost` ) {
+                T c → {
+                    = all & all ( chk `mldsa_only_pem      ` == ( tls_cv_scheme c ) 2309 )
+                    ( tls_close c )
+                }
+                F _e → { = all ( chk `mldsa_only_pem      ` F ) }
+            }
+            ( thread_join t )
+            : *u env # *u server 1
+            ( nurl_free # s env )
+        }
+        F _e → { = all ( chk `thread              ` F ) }
+    }
+    = all & all ( chk `server_saw_mldsa65  ` == g_srv_scheme 2309 )
+    = all & all ( chk `served_both         ` == g_served 2 )
+    ( tcp_close_listener l )
+    ( tcp_close_listener l2 )
+
+    ( vec_free [u] ml_sk ) ( vec_free [u] ml_chain )
+    ( vec_free [u] ec_priv ) ( vec_free [u] ec_chain )
+    ( x509_selfsigned_free ml )
+    ( x509_selfsigned_free ec )
+    ^ ? all 0 1
+}

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -120,6 +120,20 @@ X25519 or NIST P-256, verifies the chain against the system trust store by
 default, and runs on a host with nothing installed. `tls_attach` upgrades
 an already-connected socket, which is what STARTTLS-style protocols need.
 
+**Post-quantum.** Key exchange prefers X25519MLKEM768 (hybrid ML-KEM-768)
+on both the client and the server, falling back to X25519 / P-256 for a
+peer without it; `tcp_is_post_quantum conn` says which. Authentication can
+be post-quantum too: the server accepts an ML-DSA (FIPS 204) leaf, either
+alone (`tcp_listen_tls` with an ML-DSA PKCS#8 key — the key form is
+auto-detected) or **beside** a classical leaf with `tcp_listen_tls_dual host
+port backlog cert key pq_cert pq_key alpn`, in which case every ClientHello
+is shown the leaf its `signature_algorithms` can verify (RFC 8446
+§4.4.2.2) — ML-DSA to the clients that list it, ECDSA / RSA to the rest.
+The selection is made on the handshake state the QUIC server shares, so
+HTTP/3 gets it as well. `tcp_tls_sig_scheme conn` reports the scheme a
+connection was signed with. The client offers `mldsa44/65/87` first and
+verifies ML-DSA chains (`std/tls_verify.nu`).
+
 A program that never calls `tcp_connect_tls` / `tcp_listen_tls` (a
 pure-NURL-TLS client, or plain TCP) links `libc` only. The
 [`psql`](../packages/psql) package builds on the pure-NURL TLS client to

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -33,6 +33,39 @@ $ `deps/http/src/http.nu`
 }
 ```
 
+## Capabilities
+
+One `http_app_listen_tls` call gives a server every protocol a client
+might ask for, chosen per connection by the client, with nothing to
+configure:
+
+| | What the client gets | How it is chosen |
+| --- | --- | --- |
+| **HTTP/1.1** | keep-alive, pipelining, chunked bodies, streaming responses | the default on both listeners |
+| **HTTP/2** (RFC 9113) | multiplexed streams, HPACK, flow control | ALPN `h2` on the TLS listener; the connection preface on the plaintext listener (prior knowledge) |
+| **HTTP/3** (RFC 9114) | QUIC (RFC 9000/9001/9002) over UDP on the same port, QPACK, 0-RTT-less 1-RTT handshake | `Alt-Svc: h3` on every TCP response; a client that already knows (curl `--http3`, a browser on its second visit) connects over UDP directly |
+| **Post-quantum key exchange** | X25519MLKEM768 (hybrid ML-KEM-768, RFC 9370 group 0x11ec) | the server's first preference on TCP and QUIC alike; a client without it (pre-2024 stacks) falls back to X25519 or P-256 |
+| **Post-quantum authentication** | an ML-DSA (FIPS 204) certificate, CertificateVerify signed with `mldsa44/65/87` | `http_app_set_pq_cert`: the ML-DSA leaf is shown to every client whose `signature_algorithms` lists its scheme (RFC 8446 §4.4.2.2), the classical leaf to the rest — so a post-quantum certificate never turns a client away |
+| **Classical authentication** | EC P-256 (`ecdsa_secp256r1_sha256`) or RSA (`rsa_pss_rsae_sha256`) leaf, full chain | the `cert` / `key` pair of `http_app_listen_tls`, key form auto-detected |
+| **Session resumption** | TLS 1.3 tickets, one shared ticket key per process | offered to every client that asks (`psk_key_exchange_modes`) |
+
+The whole stack — TCP/TLS 1.3, QUIC, HTTP/1.1, HTTP/2, HTTP/3, ML-KEM,
+ML-DSA, X.509 — is pure NURL over a libc socket: no OpenSSL, no nghttp2,
+no quiche. With both post-quantum pieces negotiated, no asymmetric
+operation in the handshake is one a quantum computer breaks: the traffic
+keys cannot be recovered from a recording, and the server cannot be
+impersonated. Public CAs do not issue ML-DSA certificates yet; mint a
+self-signed one with `x509_selfsigned_mldsa` (`std/x509_gen.nu`) or run
+the [pki-server](../pki-server) package as a private CA.
+
+```nurl
+( http_app_set_pq_cert a `certs/mldsa65.pem` `certs/mldsa65.key` )   // optional
+^ ( http_app_listen_tls a `0.0.0.0` 443 `certs/fullchain.pem` `certs/privkey.pem` )
+```
+
+`tcp_tls_sig_scheme conn` / `tcp_is_post_quantum conn` (`std/net.nu`)
+report what a given connection settled on.
+
 ## The App API
 
 Construction & serving:
@@ -41,8 +74,9 @@ Construction & serving:
 | --- | --- |
 | `( http_app_new )` → `*HttpApp` | create an app (free with `http_app_free`) |
 | `( http_app_listen a host port )` → `i` | bind + serve until closed (SIGINT/SIGTERM/error); HTTP/1.1 and HTTP/2 (prior knowledge) on the same port |
-| `( http_app_listen_tls a host port cert key )` → `i` | same, over TLS (PEM paths; EC or RSA leaf); ALPN `h2 http/1.1`, so HTTP/2-capable clients get HTTP/2; **HTTP/3 (QUIC) on the same port over UDP**, announced with `Alt-Svc` on the TCP responses |
+| `( http_app_listen_tls a host port cert key )` → `i` | same, over TLS (PEM paths; EC, RSA or ML-DSA leaf, auto-detected); ALPN `h2 http/1.1`, so HTTP/2-capable clients get HTTP/2; **HTTP/3 (QUIC) on the same port over UDP**, announced with `Alt-Svc` on the TCP responses |
 | `( http_app_set_http3 a 0 )` → `v` | keep a TLS listener TCP-only (no UDP socket, no Alt-Svc); default 1 |
+| `( http_app_set_pq_cert a cert key )` → `v` | a second, **post-quantum identity** (ML-DSA-44/65/87 chain + PKCS#8 key) served beside the classical pair; each client is shown the one its `signature_algorithms` can verify — see [Capabilities](#capabilities) |
 
 Routing (handlers are `( @ HttpResponse HttpRequest Params )`):
 

--- a/packages/http/nurl.toml
+++ b/packages/http/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http"
-version = "0.4.0"
+version = "0.5.0"
 description = "The unified HTTP server interface for NURL — one dependency for anything that needs to SERVE HTTP. A single importable facade over the stdlib HTTP stack (sockets + TLS, request parser, response builder, keep-alive server with worker pools and DoS limits, router, static-file serving, auth / jwt / multipart / middleware / websocket / streaming SSE-NDJSON responses). Where the stdlib ships the building blocks, `http` ships the glue: an ergonomic `HttpApp` that collapses bind → router → shutdown-signal → logging / CORS / panic-recovery → keep-alive loop into a few calls, so `( http_app_new )`, a handful of `( http_get a ... )` registrations, and `( http_listen a host port )` stand up a complete server — over plain TCP or TLS."
 license = "MIT OR Apache-2.0"
 

--- a/packages/http/src/app.nu
+++ b/packages/http/src/app.nu
@@ -58,6 +58,8 @@ $ `stdlib/ext/http3_server.nu`
     i max_keepalive  // per-conn request reuse cap; -1 → server default (0 = close after one)
     i req_timeout_ms  // per-request wall-clock budget; -1 → server default (0 = disabled)
     i http3  // 1 → a TLS listener also serves HTTP/3 on the same port over UDP (default)
+    String pq_cert  // optional second identity for TLS listeners: ML-DSA chain PEM ("" = none)
+    String pq_key  // ...and its PKCS#8 key PEM
 }
 
 // ── Construction / teardown ───────────────────────────────────────────
@@ -79,12 +81,16 @@ $ `stdlib/ext/http3_server.nu`
     = . a max_keepalive -1
     = . a req_timeout_ms -1
     = . a http3 1
+    = . a pq_cert ( string_new )
+    = . a pq_key ( string_new )
     ^ a
 }
 
 @ http_app_free * HttpApp a → v {
     ( router_free . a router )
     ( string_free . a webroot )
+    ( string_free . a pq_cert )
+    ( string_free . a pq_key )
     ( nurl_free a )
 }
 
@@ -100,6 +106,26 @@ $ `stdlib/ext/http3_server.nu`
 // HTTP/3 on TLS listeners: on by default. `http_app_set_http3 a 0` keeps
 // a TLS listener TCP-only (no UDP socket, no Alt-Svc).
 @ http_app_set_http3 * HttpApp a i on → v { = . a http3 on }
+
+// A second, post-quantum identity for `http_app_listen_tls`: an ML-DSA
+// (44 / 65 / 87) certificate chain and PKCS#8 key, served BESIDE the
+// classical pair the listen call takes. Which one a connection is shown
+// is decided per ClientHello from the client's signature_algorithms
+// (RFC 8446 §4.4.2.2): the ML-DSA leaf for every client that lists its
+// scheme, the classical leaf for the rest — so deploying a post-quantum
+// certificate never turns a client away. Applies to HTTP/1.1, HTTP/2 and
+// HTTP/3 alike (the QUIC handshake is the same TLS 1.3 code). Mint a
+// self-signed pair with `x509_selfsigned_mldsa` (std/x509_gen.nu) or the
+// pki-server package; no public CA issues ML-DSA certificates yet.
+//
+// To serve ONLY an ML-DSA certificate, hand it to `http_app_listen_tls`
+// directly — the key form is auto-detected.
+@ http_app_set_pq_cert * HttpApp a s cert s key → v {
+    ( string_free . a pq_cert )
+    = . a pq_cert ( string_from cert )
+    ( string_free . a pq_key )
+    = . a pq_key ( string_from key )
+}
 
 // Serve fiber-per-connection on the M:N async runtime (server_run_async):
 // every accepted connection gets its own fiber, and `n` worker pthreads
@@ -319,6 +345,16 @@ $ `stdlib/ext/http3_server.nu`
     : ~ ( @ HttpResponse HttpRequest ) altw base
     ? & & != . a http3 0 > ( nurl_str_len cert ) 0 != 0 ( nurl_str_eq scheme `https` ) {
         = h3_creds ( http3_creds_load cert key )
+        // The second identity, when configured: the TCP listener has
+        // already loaded the same files, so a failure here is a
+        // filesystem race, and it is reported the same way as the
+        // primary pair rather than served half-configured.
+        ? & != # i h3_creds 0 > ( string_len . a pq_cert ) 0 {
+            ? ( http3_creds_add_pq h3_creds ( string_data . a pq_cert ) ( string_data . a pq_key ) ) {} {
+                ( quic_creds_free h3_creds )
+                = h3_creds # *QuicCreds 0
+            }
+        } {}
         ? == # i h3_creds 0 { ( nurl_eprintln `http: HTTP/3 off — certificate or key could not be loaded for QUIC` ) } {
             ?? ( udp_bind host port ) {
                 F e → {
@@ -408,8 +444,9 @@ $ `stdlib/ext/http3_server.nu`
     }
 }
 
-// Same, over TLS. `cert`/`key` are PEM paths (EC or RSA leaf; a fullchain
-// PEM is accepted for `cert`).
+// Same, over TLS. `cert`/`key` are PEM paths (EC, RSA or ML-DSA leaf,
+// auto-detected; a fullchain PEM is accepted for `cert`). With
+// `http_app_set_pq_cert` an ML-DSA pair is served beside this one.
 @ http_app_listen_tls * HttpApp a s host i port s cert s key → i {
     // Advertise HTTP/2 and HTTP/1.1 over ALPN (RFC 7301), h2 preferred:
     // an HTTP/2-capable client (browsers, curl, oha) gets HTTP/2, anything
@@ -417,7 +454,9 @@ $ `stdlib/ext/http3_server.nu`
     // server itself tells the protocols apart by the connection preface.
     // HTTP/3 rides beside it: `__httpapp_serve` binds the same port over
     // UDP for QUIC and the TCP responses announce it with Alt-Svc.
-    : !TcpListener NetErr lr ( tcp_listen_tls_with_alpn host port 128 cert key `h2 http/1.1` )
+    : !TcpListener NetErr lr ? > ( string_len . a pq_cert ) 0
+    ( tcp_listen_tls_dual host port 128 cert key ( string_data . a pq_cert ) ( string_data . a pq_key ) `h2 http/1.1` )
+    ( tcp_listen_tls_with_alpn host port 128 cert key `h2 http/1.1` )
     ?? lr {
         T listener → { ^ ( __httpapp_serve a listener `https` host port cert key ) }
         F e → {

--- a/stdlib/ext/http3_server.nu
+++ b/stdlib/ext/http3_server.nu
@@ -101,8 +101,8 @@ $ `stdlib/ext/http3_conn.nu`
 }
 
 // The same certificate / key files the TLS listener takes, through the
-// same loader (`std/net.nu` `_load_tls_creds`: fullchain PEM, EC P-256
-// or RSA key auto-detected).
+// same loader (`std/net.nu` `_load_tls_creds`: fullchain PEM; EC P-256,
+// RSA or ML-DSA key auto-detected).
 @ http3_creds_load s cert_path s key_path → *QuicCreds {
     : ( Vec u ) chain ( vec_new [u] )
     : ( Vec u ) k1 ( vec_new [u] )
@@ -111,11 +111,29 @@ $ `stdlib/ext/http3_conn.nu`
     : i kt ( _load_tls_creds cert_path key_path chain k1 k2 k3 )
     : ~ * QuicCreds out # *QuicCreds 0
     : ( Vec u ) e ( vec_new [u] )
-    // keytype 0: EC scalar in k1 · 1: RSA n in k1, d in k2, e in k3
+    // keytype 0: EC scalar in k1 · 1: RSA n in k1, d in k2, e in k3 ·
+    // 2: ML-DSA secret key in k1, its length naming the parameter set
     ? == kt 0 { = out ( quic_creds_new chain 0 k1 e e e 0 ) } {}
     ? == kt 1 { = out ( quic_creds_new chain 1 e k1 k3 k2 0 ) } {}
+    ? == kt 2 { = out ( quic_creds_new chain 2 k1 e e e ( mldsa_level_of_sk_len ( vec_len [u] k1 ) ) ) } {}
     ( vec_free [u] e ) ( vec_free [u] k3 ) ( vec_free [u] k2 ) ( vec_free [u] k1 ) ( vec_free [u] chain )
     ^ out
+}
+
+// Add the second, ML-DSA identity `tcp_listen_tls_dual` serves on the TCP
+// side, so QUIC connections get the same per-ClientHello choice
+// (RFC 8446 §4.4.2.2). F when the files do not load or the key is not
+// an ML-DSA key — the same refusal the TCP listener makes.
+@ http3_creds_add_pq * QuicCreds k s pq_cert_path s pq_key_path → b {
+    : ( Vec u ) chain ( vec_new [u] )
+    : ( Vec u ) k1 ( vec_new [u] )
+    : ( Vec u ) k2 ( vec_new [u] )
+    : ( Vec u ) k3 ( vec_new [u] )
+    : i kt ( _load_tls_creds pq_cert_path pq_key_path chain k1 k2 k3 )
+    : b ok == kt 2
+    ? ok { ( quic_creds_set_pq k chain ( mldsa_level_of_sk_len ( vec_len [u] k1 ) ) k1 ) } {}
+    ( vec_free [u] k3 ) ( vec_free [u] k2 ) ( vec_free [u] k1 ) ( vec_free [u] chain )
+    ^ ok
 }
 
 // Limits: 30 s idle, 1 MiB connection window, 256 KiB per stream,

--- a/stdlib/std/mldsa.nu
+++ b/stdlib/std/mldsa.nu
@@ -96,6 +96,16 @@ $ `stdlib/std/subtle.nu`
     ^ + + 128 * * 32 . p sbits + . p k . p l * 416 . p k
 }
 
+// The parameter set a secret key of `n` bytes belongs to — the three
+// FIPS 204 sizes are distinct (2560 / 4032 / 4896), so a raw key names
+// its own level. 0 for any other length.
+@ mldsa_level_of_sk_len i n → i {
+    ? == n ( mldsa_sk_len 44 ) { ^ 44 } {}
+    ? == n ( mldsa_sk_len 65 ) { ^ 65 } {}
+    ? == n ( mldsa_sk_len 87 ) { ^ 87 } {}
+    ^ 0
+}
+
 @ mldsa_sig_len i level → i {
     : MldsaParams p ( __mldsa_params level )
     ^ + + . p lam * * 32 . p zbits . p l + . p omega . p k

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -100,12 +100,16 @@ $ `stdlib/std/pkey.nu`
 // CertificateEntry blobs, leaf first) + the leaf's private key, so each
 // accept can run the pure handshake (is_tls = 1). keytype selects the
 // key form: 0 = EC P-256 (kp1 = 32-byte scalar, kp2 unused), 1 = RSA
-// (kp1 = modulus n, kp2 = private exponent d), both big-endian. All are
-// held as raw malloc'd (ptr, len) pairs — NOT Vec fields — because a
-// value struct returned with owned-Vec fields is auto-dropped at the
-// constructing function's exit (a borrowck escape gap), which would free
-// the buffers out from under the listener.
-: TcpListener { s raw i is_tls i keytype i certp i certlen i kp1 i kl1 i kp2 i kl2 i kp3 i kl3 i alpnp i alpnlen }
+// (kp1 = modulus n, kp2 = private exponent d, kp3 = public exponent e),
+// 2 = ML-DSA (kp1 = the FIPS 204 secret key; its length names the
+// parameter set), all big-endian. pqcertp / pqkp are an OPTIONAL second
+// identity — an ML-DSA chain and key served beside the classical one to
+// clients that list its scheme (`tcp_listen_tls_dual`), 0/0 otherwise.
+// All are held as raw malloc'd (ptr, len) pairs — NOT Vec fields —
+// because a value struct returned with owned-Vec fields is auto-dropped
+// at the constructing function's exit (a borrowck escape gap), which
+// would free the buffers out from under the listener.
+: TcpListener { s raw i is_tls i keytype i certp i certlen i kp1 i kl1 i kp2 i kl2 i kp3 i kl3 i alpnp i alpnlen i pqcertp i pqcertlen i pqkp i pqkl }
 // alpnp/alpnlen: the TLS listener's ALPN preference list in wire form
 // ([len:1][name] entries, server order — see tls_alpn_pack), 0/0 when the
 // listener does not negotiate ALPN.
@@ -173,7 +177,7 @@ $ `stdlib/std/pkey.nu`
         ^ @ !TcpListener NetErr { F ( _net_err_of ek ) }
     } {}
     : s rp # s raw
-    : TcpListener l @ TcpListener { rp 0 0 0 0 0 0 0 0 0 0 0 0 }
+    : TcpListener l @ TcpListener { rp 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 }
     ^ @ !TcpListener NetErr { T l }
 }
 
@@ -255,9 +259,11 @@ $ `stdlib/std/pkey.nu`
 // Load cert chain + private key from PEM files into a TLS listener. Fills
 // `cert_out` with the framed certificate_list and `k1`/`k2` with the key
 // material; returns the keytype (0 = EC P-256 scalar in k1; 1 = RSA with
-// modulus in k1, private exponent in k2), or a NEGATIVE NetErr-style code
-// on failure (-10 cert, -11 key). The key form is auto-detected: EC and
-// RSA parsers each cleanly reject the other's encoding.
+// modulus in k1, private exponent in k2, public exponent in k3; 2 =
+// ML-DSA with the FIPS 204 secret key in k1), or a NEGATIVE NetErr-style
+// code on failure (-10 cert, -11 key). The key form is auto-detected:
+// the EC, RSA and ML-DSA PKCS#8 parsers each cleanly reject the others'
+// encodings.
 @ _load_tls_creds s cert_path s key_path ( Vec u ) cert_out ( Vec u ) k1 ( Vec u ) k2 ( Vec u ) k3 → i {
     : String certpem ?? ( read_file cert_path ) { T p → p F _ → ( string_new ) }
     : ( Vec u ) chain ( __net_cert_chain certpem )
@@ -280,21 +286,25 @@ $ `stdlib/std/pkey.nu`
             ( bytes_extend_bytes k3 . k e )  // public exponent — for sign-time blinding
             ( rsa_priv_free k ) 1
         }
-        F _ → -11
+        F _ → ?? ( mldsa_priv_from_pem ( string_data keypem ) ) {
+            T mk → { ( bytes_extend_bytes k1 . mk sk ) ( mldsa_priv_free mk ) 2 }
+            F _ → -11
+        }
     }
     ( string_free keypem )
     ^ kt
 }
 
 @ tcp_listen_tls_with_backlog s host i port i backlog s cert_path s key_path → !TcpListener NetErr {
-    ^ ( __tcp_listen_tls_impl host port backlog cert_path key_path `` )
+    ^ ( __tcp_listen_tls_impl host port backlog cert_path key_path `` `` `` )
 }
 
 // Shared body of the TLS listener constructors. `alpn_protocols` is a
 // space-separated server preference list ("h2 http/1.1") or "" for no
 // ALPN; it is packed to wire form once here and parked on the listener
-// like the cert and key.
-@ __tcp_listen_tls_impl s host i port i backlog s cert_path s key_path s alpn_protocols → !TcpListener NetErr {
+// like the cert and key. `pq_cert_path` / `pq_key_path` name an optional
+// ML-DSA chain + key to serve beside the classical pair ("" for none).
+@ __tcp_listen_tls_impl s host i port i backlog s cert_path s key_path s alpn_protocols s pq_cert_path s pq_key_path → !TcpListener NetErr {
     : ( Vec u ) cert ( vec_new [u] )
     : ( Vec u ) k1 ( vec_new [u] )
     : ( Vec u ) k2 ( vec_new [u] )
@@ -304,11 +314,33 @@ $ `stdlib/std/pkey.nu`
         ( vec_free [u] cert ) ( vec_free [u] k1 ) ( vec_free [u] k2 ) ( vec_free [u] k3 )
         ^ @ !TcpListener NetErr { F ( _net_err_of - 0 keytype ) }
     } {}
+    // The second identity: it has to BE an ML-DSA key — a classical key
+    // here would be a configuration mistake, and is refused as a key
+    // load error rather than silently served as a second ECDSA cert.
+    : ( Vec u ) pqcert ( vec_new [u] )
+    : ( Vec u ) pqk ( vec_new [u] )
+    ? > ( nurl_str_len pq_cert_path ) 0 {
+        : ( Vec u ) u2 ( vec_new [u] )
+        : ( Vec u ) u3 ( vec_new [u] )
+        : i pqt ( _load_tls_creds pq_cert_path pq_key_path pqcert pqk u2 u3 )
+        ( vec_free [u] u2 ) ( vec_free [u] u3 )
+        : i pqerr ? < pqt 0 - 0 pqt ? != pqt 2 11 0
+        ? != pqerr 0 {
+            ( vec_free [u] cert ) ( vec_free [u] k1 ) ( vec_free [u] k2 ) ( vec_free [u] k3 )
+            ( vec_free [u] pqcert ) ( vec_free [u] pqk )
+            ^ @ !TcpListener NetErr { F ( _net_err_of pqerr ) }
+        } {}
+    } {}
     : i raw ( nurl_tcp_listen host port backlog )
-    ? == raw 0 { ( vec_free [u] cert ) ( vec_free [u] k1 ) ( vec_free [u] k2 ) ( vec_free [u] k3 ) ^ @ !TcpListener NetErr { F # NetErr NetOther } } {}
+    ? == raw 0 {
+        ( vec_free [u] cert ) ( vec_free [u] k1 ) ( vec_free [u] k2 ) ( vec_free [u] k3 )
+        ( vec_free [u] pqcert ) ( vec_free [u] pqk )
+        ^ @ !TcpListener NetErr { F # NetErr NetOther }
+    } {}
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 {
         ( nurl_tcp_close raw ) ( vec_free [u] cert ) ( vec_free [u] k1 ) ( vec_free [u] k2 ) ( vec_free [u] k3 )
+        ( vec_free [u] pqcert ) ( vec_free [u] pqk )
         ^ @ !TcpListener NetErr { F ( _net_err_of ek ) }
     } {}
     // The session-ticket key is drawn here, while the process is still
@@ -329,8 +361,13 @@ $ `stdlib/std/pkey.nu`
     : i alpnp ( __net_dup alpn )
     : i alpnlen ( vec_len [u] alpn )
     ( vec_free [u] alpn )
+    : i pqcertp ( __net_dup pqcert )
+    : i pqcertlen ( vec_len [u] pqcert )
+    : i pqkp ( __net_dup pqk )
+    : i pqkl ( vec_len [u] pqk )
+    ( vec_free [u] pqcert ) ( vec_free [u] pqk )
     : s rp # s raw
-    ^ @ !TcpListener NetErr { T @ TcpListener { rp 1 keytype certp certlen kp1 kl1 kp2 kl2 kp3 kl3 alpnp alpnlen } }
+    ^ @ !TcpListener NetErr { T @ TcpListener { rp 1 keytype certp certlen kp1 kl1 kp2 kl2 kp3 kl3 alpnp alpnlen pqcertp pqcertlen pqkp pqkl } }
 }
 
 @ tcp_listen_tls s host i port s cert_path s key_path → !TcpListener NetErr {
@@ -347,7 +384,27 @@ $ `stdlib/std/pkey.nu`
 // that sends no ALPN negotiates nothing and gets "" — the caller decides
 // what that means (HTTP servers treat it as HTTP/1.1).
 @ tcp_listen_tls_with_alpn s host i port i backlog s cert_path s key_path s alpn_protocols → !TcpListener NetErr {
-    ^ ( __tcp_listen_tls_impl host port backlog cert_path key_path alpn_protocols )
+    ^ ( __tcp_listen_tls_impl host port backlog cert_path key_path alpn_protocols `` `` )
+}
+
+// A TLS listener with TWO identities: the classical `cert_path` /
+// `key_path` (EC P-256 or RSA) and a post-quantum `pq_cert_path` /
+// `pq_key_path` (an ML-DSA-44/65/87 leaf, PKCS#8 key). Each accepted
+// connection is shown the one its ClientHello can verify: the ML-DSA
+// leaf when the client's signature_algorithms lists its scheme
+// (RFC 8446 §4.4.2.2), the classical leaf otherwise — so a server can
+// deploy an ML-DSA certificate for the clients that understand it
+// without turning away a single client that does not. With the
+// X25519MLKEM768 group the handshake already prefers, such a
+// connection has no classical asymmetric operation left in it.
+// `tcp_is_post_quantum` reports the group; `tcp_tls_sig_scheme` the
+// scheme the server signed with.
+//
+// The PQ key file must hold an ML-DSA key — a classical key there is
+// refused with NetTlsKeyLoad, since serving it as a second ECDSA
+// identity would silently not be what was asked for.
+@ tcp_listen_tls_dual s host i port i backlog s cert_path s key_path s pq_cert_path s pq_key_path s alpn_protocols → !TcpListener NetErr {
+    ^ ( __tcp_listen_tls_impl host port backlog cert_path key_path alpn_protocols pq_cert_path pq_key_path )
 }
 
 // Read the negotiated ALPN protocol off a TLS conn — a client conn (kind
@@ -399,6 +456,17 @@ $ `stdlib/std/pkey.nu`
 // factoring later.
 @ tcp_is_post_quantum TcpConn c → b {
     ^ == ( tcp_tls_group c ) 4588
+}
+
+// The SignatureScheme the CertificateVerify of this TLS connection was
+// signed with — on an accepted connection, which of the listener's
+// identities this client was shown: ecdsa_secp256r1_sha256 0x0403 (1027),
+// rsa_pss_rsae_sha256 0x0804 (2052), mldsa44/65/87 0x0904–0x0906
+// (2308–2310). 0 for plaintext and for resumed handshakes (no certificate).
+@ tcp_tls_sig_scheme TcpConn c → i {
+    : i tp ( __conn_tlsptr c )
+    ? == tp 0 { ^ 0 } {}
+    ^ ( tls_cv_scheme # *TlsConn tp )
 }
 
 // Open a plain (unencrypted) TCP client connection. Returns a
@@ -491,6 +559,8 @@ $ `stdlib/std/pkey.nu`
         ? != . l kp2 0 { ( nurl_free # s . l kp2 ) } {}
         ? != . l kp3 0 { ( nurl_free # s . l kp3 ) } {}
         ? != . l alpnp 0 { ( nurl_free # s . l alpnp ) } {}
+        ? != . l pqcertp 0 { ( nurl_free # s . l pqcertp ) } {}
+        ? != . l pqkp 0 { ( nurl_free # s . l pqkp ) } {}
     } {}
 }
 
@@ -611,14 +681,23 @@ $ `stdlib/std/pkey.nu`
     : ( Vec u ) cert ( __net_vecview . l certp . l certlen )
     : ( Vec u ) k1 ( __net_vecview . l kp1 . l kl1 )
     : ( Vec u ) alpn ( __net_vecview . l alpnp . l alpnlen )
-    // keytype 1 = RSA (k1 = n, k2 = d, k3 = e); else EC P-256 (k1 = scalar).
-    : !*TlsConn TlsErr r ? == . l keytype 1
-    { : ( Vec u ) k2 ( __net_vecview . l kp2 . l kl2 )
-        : ( Vec u ) k3 ( __net_vecview . l kp3 . l kl3 )
-        : !*TlsConn TlsErr rr ( tls_accept_rsa_alpn craw cert k1 k3 k2 alpn )
-        ( vec_free [u] k2 ) ( vec_free [u] k3 )
-        rr }
-    ( tls_accept_alpn craw cert k1 alpn )
+    // keytype 0 = EC P-256 (k1 = scalar), 1 = RSA (k1 = n, k2 = d, k3 =
+    // e), 2 = ML-DSA (k1 = secret key). With a second identity parked
+    // on the listener the handshake chooses between the two per
+    // ClientHello (tls_accept_dual_alpn); without one the classical /
+    // ML-DSA single-identity entry points are the same code.
+    : ( Vec u ) k2 ( __net_vecview . l kp2 . l kl2 )
+    : ( Vec u ) k3 ( __net_vecview . l kp3 . l kl3 )
+    : ( Vec u ) pqc ( __net_vecview . l pqcertp . l pqcertlen )
+    : ( Vec u ) pqk ( __net_vecview . l pqkp . l pqkl )
+    : ( Vec u ) none ( vec_new [u] )
+    : !*TlsConn TlsErr r ? == . l keytype 2
+    ( tls_accept_mldsa_alpn craw cert ( mldsa_level_of_sk_len ( vec_len [u] k1 ) ) k1 alpn )
+    ( tls_accept_dual_alpn craw cert . l keytype ? == . l keytype 1 none k1 ? == . l keytype 1 k1 none k3 k2
+    pqc ( mldsa_level_of_sk_len ( vec_len [u] pqk ) ) pqk alpn )
+    ( vec_free [u] none )
+    ( vec_free [u] pqc ) ( vec_free [u] pqk )
+    ( vec_free [u] k2 ) ( vec_free [u] k3 )
     ( vec_free [u] cert )
     ( vec_free [u] k1 )
     ( vec_free [u] alpn )

--- a/stdlib/std/pkey.nu
+++ b/stdlib/std/pkey.nu
@@ -66,7 +66,12 @@ $ `stdlib/std/ecdsa_p256.nu`
     } {}
     ? == . e1 tag 48 {
         // PKCS#8: e1 = AlgorithmIdentifier SEQUENCE, e2 = OCTET STRING that
-        // itself contains the SEC1 ECPrivateKey.
+        // itself contains the SEC1 ECPrivateKey. The algorithm has to BE
+        // id-ecPublicKey (1.2.840.10045.2.1): every PKCS#8 key shares
+        // this outer shape, and an ML-DSA key's inner OCTET STRING would
+        // otherwise be sliced into a 32-byte "scalar" and accepted.
+        : DerTlv aoid ( _der_child der e1 )
+        ? | == . aoid ok 0 ! ( _der_oid_is der aoid `2a8648ce3d0201` ) { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
         : DerTlv e2 ( _der_next der e1 )
         ? != . e2 tag 4 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
         : ( Vec u ) inner ( _der_content der e2 )
@@ -159,7 +164,11 @@ $ `stdlib/std/ecdsa_p256.nu`
             : DerTlv c0 ( _der_child der seq )  // version
             : DerTlv c1 ( _der_next der c0 )
             // PKCS#8: { version, AlgorithmIdentifier SEQUENCE, OCTET STRING }.
+            // The algorithm must be rsaEncryption (1.2.840.113549.1.1.1);
+            // the wrapper is shared by every key type (see the EC parser).
             ? & == . c1 ok 1 == . c1 tag 48 {
+                : DerTlv aoid ( _der_child der c1 )
+                ? | == . aoid ok 0 ! ( _der_oid_is der aoid `2a864886f70d010101` ) { ( vec_free [u] der ) ^ @ !RsaPriv ParseErr { F @ ParseErr { BadFormat } } } {}
                 : DerTlv c2 ( _der_next der c1 )  // privateKey OCTET STRING
                 ? | == . c2 ok 0 != . c2 tag 4 { ( vec_free [u] der ) ^ @ !RsaPriv ParseErr { F @ ParseErr { BadFormat } } } {}
                 : ( Vec u ) inner ( _der_content der c2 )

--- a/stdlib/std/quic_conn.nu
+++ b/stdlib/std/quic_conn.nu
@@ -63,7 +63,12 @@ $ `stdlib/std/quic_recovery.nu`
 
 @ quic_err_application → i { ^ 12 }
 
-// Server credentials, the same inputs `tls_accept*` takes.
+// Server credentials, the same inputs `tls_accept*` takes. keytype 0 =
+// EC P-256 (ec_priv = scalar), 1 = RSA, 2 = ML-DSA (ec_priv = the FIPS
+// 204 secret key, ml_level its parameter set). `pq_chain` / `pq_sk` /
+// `pq_level` are an optional SECOND identity — an ML-DSA leaf served
+// beside the classical one to clients whose signature_algorithms list
+// it (`quic_creds_set_pq`, the tls_accept_dual_alpn inputs).
 : QuicCreds {
     ( Vec u ) cert_chain
     i keytype
@@ -72,6 +77,9 @@ $ `stdlib/std/quic_recovery.nu`
     ( Vec u ) rsa_e
     ( Vec u ) rsa_d
     i ml_level
+    ( Vec u ) pq_chain
+    i pq_level
+    ( Vec u ) pq_sk
 }
 
 @ quic_creds_new ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d i ml_level → *QuicCreds {
@@ -83,13 +91,26 @@ $ `stdlib/std/quic_recovery.nu`
     = . k rsa_e ( bytes_slice rsa_e 0 ( vec_len [u] rsa_e ) )
     = . k rsa_d ( bytes_slice rsa_d 0 ( vec_len [u] rsa_d ) )
     = . k ml_level ml_level
+    = . k pq_chain ( vec_new [u] )
+    = . k pq_level 0
+    = . k pq_sk ( vec_new [u] )
     ^ k
+}
+
+// Park an ML-DSA identity beside the classical one (copies).
+@ quic_creds_set_pq * QuicCreds k ( Vec u ) pq_chain i pq_level ( Vec u ) pq_sk → v {
+    ( vec_clear [u] . k pq_chain )
+    ( bytes_extend_bytes . k pq_chain pq_chain )
+    ( vec_clear [u] . k pq_sk )
+    ( bytes_extend_bytes . k pq_sk pq_sk )
+    = . k pq_level pq_level
 }
 
 @ quic_creds_free * QuicCreds k → v {
     ? == # i k 0 { ^ } {}
     ( vec_free [u] . k cert_chain ) ( vec_free [u] . k ec_priv )
     ( vec_free [u] . k rsa_n ) ( vec_free [u] . k rsa_e ) ( vec_free [u] . k rsa_d )
+    ( vec_free [u] . k pq_chain ) ( vec_free [u] . k pq_sk )
     ( nurl_free # s k )
 }
 
@@ -310,6 +331,7 @@ $ `stdlib/std/quic_recovery.nu`
     = . c local_tp mine
     : ( Vec u ) tpb ( quic_tp_encode mine T )
     = . c tls ( quic_tls_srv_new . creds cert_chain . creds keytype . creds ec_priv . creds rsa_n . creds rsa_e . creds rsa_d . creds ml_level alpn_prefs tpb )
+    ? > ( vec_len [u] . creds pq_chain ) 0 { ( quic_tls_srv_set_pq . c tls . creds pq_chain . creds pq_level . creds pq_sk ) } {}
     ( vec_free [u] tpb )
     = . c tls_state 0
     = . c k_rx0 ( quic_initial_keys odcid T )

--- a/stdlib/std/quic_tls.nu
+++ b/stdlib/std/quic_tls.nu
@@ -9,6 +9,7 @@
 //
 //   ( quic_tls_srv_new cert_chain keytype ec_priv rsa_n rsa_e rsa_d ml_level alpn_prefs tp )
 //                                         → *QuicTlsSrv   `tp` = encoded quic_transport_parameters body
+//   ( quic_tls_srv_set_pq s pq_chain pq_level pq_sk ) → v   optional ML-DSA identity beside the classical one
 //   ( quic_tls_srv_free s )               → v
 //   ( quic_tls_srv_crypto s level off data ) → i          0 ok, else a QUIC transport error code:
 //                                                          0x100+alert (CRYPTO_ERROR), 0x0a PROTOCOL_VIOLATION,
@@ -84,6 +85,13 @@ $ `stdlib/std/quic_rxbuf.nu`
     = . s out1 ( vec_new [u] )
     = . s out2 ( vec_new [u] )
     ^ s
+}
+
+// A second, ML-DSA identity for this handshake — chosen over the
+// classical one when the ClientHello's signature_algorithms lists its
+// scheme (`_srv_hs_set_pq` / `__srv_pick_cert` in std/tls_server.nu).
+@ quic_tls_srv_set_pq * QuicTlsSrv s ( Vec u ) pq_chain i pq_level ( Vec u ) pq_sk → v {
+    ( _srv_hs_set_pq . s hs pq_chain pq_level pq_sk )
 }
 
 @ quic_tls_srv_free * QuicTlsSrv s → v {
@@ -174,6 +182,9 @@ $ `stdlib/std/quic_rxbuf.nu`
 @ quic_tls_srv_alpn * QuicTlsSrv s → ( Vec u ) { ^ . . s hs alpn_sel }
 
 @ quic_tls_srv_cipher * QuicTlsSrv s → i { ^ ? == . . s hs cipher 1 1 2 }
+
+// The CertificateVerify scheme this handshake signs with (see tls_cv_scheme).
+@ quic_tls_srv_sig_scheme * QuicTlsSrv s → i { ^ ( _srv_hs_sig_scheme . s hs ) }
 
 @ quic_tls_srv_c_hs * QuicTlsSrv s → ( Vec u ) { ^ . . s hs c_hs }
 

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -1354,6 +1354,14 @@ $ `stdlib/std/async_ffi.nu`
     ^ . c kx_group
 }
 
+// The SignatureScheme of this connection's CertificateVerify: on a client,
+// what the server signed with; on a server, what it chose to sign with
+// (ecdsa_secp256r1_sha256 0x0403, rsa_pss_rsae_sha256 0x0804, mldsa44/65/87
+// 0x0904–0x0906). 0 on a resumed handshake, which carries no certificate.
+@ tls_cv_scheme * TlsConn c → i {
+    ^ . c cv_scheme
+}
+
 // T when the negotiated group carries a post-quantum component, so the
 // session's forward secrecy survives a future quantum adversary
 // recording it today.

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -8,12 +8,14 @@
 // the client keys; tls.nu's client functions are hardwired the other way).
 //
 // Scope: TLS 1.3 only; an EC P-256 leaf (CertificateVerify signed with
-// ecdsa_secp256r1_sha256) OR an RSA leaf (rsa_pss_rsae_sha256); the
-// X25519MLKEM768, X25519 and secp256r1 groups; the AES-128-GCM /
-// ChaCha20-Poly1305 cipher suites — i.e. exactly what tls.nu's client
-// offers, so the two interoperate. A full certificate chain (leaf +
-// intermediates) is supported via the tls_cert_entry-framed cert_chain
-// argument.
+// ecdsa_secp256r1_sha256), an RSA leaf (rsa_pss_rsae_sha256) or an ML-DSA
+// leaf (mldsa44/65/87) — or a classical leaf AND an ML-DSA leaf together,
+// chosen per connection from the client's signature_algorithms
+// (`tls_accept_dual_alpn`, RFC 8446 §4.4.2.2); the X25519MLKEM768, X25519
+// and secp256r1 groups; the AES-128-GCM / ChaCha20-Poly1305 cipher
+// suites — i.e. exactly what tls.nu's client offers, so the two
+// interoperate. A full certificate chain (leaf + intermediates) is
+// supported via the tls_cert_entry-framed cert_chain argument.
 //
 // On X25519MLKEM768 the server is the *encapsulating* side: the client
 // sends an ML-KEM encapsulation key and gets back a ciphertext, not a
@@ -34,6 +36,11 @@
 //       priv       = 32-byte EC P-256 private scalar (see std/pkey.nu)
 //       n / d      = RSA modulus / private exponent, big-endian
 //                    (std/pkey.nu rsa_priv_from_pem → RsaPriv)
+//   ( tls_accept_mldsa i raw ( Vec u ) cert_chain i level ( Vec u ) sk )
+//       an ML-DSA leaf: level 44 / 65 / 87, sk = the FIPS 204 secret key
+//   ( tls_accept_dual_alpn i raw cert_chain keytype ec_priv n e d pq_chain pq_level pq_sk alpn_prefs )
+//       a classical leaf plus an ML-DSA leaf; the client's
+//       signature_algorithms picks which one it is shown
 //   ( tls_server_read  *TlsConn c i max )      → !( Vec u ) TlsErr
 //   ( tls_server_write *TlsConn c ( Vec u ) )  → !v TlsErr
 //   ( tls_close *TlsConn c )                   → v   (reused from tls.nu)
@@ -479,7 +486,7 @@ $ `stdlib/std/aes_gcm.nu`
     ? == keytype 2 {
         : ( Vec u ) ctx ( vec_new [u] )
         : ( Vec u ) sig ( mldsa_sign ml_level ec_priv cvc ctx )
-        : i scheme ? == ml_level 44 2308 ? == ml_level 65 2309 2310
+        : i scheme ( __srv_mldsa_scheme ml_level )
         ( _tls_u16 cvbody scheme )
         ( _tls_u16 cvbody ( vec_len [u] sig ) )
         ( _tls_cat cvbody sig )
@@ -670,6 +677,13 @@ $ `stdlib/std/aes_gcm.nu`
     ( Vec u ) out_sh
     ( Vec u ) out_hs
     ( Vec u ) out_ticket
+    // Optional second identity: an ML-DSA leaf chain + FIPS 204 secret
+    // key, selected per ClientHello by `__srv_pick_cert` when the
+    // client's signature_algorithms lists its scheme. Empty when the
+    // caller configured a single certificate.
+    ( Vec u ) pq_chain
+    ( Vec u ) pq_sk
+    i pq_level
 }
 
 @ _srv_hs_new ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d i ml_level ( Vec u ) alpn_prefs → *SrvHs {
@@ -708,7 +722,23 @@ $ `stdlib/std/aes_gcm.nu`
     = . h out_sh ( vec_new [u] )
     = . h out_hs ( vec_new [u] )
     = . h out_ticket ( vec_new [u] )
+    = . h pq_chain ( vec_new [u] )
+    = . h pq_sk ( vec_new [u] )
+    = . h pq_level 0
     ^ h
+}
+
+// Give the handshake a second, post-quantum identity: `pq_chain` is a
+// tls_cert_entry-framed ML-DSA certificate_list and `pq_sk` the matching
+// FIPS 204 secret key at `pq_level` (44 / 65 / 87). Which of the two
+// identities a connection gets is decided per ClientHello — see
+// `__srv_pick_cert`. Copies, like the constructor.
+@ _srv_hs_set_pq * SrvHs h ( Vec u ) pq_chain i pq_level ( Vec u ) pq_sk → v {
+    ( vec_clear [u] . h pq_chain )
+    ( bytes_extend_bytes . h pq_chain pq_chain )
+    ( vec_clear [u] . h pq_sk )
+    ( bytes_extend_bytes . h pq_sk pq_sk )
+    = . h pq_level pq_level
 }
 
 @ _srv_hs_set_ext * SrvHs h i want ( Vec u ) ext_out → v {
@@ -739,6 +769,8 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_free [u] . h out_sh )
     ( vec_free [u] . h out_hs )
     ( vec_free [u] . h out_ticket )
+    ( vec_free [u] . h pq_chain )
+    ( vec_free [u] . h pq_sk )
     ( nurl_free # s h )
 }
 
@@ -746,6 +778,58 @@ $ `stdlib/std/aes_gcm.nu`
 @ __srv_hs_fail * SrvHs h i desc → i {
     = . h state 3
     ^ desc
+}
+
+// The TLS SignatureScheme for an ML-DSA parameter set
+// (draft-ietf-tls-mldsa): mldsa44 0x0904, mldsa65 0x0905, mldsa87 0x0906.
+@ __srv_mldsa_scheme i level → i {
+    ^ ? == level 44 2308 ? == level 65 2309 2310
+}
+
+// Certificate selection, RFC 8446 §4.4.2.2: a server with more than one
+// identity picks the one whose signature scheme the client listed in
+// signature_algorithms. Here that is a choice between the classical
+// leaf the handshake was constructed with and the ML-DSA leaf parked
+// by `_srv_hs_set_pq`; the ML-DSA leaf wins whenever the client says it
+// can verify it — a client that offers `mldsaNN` is asking for it, and
+// nothing classical is left in the handshake once it is chosen. A
+// client without the scheme (every stack older than 2025, and every
+// OpenSSL before 3.5) gets the classical leaf exactly as before, so
+// adding a post-quantum certificate never costs a connection.
+//
+// No `pq_chain` → nothing to choose. No signature_algorithms extension
+// at all is a client that must be refused later anyway (§4.2.3 makes
+// it mandatory for certificate authentication); it gets the classical
+// leaf and the failure it was heading for.
+// The scheme this handshake signs (or signed) its CertificateVerify with.
+@ _srv_hs_sig_scheme * SrvHs h → i {
+    ? == . h keytype 2 { ^ ( __srv_mldsa_scheme . h ml_level ) } {}
+    ^ ? == . h keytype 1 2052 1027
+}
+
+@ __srv_pick_cert * SrvHs h ( Vec u ) ch i es i ee → v {
+    ? == ( vec_len [u] . h pq_chain ) 0 { ^ } {}
+    : i want ( __srv_mldsa_scheme . h pq_level )
+    : i sa ( __srv_find_ext ch es ee 13 )
+    ? < sa 0 { ^ } {}
+    : i extlen ( _rdint ch - sa 2 2 )
+    ? | < extlen 2 > + sa extlen ee { ^ } {}
+    : i salen ( _rdint ch sa 2 )
+    : i saend + + sa 2 salen
+    ? > saend + sa extlen { ^ } {}
+    : ~ i p + sa 2
+    : ~ i hit 0
+    ~ & < + p 1 saend == hit 0 {
+        ? == ( _rdint ch p 2 ) want { = hit 1 } {}
+        = p + p 2
+    }
+    ? == hit 0 { ^ } {}
+    ( vec_free [u] . h cert_chain )
+    ( vec_free [u] . h ec_priv )
+    = . h cert_chain ( bytes_slice . h pq_chain 0 ( vec_len [u] . h pq_chain ) )
+    = . h ec_priv ( bytes_slice . h pq_sk 0 ( vec_len [u] . h pq_sk ) )
+    = . h keytype 2
+    = . h ml_level . h pq_level
 }
 
 @ _srv_hs_client_hello * SrvHs h ( Vec u ) ch → i {
@@ -791,6 +875,10 @@ $ `stdlib/std/aes_gcm.nu`
     : i es + p3 2
     : i ee + es extlen
     ? > ee ( vec_len [u] ch ) { ^ ( __srv_hs_fail h 50 ) } {}
+
+    // Which identity this connection gets (§4.4.2.2) — decided before
+    // anything below reads keytype / cert_chain.
+    ( __srv_pick_cert h ch es ee )
 
     // key_share (0x0033): pick x25519 (0x001d) if offered, else secp256r1.
     : i ks ( __srv_find_ext ch es ee 51 )
@@ -1106,7 +1194,7 @@ $ `stdlib/std/aes_gcm.nu`
     }
 }
 
-@ __tls_accept_impl i raw ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d i ml_level ( Vec u ) alpn_prefs → !*TlsConn TlsErr {
+@ __tls_accept_impl i raw ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d i ml_level ( Vec u ) pq_chain i pq_level ( Vec u ) pq_sk ( Vec u ) alpn_prefs → !*TlsConn TlsErr {
     ? <= raw 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
     : *TlsConn c ( nurl_alloc Z TlsConn )
     = . c fd raw
@@ -1136,6 +1224,7 @@ $ `stdlib/std/aes_gcm.nu`
     = . c tk_received_ms 0
 
     : *SrvHs hs ( _srv_hs_new cert_chain keytype ec_priv rsa_n rsa_e rsa_d ml_level alpn_prefs )
+    ? > ( vec_len [u] pq_chain ) 0 { ( _srv_hs_set_pq hs pq_chain pq_level pq_sk ) } {}
 
     // ── ClientHello ──
     : !( Vec u ) TlsErr chr ( __srv_next_hs c )
@@ -1152,6 +1241,7 @@ $ `stdlib/std/aes_gcm.nu`
     = . c cipher . hs cipher
     = . c kx_group . hs kx_group
     = . c resumed . hs resumed
+    = . c cv_scheme ? == . hs resumed 0 ( _srv_hs_sig_scheme hs ) 0
     ( vec_free [u] . c alpn_sel )
     = . c alpn_sel ( bytes_slice . hs alpn_sel 0 ( vec_len [u] . hs alpn_sel ) )
 
@@ -1229,7 +1319,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) en ( vec_new [u] )
     : ( Vec u ) ee ( vec_new [u] )
     : ( Vec u ) ed ( vec_new [u] )
-    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 0 priv en ee ed 0 alpn_prefs )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 0 priv en ee ed 0 en 0 en alpn_prefs )
     ( vec_free [u] en ) ( vec_free [u] ee ) ( vec_free [u] ed )
     ^ r
 }
@@ -1270,7 +1360,7 @@ $ `stdlib/std/aes_gcm.nu`
 // tls_accept_rsa with an ALPN preference list — see tls_accept_alpn.
 @ tls_accept_rsa_alpn i raw ( Vec u ) cert_chain ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d ( Vec u ) alpn_prefs → !*TlsConn TlsErr {
     : ( Vec u ) ee ( vec_new [u] )
-    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 1 ee rsa_n rsa_e rsa_d 0 alpn_prefs )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 1 ee rsa_n rsa_e rsa_d 0 ee 0 ee alpn_prefs )
     ( vec_free [u] ee )
     ^ r
 }
@@ -1298,9 +1388,25 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) en ( vec_new [u] )
     : ( Vec u ) ee ( vec_new [u] )
     : ( Vec u ) ed ( vec_new [u] )
-    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 2 sk en ee ed level alpn_prefs )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 2 sk en ee ed level en 0 en alpn_prefs )
     ( vec_free [u] en ) ( vec_free [u] ee ) ( vec_free [u] ed )
     ^ r
+}
+
+// Accept with TWO identities and let the client's signature_algorithms
+// decide which one it sees (RFC 8446 §4.4.2.2): the classical leaf
+// (`keytype` 0 = EC P-256 with `ec_priv`; 1 = RSA with `rsa_n` / `rsa_e`
+// / `rsa_d`) for clients that cannot verify ML-DSA, the ML-DSA leaf
+// (`pq_chain`, `pq_level`, `pq_sk` — the tls_accept_mldsa inputs) for
+// every client that lists `mldsaNN`. This is how a server serves a
+// post-quantum certificate to browsers and curl builds that understand
+// it while the rest of the world keeps its ECDSA — the same operation
+// OpenSSL performs when a context holds one certificate per key type.
+// `tcp_listen_tls_dual` (std/net.nu) is the PEM-file front of this.
+//
+// An empty `pq_chain` makes it tls_accept_alpn / tls_accept_rsa_alpn.
+@ tls_accept_dual_alpn i raw ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d ( Vec u ) pq_chain i pq_level ( Vec u ) pq_sk ( Vec u ) alpn_prefs → !*TlsConn TlsErr {
+    ^ ( __tls_accept_impl raw cert_chain keytype ec_priv rsa_n rsa_e rsa_d 0 pq_chain pq_level pq_sk alpn_prefs )
 }
 
 // Discard a live transcript hasher (error paths).


### PR DESCRIPTION
## What

The pure-NURL TLS 1.3 server can now hold **two identities** — the EC P-256 / RSA leaf it always had and an **ML-DSA (FIPS 204)** leaf — and shows each ClientHello the one it can verify (RFC 8446 §4.4.2.2): the ML-DSA leaf to a client listing `mldsaNN` in `signature_algorithms`, the classical leaf to everything else. Deploying a post-quantum certificate never turns a client away.

The choice is made once, on the shared `SrvHs` (`__srv_pick_cert`), so **TCP TLS and the QUIC handshake (HTTP/3) get it from the same lines.**

## API

- `std/tls_server.nu`: `tls_accept_dual_alpn`; `tls_cv_scheme conn` (both ends)
- `std/net.nu`: `tcp_listen_tls_dual host port backlog cert key pq_cert pq_key alpn`; `tcp_tls_sig_scheme conn`; `_load_tls_creds` auto-detects an ML-DSA PKCS#8 key (keytype 2), so `tcp_listen_tls` with an ML-DSA pair alone serves it directly; a non-ML-DSA key in the PQ slot is refused with `NetTlsKeyLoad`
- QUIC: `quic_creds_set_pq`, `quic_tls_srv_set_pq`, `http3_creds_add_pq`
- **http 0.5.0**: `http_app_set_pq_cert a cert key`; README gains a Capabilities table (HTTP/1.1, /2, /3, PQ key exchange, PQ authentication, how each is chosen)

```nurl
( http_app_set_pq_cert a `certs/mldsa65.pem` `certs/mldsa65.key` )   // optional
^ ( http_app_listen_tls a `0.0.0.0` 443 `certs/fullchain.pem` `certs/privkey.pem` )
```

## Fixed on the way

`ec_p256_priv_from_pem` and `rsa_priv_from_pem` never checked the PKCS#8 AlgorithmIdentifier: an ML-DSA key parsed as a 32-byte "P-256 scalar", so the listener's key auto-detection could not reach the ML-DSA parser. Both now require their own OID (id-ecPublicKey / rsaEncryption).

## Verification

- New `compiler/tests/tls_cert_select.nu`: offline selection against the RFC 9001 A.2 ClientHello (classical → ECDSA; `mldsa65` added → ML-DSA leaf, Certificate message carries the right chain; `mldsa44` only → classical (level must match); no second identity → classical), and end to end from PEM files (dual listener → mldsa65 over X25519MLKEM768, CertificateVerify verifies, server reports the same scheme; ML-DSA-only PEM auto-detected; classical key in PQ slot refused)
- Full suite 921/921, http package smoke 9/9, `tools/h3spec_gate.sh` 49/49
- Interop against **one** dual listener (`http_app_listen_tls` + `http_app_set_pq_cert`):
  - OpenSSL 3.0.13 / curl 8.5 → `Peer signature type: ECDSA`, HTTP/2 200
  - OpenSSL 3.5.8 / curl 8.14 (alpine:3.22, **default settings, no flags**) → `Peer signature type: mldsa65`, `Negotiated TLS1.3 group: X25519MLKEM768`, HTTP/2 200
  - HTTP/3 (ymuski/curl-http3) → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw