### PR TITLE
http-client: a unified HTTP client facade (ALPN h2/h1, PQ-TLS, pooling, cookies, gzip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`packages/http-client` — the unified HTTP *client* facade, the
+  mirror of `packages/http`.** One `HttpClient` fetches over whichever
+  protocol the server offers — HTTP/2 or HTTP/1.1 chosen by ALPN — with
+  post-quantum TLS (X25519MLKEM768 + ML-DSA chains) used automatically,
+  per-origin connection pooling and TLS-session resumption, redirect
+  following (303 / POST→GET downgrade, RFC 3986 §5.2 relative
+  resolution), a wired-in RFC 6265 cookie jar, and transparent
+  gzip/deflate decoding with a decompression-bomb cap. `http_client_get`
+  / `_post` / `_request`, a unified `HttpResponse` + `HttpClientErr`, and
+  `http_client_last_proto` / `_last_pq` evidence. The stdlib gained the
+  primitives a package cannot: an ALPN **preference list** in the TLS
+  client (`tls_connect_full` / `tcp_connect_tls_full`, the negotiated
+  protocol validated to be one offered — RFC 7301 §3.2), and HTTP/1.1
+  keep-alive with honoured read/write deadlines, a body cap, interim-1xx
+  skipping, chunked-trailer consumption and `Connection`-aware pooling
+  in `http_pure.nu` (`hp_stream_open_on` / `hp_stream_release`).
+
+### Security
+
+- **A decompression-output cap in the DEFLATE path**, enforced *while*
+  decoding rather than after: `inflate_max`, `zlib_decompress_max` and
+  `gzip_decompress_max` stop with an error the moment the output would
+  pass the caller's byte limit — the guard an HTTP client needs before
+  it trusts a `Content-Encoding` body (1 KB of DEFLATE can expand to a
+  megabyte, so a cap checked only after the fact is no cap at all).
+
 ### Security
 
 - **HTTP stack hardened against the standard smuggling / flood / DoS

--- a/compiler/tests/http_keepalive.nu
+++ b/compiler/tests/http_keepalive.nu
@@ -1,0 +1,347 @@
+// http_keepalive.nu — the pure HTTP/1.1 client's connection reuse,
+// framing rules, deadlines and body cap (stdlib/ext/http_pure.nu).
+//
+// Until 2026-09-03 the client hardcoded `Connection: close`, ignored the
+// timeouts it was handed, had no body cap, and read every body to EOF
+// or Content-Length — a HEAD or 204 with a Content-Length would have
+// hung on a keep-alive connection. This pins:
+//   * hp_stream_open_on + hp_stream_release: three requests over ONE
+//     accepted connection of the real HttpServer (one server_run_once);
+//   * an interim 100 Continue is skipped, the final response is the one
+//     reported, and the connection stays reusable;
+//   * HEAD with Content-Length and 204 carry no body and keep the
+//     connection; a body delimited by EOF, or `Connection: close`, does
+//     not (release → none);
+//   * the read deadline fires as error 2 (timeout), a Content-Length
+//     body cut short by EOF as error 6, a body over the cap as error 7;
+//   * redirect Location resolution (RFC 3986 §5.2) and the header-blob
+//     probe that lets a caller take over Accept-Encoding / Connection.
+//
+// Servers on OS threads (tcp_accept blocks), client on the main thread.
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/url.nu`
+$ `stdlib/ext/http_pure.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_server.nu`
+
+: ~ i handled 0
+: ~ i run_once_returns 0
+
+@ label s k s v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ yn b v → s { ^ ? v `T` `F` }
+
+// ── canned server: one accepted connection per case ─────────────────
+
+// Read until the request head is complete (or the peer goes away).
+@ read_head TcpConn c → v {
+    : ( Vec u ) acc ( vec_new [u] )
+    : ~ b reading T
+    ~ reading {
+        ?? ( tcp_read_chunk c 4096 ) {
+            T v → {
+                ( bytes_extend_bytes acc v ) ( vec_free [u] v )
+                : String s ( bytes_to_str acc )
+                ? >= ( nurl_str_find ( string_data s ) `\r\n\r\n` ) 0 { = reading F } {}
+                ( string_free s )
+            }
+            F _ → { = reading F }
+        }
+    }
+    ( vec_free [u] acc )
+}
+
+@ send_text TcpConn c s text → v {
+    : ( Vec u ) b ( bytes_from_str text )
+    ?? ( tcp_write_all c b ) { T _ → {} F _ → {} }
+    ( vec_free [u] b )
+}
+
+// One accepted connection: answer `first`; if `second` is non-empty read
+// another request on the same connection and answer that too.
+@ canned TcpListener l s first s second i delay_ms → v {
+    ?? ( tcp_accept l ) {
+        T c → {
+            ( read_head c )
+            ? > delay_ms 0 { ( sleep_ms delay_ms ) } {}
+            ( send_text c first )
+            ? > ( nurl_str_len second ) 0 {
+                ( read_head c )
+                ( send_text c second )
+            } {}
+            ( tcp_close_conn c )
+        }
+        F _ → {}
+    }
+}
+
+@ big_body → String {
+    : String r ( string_new )
+    : ~ i k 0
+    ~ < k 10000 { ( string_push_str r `x` ) = k + k 1 }
+    ^ r
+}
+
+// ── client side ─────────────────────────────────────────────────────
+
+// One exchange on `conn`; prints status/body/err, returns the released
+// transport (none when the response made it single-use).
+@ exchange s name HttpConn conn s method s target i body_max → ?HttpConn {
+    : *HttpStreamState st ( hp_stream_open_on conn method `127.0.0.1` 18951 0 target # *u 0 0 `` `nurl-test` )
+    ( hp_stream_set_body_max st body_max )
+    ~ == . st finished 0 { ( hp_stream_pump st ) }
+    : String v ( string_new )
+    ? != . st err_kind 0 {
+        ( string_push_str v `err=` )
+        ( string_push_int v . st err_kind )
+    } {
+        ( string_push_int v . st status )
+        ( string_push_str v ` body=[` )
+        : i bl ( vec_len [u] . st body )
+        ? > bl 20 {
+            ( string_push_int v bl )
+            ( string_push_str v ` bytes` )
+        } {
+            : String b ( string_from_bytes ( vec_data [u] . st body ) bl )
+            ( string_push_str v ( string_data b ) )
+            ( string_free b )
+        }
+        ( string_push_str v `]` )
+    }
+    : ?HttpConn back ( hp_stream_release st )
+    ( string_push_str v ` reusable=` )
+    ?? back { T _ → { ( string_push_str v `T` ) } F _ → { ( string_push_str v `F` ) } }
+    ( label name ( string_data v ) )
+    ( string_free v )
+    ^ back
+}
+
+@ open_conn i timeout_ms → ?HttpConn {
+    ?? ( hp_conn_open 0 `127.0.0.1` 18951 `127.0.0.1` 0 ) {
+        T c → {
+            ? > timeout_ms 0 { ( hp_conn_set_timeout c timeout_ms ) } {}
+            ^ @ ?HttpConn { T c }
+        }
+        F e → { ( label `connect` `FAIL` ) ^ @ ?HttpConn { F # HttpConn 0 } }
+    }
+}
+
+@ drop_conn ? HttpConn c → v {
+    ?? c { T x → ( hp_conn_close x ) F _ → {} }
+}
+
+@ canned_cases TcpListener l → v {
+    : s h100 `HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok`
+    : s h_head `HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nETag: "x"\r\n\r\n`
+    : s h204 `HTTP/1.1 204 No Content\r\n\r\n`
+    : s h_eof `HTTP/1.1 200 OK\r\n\r\nhello`
+    : s h_close `HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nbye`
+    : s h_short `HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nabc`
+    : s h10 `HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok`
+    : s h_10 `HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\nok`
+    : s h_10ka `HTTP/1.0 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok`
+    : String big ( big_body )
+    : String h_big ( string_from `HTTP/1.1 200 OK\r\nContent-Length: 10000\r\n\r\n` )
+    ( string_push_str h_big ( string_data big ) )
+    : s chunked `HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n`
+
+    ( canned l h100 h10 0 )  // 1: interim skipped, then reused
+    ( canned l h_head h204 0 )  // 2: HEAD + 204 on one connection
+    ( canned l h_eof `` 0 )  // 3: EOF-delimited
+    ( canned l h_close `` 0 )  // 4: Connection: close
+    ( canned l h10 `` 900 )  // 5: deadline
+    ( canned l h_short `` 0 )  // 6: truncated
+    ( canned l ( string_data h_big ) `` 0 )  // 7: over the cap
+    ( canned l chunked h10 0 )  // 8: chunked then reused
+    ( canned l h_10 `` 0 )  // 9: HTTP/1.0 → single use
+    ( canned l h_10ka `` 0 )  // 10: HTTP/1.0 + keep-alive → reusable
+    ( string_free big )
+    ( string_free h_big )
+}
+
+// ── the real HttpServer: three requests, one connection ─────────────
+
+@ count_handler HttpRequest req → HttpResponse {
+    = handled + handled 1
+    : String body ( string_from `req ` )
+    ( string_push_int body handled )
+    ( string_push_str body ` ` )
+    ( string_push_str body ( string_data . req path ) )
+    : HttpResponse r ( response_text 200 ( string_data body ) )
+    ( string_free body )
+    ^ r
+}
+
+@ real_server_case → v {
+    ?? ( hp_conn_open 0 `127.0.0.1` 18952 `127.0.0.1` 0 ) {
+        T c0 → {
+            : ~ ? HttpConn cur @ ?HttpConn { T c0 }
+            : ~ i k 1
+            ~ <= k 3 {
+                ?? cur {
+                    T c → {
+                        : String tg ( string_from `/n` )
+                        ( string_push_int tg k )
+                        : *HttpStreamState st ( hp_stream_open_on c `GET` `127.0.0.1` 18952 0 ( string_data tg ) # *u 0 0 `` `nurl-test` )
+                        ~ == . st finished 0 { ( hp_stream_pump st ) }
+                        : String v ( string_new )
+                        ( string_push_int v . st status )
+                        ( string_push_str v ` ` )
+                        : String b ( string_from_bytes ( vec_data [u] . st body ) ( vec_len [u] . st body ) )
+                        ( string_push_str v ( string_data b ) )
+                        : String nm ( string_from `server_req` )
+                        ( string_push_int nm k )
+                        ( label ( string_data nm ) ( string_data v ) )
+                        ( string_free nm ) ( string_free b ) ( string_free v ) ( string_free tg )
+                        = cur ( hp_stream_release st )
+                    }
+                    F _ → { ( label `server_conn_lost` `T` ) = k 99 }
+                }
+                = k + k 1
+            }
+            ( drop_conn cur )
+        }
+        F _ → { ( label `server_connect` `FAIL` ) }
+    }
+}
+
+// ── offline: Location resolution and the header-blob probe ──────────
+
+@ resolve s base s loc → s {
+    ?? ( url_parse base ) {
+        T u → {
+            : ?String r ( _hp_resolve_redirect u loc )
+            ( url_free u )
+            ?? r { T s → ^ ( string_data s ) F _ → ^ `(none)` }
+        }
+        F _ → ^ `(bad base)`
+    }
+}
+
+@ offline → v {
+    ( label `abs` ( resolve `http://a/b/c/d;p?q` `https://x.example/y#frag` ) )
+    ( label `scheme_rel` ( resolve `https://a:8443/b/c` `//other/p` ) )
+    ( label `root_rel` ( resolve `https://a:8443/b/c?q` `/g?x=1` ) )
+    ( label `path_rel` ( resolve `http://a/b/c/d;p?q` `g` ) )
+    ( label `dotdot` ( resolve `http://a/b/c/d;p?q` `../g` ) )
+    ( label `dotdot2` ( resolve `http://a/b/c/d;p?q` `../../g` ) )
+    ( label `dotdot_over` ( resolve `http://a/b/c/d;p?q` `../../../g` ) )
+    ( label `dot` ( resolve `http://a/b/c/d;p?q` `./g/.` ) )
+    ( label `query_only` ( resolve `http://a/b/c/d;p?q` `?y` ) )
+    ( label `empty_path_base` ( resolve `http://a` `g` ) )
+    ( label `blob_has_ae` ( yn ( _hp_blob_has `Accept-Encoding: gzip\r\n` `accept-encoding` ) ) )
+    ( label `blob_has_ae_second` ( yn ( _hp_blob_has `X: 1\r\naccept-encoding: br\r\n` `accept-encoding` ) ) )
+    ( label `blob_has_ae_not_value` ( yn ( _hp_blob_has `X: accept-encoding: gzip\r\n` `accept-encoding` ) ) )
+    ( label `blob_has_ae_prefix` ( yn ( _hp_blob_has `Accept-Encodings: gzip\r\n` `accept-encoding` ) ) )
+    ( label `blob_has_empty` ( yn ( _hp_blob_has `` `connection` ) ) )
+}
+
+@ run → v {
+    ( offline )
+    : !TcpListener NetErr lr1 ( tcp_listen `127.0.0.1` 18951 )
+    : !TcpListener NetErr lr2 ( tcp_listen `127.0.0.1` 18952 )
+    ?? lr1 {
+        T l1 → {
+            ?? lr2 {
+                T l2 → {
+                    : ( @ HttpResponse HttpRequest ) handler \ HttpRequest req → HttpResponse { ^ ( count_handler req ) }
+                    : HttpServer srv ( server_new_with_timeout l2 handler 5000 )
+                    : ( @ v ) server \ → v {
+                        ( canned_cases l1 )
+                        : !v NetErr r1 ( server_run_once srv )
+                        = run_once_returns + run_once_returns 1
+                    }
+                    ?? ( thread_spawn server ) {
+                        T t → {
+                            ( sleep_ms 150 )
+                            // 1. 100 Continue skipped; reuse for a second request
+                            : ?HttpConn c1 ( open_conn 0 )
+                            ?? c1 {
+                                T c → {
+                                    : ?HttpConn c1b ( exchange `interim_100` c `GET` `/a` 0 )
+                                    ?? c1b {
+                                        T cc → { ( drop_conn ( exchange `interim_100_reuse` cc `GET` `/b` 0 ) ) }
+                                        F _ → { ( label `interim_100_reuse` `no conn` ) }
+                                    }
+                                }
+                                F _ → {}
+                            }
+                            // 2. HEAD with Content-Length, then 204, one connection
+                            : ?HttpConn c2 ( open_conn 0 )
+                            ?? c2 {
+                                T c → {
+                                    : ?HttpConn c2b ( exchange `head_clen` c `HEAD` `/h` 0 )
+                                    ?? c2b {
+                                        T cc → { ( drop_conn ( exchange `no_content_204` cc `GET` `/n` 0 ) ) }
+                                        F _ → { ( label `no_content_204` `no conn` ) }
+                                    }
+                                }
+                                F _ → {}
+                            }
+                            // 3. body to EOF
+                            : ?HttpConn c3 ( open_conn 0 )
+                            ?? c3 { T c → { ( drop_conn ( exchange `eof_body` c `GET` `/e` 0 ) ) } F _ → {} }
+                            // 4. Connection: close
+                            : ?HttpConn c4 ( open_conn 0 )
+                            ?? c4 { T c → { ( drop_conn ( exchange `conn_close` c `GET` `/c` 0 ) ) } F _ → {} }
+                            // 5. deadline 250 ms, server answers after 900 ms
+                            : ?HttpConn c5 ( open_conn 250 )
+                            ?? c5 { T c → { ( drop_conn ( exchange `deadline` c `GET` `/t` 0 ) ) } F _ → {} }
+                            // 6. Content-Length 10, 3 bytes then EOF
+                            : ?HttpConn c6 ( open_conn 0 )
+                            ?? c6 { T c → { ( drop_conn ( exchange `truncated` c `GET` `/s` 0 ) ) } F _ → {} }
+                            // 7. 10000-byte body against a 100-byte cap
+                            : ?HttpConn c7 ( open_conn 0 )
+                            ?? c7 { T c → { ( drop_conn ( exchange `over_cap` c `GET` `/big` 100 ) ) } F _ → {} }
+                            // 8. chunked, then reuse
+                            : ?HttpConn c8 ( open_conn 0 )
+                            ?? c8 {
+                                T c → {
+                                    : ?HttpConn c8b ( exchange `chunked` c `GET` `/ch` 0 )
+                                    ?? c8b {
+                                        T cc → { ( drop_conn ( exchange `chunked_reuse` cc `GET` `/b` 0 ) ) }
+                                        F _ → { ( label `chunked_reuse` `no conn` ) }
+                                    }
+                                }
+                                F _ → {}
+                            }
+                            // 9. HTTP/1.0 response → single use
+                            : ?HttpConn c9 ( open_conn 0 )
+                            ?? c9 { T c → { ( drop_conn ( exchange `http10` c `GET` `/o` 0 ) ) } F _ → {} }
+                            // 10. HTTP/1.0 + Connection: keep-alive → reusable
+                            : ?HttpConn c10 ( open_conn 0 )
+                            ?? c10 { T c → { ( drop_conn ( exchange `http10_keepalive` c `GET` `/o` 0 ) ) } F _ → {} }
+
+                            ( real_server_case )
+                            ( thread_join t )
+                            : *u env # *u server 1
+                            ( nurl_free # s env )
+                            ( label `server_handled` ( nurl_str_int handled ) )
+                            ( label `server_run_once_returns` ( nurl_str_int run_once_returns ) )
+                        }
+                        F _ → { ( label `thread` `FAIL` ) }
+                    }
+                    ( server_stop srv )
+                }
+                F e → { ( label `listen2` ( net_err_name e ) ) }
+            }
+            ( tcp_close_listener l1 )
+        }
+        F e → { ( label `listen1` ( net_err_name e ) ) }
+    }
+}
+
+@ main → i {
+    ( run )
+    ^ 0
+}

--- a/compiler/tests/outputs/http_keepalive.txt
+++ b/compiler/tests/outputs/http_keepalive.txt
@@ -1,0 +1,37 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+abs=https://x.example/y
+scheme_rel=https://other/p
+root_rel=https://a:8443/g?x=1
+path_rel=http://a/b/c/g
+dotdot=http://a/b/g
+dotdot2=http://a/g
+dotdot_over=http://a/g
+dot=http://a/b/c/g/
+query_only=http://a/b/c/d;p?y
+empty_path_base=http://a/g
+blob_has_ae=T
+blob_has_ae_second=T
+blob_has_ae_not_value=F
+blob_has_ae_prefix=F
+blob_has_empty=F
+interim_100=200 body=[ok] reusable=T
+interim_100_reuse=200 body=[ok] reusable=T
+head_clen=200 body=[] reusable=T
+no_content_204=204 body=[] reusable=T
+eof_body=200 body=[hello] reusable=F
+conn_close=200 body=[bye] reusable=F
+deadline=err=2 reusable=F
+truncated=err=6 reusable=F
+over_cap=err=7 reusable=F
+chunked=200 body=[abcde] reusable=T
+chunked_reuse=200 body=[ok] reusable=T
+http10=200 body=[ok] reusable=F
+http10_keepalive=200 body=[ok] reusable=T
+server_req1=200 req 1 /n1
+server_req2=200 req 2 /n2
+server_req3=200 req 3 /n3
+server_handled=3
+server_run_once_returns=1

--- a/compiler/tests/outputs/tls_alpn_server.txt
+++ b/compiler/tests/outputs/tls_alpn_server.txt
@@ -2,12 +2,19 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
+offered_h2_in_list=T
+offered_http11_in_list=T
+offered_prefix_rejected=F
+offered_superstring_rejected=F
+offered_empty_list=F
 client_h2=[h2] echo=T
 client_http11=[http/1.1] echo=T
 client_mismatch=NetTlsHandshake
 client_none=[] echo=T
 openssl_client=[h2] echo=T
 openssl_mismatch=alert_120
+client_list_server_pref=[h2] echo=T
+client_list_partial=[http/1.1] echo=T
 noalpn_listener_client_h2=[] echo=T
 server_1=[h2]
 server_2=[http/1.1]
@@ -15,5 +22,7 @@ server_3=handshake_failed
 server_4=[]
 server_5=[h2]
 server_6=handshake_failed
+server_7=[h2]
+server_8=[http/1.1]
 server_b1=[]
-server_echoed_5=T
+server_echoed_7=T

--- a/compiler/tests/tls_alpn_server.nu
+++ b/compiler/tests/tls_alpn_server.nu
@@ -10,13 +10,18 @@
 //   * negotiate nothing for a client that sends no ALPN extension, and
 //     still serve it;
 //   * pick by SERVER preference: a Python/OpenSSL client offering
-//     ["http/1.1", "h2"] in that order gets "h2" (RFC 7301 §3.2).
+//     ["http/1.1", "h2"] in that order gets "h2" (RFC 7301 §3.2) — and
+//     so does our own client offering the list "http/1.1 h2"; a list
+//     with one unknown and one known entry ("spdy/3 http/1.1") gets the
+//     known one instead of a mismatch alert.
 // A plain tcp_listen_tls listener (no ALPN list) must keep ignoring the
 // client's offer: the client sees "" and the connection works.
 //
 // Before 2026-09-02 the pure server never parsed the extension and sent
 // an empty EncryptedExtensions, so tcp_listen_tls_with_alpn silently
-// served HTTP/1.1 to every HTTP/2-capable client.
+// served HTTP/1.1 to every HTTP/2-capable client. Until 2026-09-03 the
+// pure CLIENT could offer only a single protocol, so an HTTP client had
+// to choose h2-or-nothing before it knew what the server spoke.
 //
 // Server on an OS thread (tcp_accept blocks), client on the main thread,
 // as tls_resume.nu does.
@@ -42,6 +47,8 @@ $ `stdlib/std/time.nu`
 : ~ i srv_proto_4 -9
 : ~ i srv_proto_5 -9
 : ~ i srv_proto_6 -9
+: ~ i srv_proto_7 -9
+: ~ i srv_proto_8 -9
 : ~ i srv_proto_b1 -9
 : ~ i srv_echoed 0
 
@@ -75,6 +82,8 @@ $ `stdlib/std/time.nu`
     ? == slot 5 { = srv_proto_5 code } {}
     ? == slot 6 { = srv_proto_6 code } {}
     ? == slot 7 { = srv_proto_b1 code } {}
+    ? == slot 8 { = srv_proto_7 code } {}
+    ? == slot 9 { = srv_proto_8 code } {}
 }
 
 // Accept one connection, echo one chunk, record the negotiated ALPN.
@@ -169,6 +178,8 @@ $ `stdlib/std/time.nu`
                         ( serve_one la 4 )
                         ( serve_one la 5 )
                         ( serve_one la 6 )
+                        ( serve_one la 8 )
+                        ( serve_one la 9 )
                         ( serve_one lb 7 )
                     }
                     : !Thread ThreadErr st ( thread_spawn server )
@@ -211,6 +222,10 @@ ss.close()" 2>&1` )
                                 T po → { ( nurl_print ( output_stdout po ) ) ( output_free po ) }
                                 F e → ( label `openssl_mismatch` ( process_err_name e ) )
                             }
+                            // 7. our client, list "http/1.1 h2": server preference → h2
+                            ( client_case `client_list_server_pref` 18931 `http/1.1 h2` )
+                            // 8. list with an unknown first entry: the known one wins
+                            ( client_case `client_list_partial` 18931 `spdy/3 http/1.1` )
                             // B. listener without an ALPN list ignores the offer
                             ( client_case `noalpn_listener_client_h2` 18932 `h2` )
 
@@ -225,8 +240,10 @@ ss.close()" 2>&1` )
                             ( label `server_4` ( proto_name srv_proto_4 ) )
                             ( label `server_5` ( proto_name srv_proto_5 ) )
                             ( label `server_6` ( proto_name srv_proto_6 ) )
+                            ( label `server_7` ( proto_name srv_proto_7 ) )
+                            ( label `server_8` ( proto_name srv_proto_8 ) )
                             ( label `server_b1` ( proto_name srv_proto_b1 ) )
-                            ( label `server_echoed_5` ( yn == srv_echoed 5 ) )
+                            ( label `server_echoed_7` ( yn == srv_echoed 7 ) )
                         }
                         F _ → { ( label `thread` `FAIL` ) }
                     }
@@ -240,7 +257,21 @@ ss.close()" 2>&1` )
     }
 }
 
+// The offer matcher itself: exact entries only, never a prefix or a
+// superstring of one.
+@ offered s list s sel → s {
+    : ( Vec u ) v ( bytes_from_str sel )
+    : b r ( _alpn_offered list v )
+    ( vec_free [u] v )
+    ^ ( yn r )
+}
+
 @ main → i {
+    ( label `offered_h2_in_list` ( offered `h2 http/1.1` `h2` ) )
+    ( label `offered_http11_in_list` ( offered `h2 http/1.1` `http/1.1` ) )
+    ( label `offered_prefix_rejected` ( offered `h2 http/1.1` `h` ) )
+    ( label `offered_superstring_rejected` ( offered `h2 http/1.1` `h2c` ) )
+    ( label `offered_empty_list` ( offered `` `h2` ) )
     ( run )
     ^ 0
 }

--- a/examples/http_basic.nu
+++ b/examples/http_basic.nu
@@ -42,6 +42,7 @@ $ `stdlib/ext/http.nu`
                 HttpDns → { ( nurl_print `Dns\n` ) }
                 HttpInvalidUrl → { ( nurl_print `InvalidUrl\n` ) }
                 HttpOther → { ( nurl_print `Other\n` ) }
+                HttpTooLarge → { ( nurl_print `TooLarge\n` ) }
             }
         }
     }
@@ -74,6 +75,7 @@ $ `stdlib/ext/http.nu`
                 HttpDns → { ( nurl_print `Dns\n` ) }
                 HttpInvalidUrl → { ( nurl_print `InvalidUrl\n` ) }
                 HttpOther → { ( nurl_print `Other\n` ) }
+                HttpTooLarge → { ( nurl_print `TooLarge\n` ) }
             }
         }
     }

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -1,0 +1,109 @@
+# http-client — the unified HTTP client interface for NURL
+
+One dependency for anything that needs to **fetch** over HTTP. NURL's
+stdlib already ships a complete client stack — pure-NURL TLS 1.3 (with
+X25519MLKEM768 hybrid key exchange and ML-DSA certificate chains), an
+HTTP/1.1 keep-alive client, a multiplexed HTTP/2 client, an RFC 6265
+cookie jar, and gzip / deflate. What it *doesn't* ship is the glue every
+program re-invents: pick the protocol the server actually offers, pool
+the connection to reuse it, carry cookies, follow redirects, decode the
+body.
+
+`http-client` is that glue, as an ergonomic, dependency-importable
+facade — the mirror image of the [`http`](../http) server package.
+
+## Hello, request
+
+```nurl
+$ `deps/http-client/src/http_client.nu`
+
+@ main → i {
+    : *HttpClient c ( http_client_new )
+    ?? ( http_client_get c `https://example.org/` ) {
+        T r → {
+            ( nurl_print_int ( http_client_status r ) )
+            ( http_response_free r )
+        }
+        F e → { ( nurl_eprintln ( http_client_err_name e ) ) }
+    }
+    ( http_client_free c )
+    ^ 0
+}
+```
+
+## What one client gives you, with nothing configured
+
+| Feature | How |
+| --- | --- |
+| **Automatic protocol** | an `https` origin is dialled with ALPN `h2 http/1.1`; whichever the server picks is what the client speaks — HTTP/2 multiplexed, or HTTP/1.1 with keep-alive. Plaintext `http` is HTTP/1.1. |
+| **Post-quantum TLS** | the stdlib client offers X25519MLKEM768 first and verifies ML-DSA (44/65/87) certificate chains, so a post-quantum server is used as such automatically. `http_client_last_pq c` reports it. |
+| **Connection pooling** | one live connection per `(scheme, host, port)` — the h2 connection is multiplexed, the h1 connection is kept alive and reused. |
+| **TLS session resumption** | tickets are cached per host and offered on the next connection, so a repeat visit skips the certificate and the signature. |
+| **Redirects** | 3xx are followed (up to `max_redirects`); a 303, and a 301/302 on a POST, become a bodyless GET, exactly as browsers do. Relative `Location`s resolve per RFC 3986 §5.2. |
+| **Cookies** | a built-in RFC 6265 jar stores `Set-Cookie` and sends `Cookie` on matching requests. |
+| **Compression** | `Accept-Encoding: gzip, deflate` is offered and the body is decoded transparently, with an output cap against decompression bombs. |
+
+## Configuration
+
+```nurl
+: *HttpClient c ( http_client_new )
+( http_client_set_verify c F )          // pinned / self-signed / test servers
+( http_client_set_timeout c 5000 )      // per read/write deadline, ms (0 = none)
+( http_client_set_max_redirects c 3 )
+( http_client_set_decompress c F )       // leave bodies as the wire carried them
+( http_client_set_body_max c 1048576 )   // cap the decoded body; larger → HcTooLarge
+( http_client_set_user_agent c `myapp/1.0` )
+```
+
+## Verbs
+
+```nurl
+( http_client_get    c url )
+( http_client_head   c url )
+( http_client_delete c url )
+( http_client_post   c url body content_type )   // body is a ( Vec u ), borrowed
+( http_client_put    c url body content_type )
+( http_client_patch  c url body content_type )
+( http_client_post_str c url `{"a":1}` `application/json` )
+( http_client_request c method url headers body ) // full control; headers consumed
+```
+
+Every call returns `!HttpResponse HttpClientErr` — the same `HttpResponse`
+the `http` server package builds, with `http_client_status`,
+`http_client_header` and `http_client_body_str` helpers, freed with
+`http_response_free`.
+
+## Evidence
+
+```nurl
+( http_client_last_proto c )   // 1 HTTP/1.1, 2 HTTP/2, 0 none yet
+( http_client_last_pq c )      // T when the key exchange was post-quantum
+```
+
+## Where the line is drawn
+
+Following the same two-layer split as the `http` package: the **stdlib**
+owns the primitives a package cannot provide (the TLS client with an ALPN
+preference list and one full-knob connect, keep-alive and honoured
+timeouts in the HTTP/1.1 transport, the HTTP/2 client, the codecs); this
+package owns the **glue** (one `HttpClient`, per-origin pooling, protocol
+selection, the cookie jar wired in, redirects, decompression, a unified
+response and error type). The toolchain's own consumers (nurlpkg, hub)
+cannot depend on a package, so they benefit from the stdlib half; this
+package versions independently of the toolchain.
+
+HTTP/3 over QUIC is not yet a client role in the stdlib (the server side
+is complete); when it lands, this facade gains it behind the same
+`Alt-Svc`-driven upgrade without an API change.
+
+## Tests
+
+`./tests/client_test.sh` builds a server on the `http` package and drives
+the facade against it over both plaintext and TLS: protocol selection,
+connection reuse, redirects and the redirect cap, cookies, gzip decoding,
+POST bodies, and post-quantum key exchange. Requires `openssl` (to mint a
+test certificate) and `curl` (readiness probe).
+
+## License
+
+MIT OR Apache-2.0.

--- a/packages/http-client/examples/fetch.nu
+++ b/packages/http-client/examples/fetch.nu
@@ -1,0 +1,64 @@
+// examples/fetch.nu — a tiny curl-like fetcher on the HttpClient facade.
+//
+// One argument, a URL; prints the negotiated protocol and whether the
+// key exchange was post-quantum, then the response body. The client
+// picks HTTP/2 or HTTP/1.1 by ALPN, resumes TLS sessions, follows
+// redirects, carries cookies and decodes gzip — none of it configured.
+//
+//   nurlpkg install http-client        # then:  fetch https://example.org/
+//   # or in a checkout:
+//   ./nurl.sh packages/http-client/examples/fetch.nu /tmp/fetch
+//   /tmp/fetch https://example.org/
+
+$ `stdlib/std/args.nu`
+$ `../src/http_client.nu`
+
+@ proto_name i p → s {
+    ? == p 2 { ^ `HTTP/2` } {}
+    ? == p 1 { ^ `HTTP/1.1` } {}
+    ^ `none`
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `fetch` `fetch a URL with the HttpClient facade` )
+    ( args_flag ap `insecure` 107 `skip TLS verification` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+    : ( Vec String ) pos ( args_positionals ap )
+    ? == ( vec_len [String] pos ) 0 {
+        ( nurl_eprintln `usage: fetch [--insecure] <url>` )
+        ( args_free ap )
+        ^ 2
+    } {}
+    : String url ( __fetch_at pos 0 )
+
+    : *HttpClient c ( http_client_new )
+    ? ( args_present ap `insecure` ) { ( http_client_set_verify c F ) } {}
+
+    : ~ i rc 0
+    ?? ( http_client_get c ( string_data url ) ) {
+        T r → {
+            ( nurl_print `# ` )
+            ( nurl_print ( proto_name ( http_client_last_proto c ) ) )
+            ? ( http_client_last_pq c ) { ( nurl_print ` (post-quantum)` ) } {}
+            ( nurl_print ` — status ` )
+            ( nurl_print_int ( http_client_status r ) )
+            ( nurl_print `\n` )
+            : String body ( http_client_body_str r )
+            ( nurl_print ( string_data body ) )
+            ( nurl_print `\n` )
+            ( string_free body )
+            ( http_response_free r )
+        }
+        F e → {
+            ( nurl_eprintln ( http_client_err_name e ) )
+            = rc 1
+        }
+    }
+    ( http_client_free c )
+    ( args_free ap )
+    ^ rc
+}
+
+@ __fetch_at ( Vec String ) v i idx → String {
+    ?? ( vec_get [String] v idx ) { T s → ^ s F _ → ^ ( string_new ) }
+}

--- a/packages/http-client/nurl.toml
+++ b/packages/http-client/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "http-client"
+version = "0.1.0"
+description = "The unified HTTP client interface for NURL — one dependency for anything that needs to FETCH over HTTP. A single importable facade over the stdlib client stack (pure-NURL TLS 1.3 with post-quantum key exchange and ML-DSA certificates, the HTTP/1.1 keep-alive client, the multiplexed HTTP/2 client, cookies, gzip/deflate): an `HttpClient` that speaks whichever protocol the server offers — HTTP/2 or HTTP/1.1 by ALPN — pools connections per origin, resumes TLS sessions, follows redirects, keeps a cookie jar and decodes compressed bodies, so `( http_client_new )` and `( http_client_get c url )` are a complete client."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/http-client/src/client.nu
+++ b/packages/http-client/src/client.nu
@@ -1,0 +1,794 @@
+// http-client/client.nu — the ergonomic HttpClient facade over the
+// stdlib client stack.
+//
+// The stdlib ships a complete client toolkit — pure-NURL TLS 1.3 (with
+// X25519MLKEM768 hybrid key exchange and ML-DSA certificate chains), an
+// HTTP/1.1 keep-alive client (http_pure.nu), a multiplexed HTTP/2 client
+// (http2_client.nu), an RFC 6265 cookie jar (cookies.nu), and gzip /
+// deflate (compress.nu). What every program re-invents is the glue that
+// wires them into one thing: pick the protocol the server actually
+// offers, pool the connection to reuse it, carry cookies, follow
+// redirects, decode the body.
+//
+// `HttpClient` collapses that into one object:
+//
+//     : *HttpClient c ( http_client_new )
+//     ?? ( http_client_get c `https://example.org/` ) {
+//         T r → { ( nurl_print_int . r status ) ( http_response_free r ) }
+//         F e → { ( nurl_eprintln ( http_client_err_name e ) ) }
+//     }
+//     ( http_client_free c )
+//
+// Protocol selection is automatic and needs nothing configured: an
+// https origin is dialled with ALPN "h2 http/1.1", and whichever the
+// server picks is what the client speaks — HTTP/2 multiplexed over one
+// connection, or HTTP/1.1 with keep-alive. The negotiated protocol and
+// whether the key exchange was post-quantum are readable after each
+// request (`http_client_last_proto` / `http_client_last_pq`).
+//
+// Memory model: `http_client_new` returns a heap `*HttpClient`; free it
+// with `http_client_free`, which closes every pooled connection. A
+// returned `HttpResponse` is owned by the caller (`http_response_free`).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/tls.nu`
+$ `stdlib/std/url.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_pure.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http2_client.nu`
+$ `stdlib/ext/cookies.nu`
+$ `stdlib/ext/compress.nu`
+
+// ── Errors ────────────────────────────────────────────────────────────
+//
+// One error type for the whole client — the h1 transport, the h2
+// transport and TLS all fold into these.
+: | HttpClientErr {
+    HcConnect  // TCP / TLS connect failed
+    HcTimeout  // a read or write passed the deadline
+    HcTls  // TLS handshake or certificate verification failed
+    HcDns  // hostname did not resolve
+    HcInvalidUrl  // malformed URL or a scheme other than http/https
+    HcProtocol  // the peer broke framing (bad h2/h1 response)
+    HcTooManyRedirects  // the redirect chain passed max_redirects
+    HcTooLarge  // the response body passed the size cap
+    HcDecode  // a Content-Encoding body would not decompress
+    HcOther
+}
+
+// Case-insensitive ASCII equality of a header name against a lowercase
+// literal — the client's own copy so it needs nothing file-private from
+// http_request.nu.
+@ _hc_eq_ci s a s b → b {
+    : i la ( nurl_str_len a )
+    ? != la ( nurl_str_len b ) { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ & ok < k la {
+        : ~ i ca ( nurl_str_get a k )
+        : ~ i cb ( nurl_str_get b k )
+        ? & >= ca 65 <= ca 90 { = ca + ca 32 } {}
+        ? & >= cb 65 <= cb 90 { = cb + cb 32 } {}
+        ? != ca cb { = ok F } {}
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ http_client_err_name HttpClientErr e → s {
+    ^ ?? e {
+        HcConnect → `HcConnect`
+        HcTimeout → `HcTimeout`
+        HcTls → `HcTls`
+        HcDns → `HcDns`
+        HcInvalidUrl → `HcInvalidUrl`
+        HcProtocol → `HcProtocol`
+        HcTooManyRedirects → `HcTooManyRedirects`
+        HcTooLarge → `HcTooLarge`
+        HcDecode → `HcDecode`
+        HcOther → `HcOther`
+    }
+}
+
+// ── Pooled origin ─────────────────────────────────────────────────────
+//
+// One live connection per (scheme, host, port). `proto` records what the
+// origin negotiated: 0 nothing yet, 1 HTTP/1.1, 2 HTTP/2. For h2 the
+// pooled connection is the multiplexed H2Client; for h1 it is one idle
+// keep-alive HttpConn, present only while `has_h1` is 1.
+: HcOrigin {
+    String key  // "scheme://host:port"
+    String host
+    i port
+    i is_https
+    i proto
+    i has_h2 H2Client h2
+    i has_h1 HttpConn h1
+    i pq  // 1 = the TLS key exchange for this origin was post-quantum
+}
+
+// ── Client ────────────────────────────────────────────────────────────
+: HttpClient {
+    CookieJar jar
+    ( Vec i ) origins  // *HcOrigin boxed, so the structs have stable identity
+    i verify  // verify TLS chains (1) or not (0)
+    i follow  // follow redirects (1) or return the 3xx (0)
+    i max_redirects
+    i timeout_ms  // per read/write deadline; 0 = none
+    i decompress  // request + decode gzip/deflate (1) or leave bodies raw (0)
+    i body_max  // response body cap in bytes; 0 = unlimited
+    String ua
+    // Evidence from the most recent request.
+    i last_proto  // 1 h1, 2 h2, 0 none yet
+    i last_pq  // 1 = post-quantum key exchange
+}
+
+@ http_client_new → *HttpClient {
+    : *HttpClient c # *HttpClient ( nurl_malloc Z HttpClient )
+    = . c jar ( cookie_jar_new )
+    = . c origins ( vec_new [i] )
+    = . c verify 1
+    = . c follow 1
+    = . c max_redirects 10
+    = . c timeout_ms 30000
+    = . c decompress 1
+    = . c body_max 0
+    = . c ua ( string_from `nurl-http-client/0.1` )
+    = . c last_proto 0
+    = . c last_pq 0
+    ^ c
+}
+
+// ── Configuration (chainable-by-mutation) ─────────────────────────────
+
+// Skip TLS certificate / hostname verification. For pinned, self-signed
+// or test servers only — an unverified connection authenticates nothing.
+@ http_client_set_verify * HttpClient c b on → v { = . c verify ? on 1 0 }
+
+// Follow 3xx redirects (default) or hand the 3xx response back.
+@ http_client_set_follow * HttpClient c b on → v { = . c follow ? on 1 0 }
+
+@ http_client_set_max_redirects * HttpClient c i n → v { = . c max_redirects n }
+
+// Per read/write deadline in milliseconds (0 = none). A stalled server
+// answers HcTimeout instead of hanging.
+@ http_client_set_timeout * HttpClient c i ms → v { = . c timeout_ms ms }
+
+// Offer and decode gzip/deflate bodies (default) or leave the body as
+// the wire carried it (the caller then owns Content-Encoding).
+@ http_client_set_decompress * HttpClient c b on → v { = . c decompress ? on 1 0 }
+
+// Cap the (decoded) response body; a larger body answers HcTooLarge.
+@ http_client_set_body_max * HttpClient c i n → v { = . c body_max n }
+
+@ http_client_set_user_agent * HttpClient c s ua → v {
+    ( string_free . c ua )
+    = . c ua ( string_from ua )
+}
+
+// The protocol / key-exchange facts of the most recent request.
+@ http_client_last_proto * HttpClient c → i { ^ . c last_proto }
+
+@ http_client_last_pq * HttpClient c → b { ^ != . c last_pq 0 }
+
+// Direct access to the cookie jar (seed a session cookie, inspect, …).
+@ http_client_jar * HttpClient c → CookieJar { ^ . c jar }
+
+// ── Origin pool ───────────────────────────────────────────────────────
+
+@ __hc_origin_key s scheme s host i port → String {
+    : String k ( string_from scheme )
+    ( string_push_str k `://` )
+    ( string_push_str k host )
+    ( string_push_str k `:` )
+    ( string_push_int k port )
+    ^ k
+}
+
+// Find the pooled origin for `key`, or 0.
+@ __hc_find_origin * HttpClient c s key → i {
+    : i n ( vec_len [i] . c origins )
+    : ~ i k 0
+    : ~ i found 0
+    ~ & == found 0 < k n {
+        ?? ( vec_get [i] . c origins k ) {
+            T p → {
+                : *HcOrigin o # *HcOrigin p
+                ? ( nurl_str_eq ( string_data . o key ) key ) { = found p } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ found
+}
+
+// Get or create the origin record for scheme://host:port (no connection
+// opened yet).
+@ __hc_origin * HttpClient c s scheme s host i port → *HcOrigin {
+    : String key ( __hc_origin_key scheme host port )
+    : i ex ( __hc_find_origin c ( string_data key ) )
+    ? != ex 0 { ( string_free key ) ^ # *HcOrigin ex } {}
+    : *HcOrigin o # *HcOrigin ( nurl_malloc Z HcOrigin )
+    = . o key key
+    = . o host ( string_from host )
+    = . o port port
+    = . o is_https ( nurl_str_eq scheme `https` )
+    = . o proto 0
+    = . o has_h2 0
+    = . o has_h1 0
+    = . o pq 0
+    ( vec_push [i] . c origins # i o )
+    ^ o
+}
+
+// Close whatever connection an origin holds (called on error / teardown).
+@ __hc_origin_drop_conn * HcOrigin o → v {
+    ? != . o has_h2 0 {
+        ( h2_client_disconnect . o h2 )
+        = . o has_h2 0
+    } {}
+    ? != . o has_h1 0 {
+        ( hp_conn_close . o h1 )
+        = . o has_h1 0
+    } {}
+    = . o proto 0
+}
+
+// ── Establishing a connection for an origin ───────────────────────────
+
+// Ensure the origin has a usable connection, negotiating the protocol on
+// first contact. Returns 0 on success, else an HttpClientErr-shaped code
+// (mapped by __hc_conn_err). An https origin is dialled with ALPN
+// "h2 http/1.1" and offered its cached TLS session; the negotiated ALPN
+// decides h2 vs h1. Plaintext http is HTTP/1.1 only.
+@ __hc_ensure_conn * HttpClient c * HcOrigin o → i {
+    ? | != . o has_h2 0 != . o has_h1 0 { ^ 0 } {}
+    ? != . o is_https 0 {
+        : ( Vec u ) sess ( hp_session_lookup ( string_data . o host ) . o port )
+        : !*TlsConn TlsErr tr ( tls_connect_full ( string_data . o host ) . o port ( string_data . o host ) `h2 http/1.1` sess . c verify )
+        ( vec_free [u] sess )
+        ?? tr {
+            F e → { ^ ?? e { TlsBadCert → 3 TlsConnect → 1 _ → 3 } }
+            T tc → {
+                = . o pq ? ( tls_is_post_quantum tc ) 1 0
+                : b is_h2 ( tls_alpn_is tc `h2` )
+                ? is_h2 {
+                    : TcpConn conn ( tcp_conn_from_tls tc )
+                    : !H2Client H2ClientErr hr ( h2_client_attach conn )
+                    ?? hr {
+                        F _ → { ( tcp_close_conn conn ) ^ 6 }
+                        T cl → {
+                            = . o has_h2 1
+                            = . o h2 cl
+                            = . o proto 2
+                            ^ 0
+                        }
+                    }
+                } {
+                    = . o h1 ( hp_conn_from_tls tc ( string_data . o host ) . o port )
+                    ? > . c timeout_ms 0 { ( hp_conn_set_timeout . o h1 . c timeout_ms ) } {}
+                    = . o has_h1 1
+                    = . o proto 1
+                    ^ 0
+                }
+            }
+        }
+    } {}
+    // Plaintext HTTP/1.1.
+    : !HttpConn i co ( hp_conn_open 0 ( string_data . o host ) . o port ( string_data . o host ) 0 )
+    ?? co {
+        F e → { ^ ? == e 1 1 6 }
+        T conn → {
+            = . o h1 conn
+            ? > . c timeout_ms 0 { ( hp_conn_set_timeout . o h1 . c timeout_ms ) } {}
+            = . o has_h1 1
+            = . o proto 1
+            ^ 0
+        }
+    }
+}
+
+@ __hc_conn_err i code → HttpClientErr {
+    ? == code 1 { ^ # HttpClientErr HcConnect } {}
+    ? == code 2 { ^ # HttpClientErr HcTimeout } {}
+    ? == code 3 { ^ # HttpClientErr HcTls } {}
+    ? == code 7 { ^ # HttpClientErr HcTooLarge } {}
+    ^ # HttpClientErr HcOther
+}
+
+// ── Header assembly ───────────────────────────────────────────────────
+
+// Build the request header blob for the h1 transport: the caller's
+// headers, then a Cookie line (from the jar) and Accept-Encoding when
+// decompression is on and the caller did not set them.
+@ __hc_h1_headers * HttpClient c s host s path i is_https ( Vec Header ) user → String {
+    : String blob ( string_new )
+    : i n ( vec_len [Header] user )
+    : *Header d ( vec_data [Header] user )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . d k
+        ( string_push_str blob ( string_data . h name ) )
+        ( string_push_str blob `: ` )
+        ( string_push_str blob ( string_data . h value ) )
+        ( string_push_str blob `\r\n` )
+        = k + k 1
+    }
+    ? ! ( __hc_user_has user `cookie` ) {
+        : String ck ( cookie_jar_header . c jar host path ? != is_https 0 T F ( now_seconds ) )
+        ? > ( string_len ck ) 0 {
+            ( string_push_str blob `Cookie: ` )
+            ( string_push_str blob ( string_data ck ) )
+            ( string_push_str blob `\r\n` )
+        } {}
+        ( string_free ck )
+    } {}
+    ? & != . c decompress 0 ! ( __hc_user_has user `accept-encoding` ) {
+        ( string_push_str blob `Accept-Encoding: gzip, deflate\r\n` )
+    } {}
+    ^ blob
+}
+
+@ __hc_user_has ( Vec Header ) user s lname → b {
+    : i n ( vec_len [Header] user )
+    : *Header d ( vec_data [Header] user )
+    : ~ i k 0
+    : ~ b hit F
+    ~ & ! hit < k n {
+        : Header h . d k
+        ? ( _hc_eq_ci ( string_data . h name ) lname ) { = hit T } {}
+        = k + k 1
+    }
+    ^ hit
+}
+
+// ── One request over an origin (no redirects, no cookie storage) ──────
+//
+// Returns the unified HttpResponse or an HttpClientErr. `user` headers
+// are BORROWED-consumed (freed here). `body` is BORROWED.
+@ __hc_do * HttpClient c * HcOrigin o s method s path ( Vec Header ) user ( Vec u ) body → !HttpResponse HttpClientErr {
+    : i ce ( __hc_ensure_conn c o )
+    ? != ce 0 {
+        ( __hc_free_headers user )
+        ^ @ !HttpResponse HttpClientErr { F ( __hc_conn_err ce ) }
+    } {}
+    = . c last_proto . o proto
+    = . c last_pq . o pq
+    ? == . o proto 2 {
+        ^ ( __hc_do_h2 c o method path user body )
+    } {}
+    ^ ( __hc_do_h1 c o method path user body )
+}
+
+@ __hc_free_headers ( Vec Header ) user → v {
+    ( vec_free_with [Header] user \ Header h → v { ( header_free h ) } )
+}
+
+// HTTP/1.1 over the pooled keep-alive connection.
+@ __hc_do_h1 * HttpClient c * HcOrigin o s method s path ( Vec Header ) user ( Vec u ) body → !HttpResponse HttpClientErr {
+    : String blob ( __hc_h1_headers c ( string_data . o host ) path . o is_https user )
+    ( __hc_free_headers user )
+    // Detach the pooled conn; hp_stream_release re-pools it if reusable.
+    : HttpConn conn . o h1
+    = . o has_h1 0
+    : *HttpStreamState st ( hp_stream_open_on conn method ( string_data . o host ) . o port . o is_https path ( vec_data [u] body ) ( vec_len [u] body ) ( string_data blob ) ( string_data . c ua ) )
+    ( string_free blob )
+    ? > . c body_max 0 { ( hp_stream_set_body_max st . c body_max ) } {}
+    ~ == ( hp_stream_finished st ) 0 { ( hp_stream_pump st ) }
+    : i ek ( hp_stream_err_kind st )
+    ? != ek 0 {
+        ( hp_stream_close st )
+        = . o proto 0
+        ^ @ !HttpResponse HttpClientErr { F ( __hc_stream_err ek ) }
+    } {}
+    : HttpResponse r ( __hc_response_from_stream c st )
+    // Re-pool the connection when the response left it reusable.
+    ?? ( hp_stream_release st ) {
+        T back → { = . o h1 back = . o has_h1 1 }
+        F _ → { = . o proto 0 }
+    }
+    ^ @ !HttpResponse HttpClientErr { T r }
+}
+
+@ __hc_stream_err i ek → HttpClientErr {
+    ? == ek 1 { ^ # HttpClientErr HcConnect } {}
+    ? == ek 2 { ^ # HttpClientErr HcTimeout } {}
+    ? == ek 3 { ^ # HttpClientErr HcTls } {}
+    ? == ek 7 { ^ # HttpClientErr HcTooLarge } {}
+    ^ # HttpClientErr HcProtocol
+}
+
+// Assemble an HttpResponse (status, headers, body) from a finished h1
+// stream, decoding the body if it is compressed and decompression is on.
+@ __hc_response_from_stream * HttpClient c * HttpStreamState st → HttpResponse {
+    : HttpResponse r ( response_new ( hp_stream_status st ) )
+    : i hc ( hp_stream_header_count st )
+    : ~ i k 0
+    ~ < k hc {
+        ( response_add_header r ( hp_stream_header_name st k ) ( hp_stream_header_value st k ) )
+        = k + k 1
+    }
+    : ( Vec u ) raw ( hp_stream_body_take st )
+    ( __hc_apply_body c r raw )
+    ^ r
+}
+
+// ── HTTP/2 over the pooled multiplexed connection ─────────────────────
+@ __hc_do_h2 * HttpClient c * HcOrigin o s method s path ( Vec Header ) user ( Vec u ) body → !HttpResponse HttpClientErr {
+    // Pseudo-headers are added by h2_client_submit; we pass the regular
+    // header list, adding Cookie / Accept-Encoding like the h1 path.
+    : ( Vec Header ) hs ( vec_new [Header] )
+    : i n ( vec_len [Header] user )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [Header] user k ) { T h → ( vec_push [Header] hs h ) F _ → {} }
+        = k + k 1
+    }
+    ( vec_free [Header] user )
+    ? ! ( __hc_hlist_has hs `cookie` ) {
+        : String ck ( cookie_jar_header . c jar ( string_data . o host ) path ? != . o is_https 0 T F ( now_seconds ) )
+        ? > ( string_len ck ) 0 { ( vec_push [Header] hs ( header_new `cookie` ( string_data ck ) ) ) } {}
+        ( string_free ck )
+    } {}
+    ? & != . c decompress 0 ! ( __hc_hlist_has hs `accept-encoding` ) {
+        ( vec_push [Header] hs ( header_new `accept-encoding` `gzip, deflate` ) )
+    } {}
+    : ( Vec u ) bcopy ( vec_new [u] )
+    ( bytes_extend_bytes bcopy body )
+    : s scheme ? != . o is_https 0 `https` `http`
+    : !i H2ClientErr sr ( h2_client_submit . o h2 method scheme ( string_data . o host ) path hs bcopy )
+    ( __hc_free_headers hs )
+    ?? sr {
+        F _ → { ( __hc_origin_drop_conn o ) ^ @ !HttpResponse HttpClientErr { F # HttpClientErr HcProtocol } }
+        T sid → {
+            : !v H2ClientErr rr ( h2_client_run_until_complete . o h2 )
+            ?? rr {
+                F e → { ( __hc_origin_drop_conn o ) ^ @ !HttpResponse HttpClientErr { F ( __hc_h2_err e ) } }
+                T _ → {
+                    : !HttpResponse H2ClientErr tr ( h2_client_take_response . o h2 sid )
+                    ?? tr {
+                        F e → { ^ @ !HttpResponse HttpClientErr { F ( __hc_h2_err e ) } }
+                        T resp → {
+                            : HttpResponse dec ( __hc_decode_response c resp )
+                            ^ @ !HttpResponse HttpClientErr { T dec }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@ __hc_h2_err H2ClientErr e → HttpClientErr {
+    ^ ?? e {
+        H2CConnect → # HttpClientErr HcConnect
+        H2CTls → # HttpClientErr HcTls
+        H2CAlpn → # HttpClientErr HcTls
+        _ → # HttpClientErr HcProtocol
+    }
+}
+
+@ __hc_hlist_has ( Vec Header ) hs s lname → b {
+    : i n ( vec_len [Header] hs )
+    : *Header d ( vec_data [Header] hs )
+    : ~ i k 0
+    : ~ b hit F
+    ~ & ! hit < k n {
+        : Header h . d k
+        ? ( _hc_eq_ci ( string_data . h name ) lname ) { = hit T } {}
+        = k + k 1
+    }
+    ^ hit
+}
+
+// Decompress an already-assembled HttpResponse's body in place (h2 path),
+// returning a possibly-new HttpResponse.
+@ __hc_decode_response * HttpClient c HttpResponse r → HttpResponse {
+    ? == . c decompress 0 { ^ r } {}
+    : String enc ( __hc_header_value . r headers `content-encoding` )
+    : s ed ( string_data enc )
+    ? | ( nurl_str_eq ed `gzip` ) ( nurl_str_eq ed `deflate` ) {
+        : !( Vec u ) CompressErr dr ( gzip_decompress_max . r body ? > . c body_max 0 . c body_max 0 )
+        ?? dr {
+            T out → {
+                ( vec_free [u] . r body )
+                = . r body out
+                ( __hc_strip_encoding r )
+            }
+            F _ → {}
+        }
+    } {}
+    ( string_free enc )
+    ^ r
+}
+
+// Decode a body Vec for the h1 path (response already built).
+@ __hc_apply_body * HttpClient c HttpResponse r ( Vec u ) raw → v {
+    ? == . c decompress 0 { ( response_set_body_bytes r raw ) ( vec_free [u] raw ) ^ v } {}
+    : String enc ( __hc_header_value . r headers `content-encoding` )
+    : s ed ( string_data enc )
+    ? | ( nurl_str_eq ed `gzip` ) ( nurl_str_eq ed `deflate` ) {
+        : !( Vec u ) CompressErr dr ( gzip_decompress_max raw ? > . c body_max 0 . c body_max 0 )
+        ?? dr {
+            T out → {
+                ( response_set_body_bytes r out )
+                ( vec_free [u] out )
+                ( vec_free [u] raw )
+                ( __hc_strip_encoding r )
+                ( string_free enc )
+                ^ v
+            }
+            F _ → {}
+        }
+    } {}
+    ( string_free enc )
+    ( response_set_body_bytes r raw )
+    ( vec_free [u] raw )
+}
+
+// Drop the Content-Encoding header once we have decoded the body, so the
+// caller does not double-decode.
+@ __hc_strip_encoding HttpResponse r → v {
+    : i n ( vec_len [Header] . r headers )
+    : *Header d ( vec_data [Header] . r headers )
+    : ~ i idx -1
+    : ~ i k 0
+    ~ & == idx -1 < k n {
+        : Header h . d k
+        ? ( _hc_eq_ci ( string_data . h name ) `content-encoding` ) { = idx k } {}
+        = k + k 1
+    }
+    ? >= idx 0 {
+        ?? ( vec_remove [Header] . r headers idx ) { T x → ( header_free x ) F _ → {} }
+    } {}
+}
+
+@ __hc_header_value ( Vec Header ) hs s lname → String {
+    : i n ( vec_len [Header] hs )
+    : *Header d ( vec_data [Header] hs )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . d k
+        ? ( _hc_eq_ci ( string_data . h name ) lname ) { ^ ( string_from ( string_data . h value ) ) } {}
+        = k + k 1
+    }
+    ^ ( string_new )
+}
+
+// ── Cookie capture ────────────────────────────────────────────────────
+
+// Store every Set-Cookie of a response into the jar.
+@ __hc_capture_cookies * HttpClient c HttpResponse r s host s path → v {
+    : i n ( vec_len [Header] . r headers )
+    : *Header d ( vec_data [Header] . r headers )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . d k
+        ? ( _hc_eq_ci ( string_data . h name ) `set-cookie` ) {
+            : b _s ( cookie_jar_set . c jar ( string_data . h value ) host path ( now_seconds ) )
+        } {}
+        = k + k 1
+    }
+}
+
+// ── The public request path (redirects + cookies) ─────────────────────
+
+@ __hc_is_redirect i sc → b {
+    ? | | == sc 301 == sc 302 == sc 303 { ^ T } {}
+    ^ | == sc 307 == sc 308
+}
+
+// The one entry point: send `method` to `url` with `body` and the caller's
+// `headers`, following redirects and carrying cookies. `headers` is
+// consumed (freed); `body` is borrowed.
+@ http_client_request * HttpClient c s method s url ( Vec Header ) headers ( Vec u ) body → !HttpResponse HttpClientErr {
+    : ~ String cur_url ( string_from url )
+    : ~ String cur_method ( string_from method )
+    : ~ i redirects 0
+    : ~ ( Vec Header ) hdrs headers
+    : ~ i result_kind 0  // 0 pending, 1 ok, 2 err
+    : ~ i err_code 0
+    : ~ HttpResponse out ( response_new 0 )
+    : ~ b looping T
+
+    ~ looping {
+        : ?Url maybe ( url_parse ( string_data cur_url ) )
+        ?? maybe {
+            F _ → {
+                = result_kind 2
+                = err_code 5
+                = looping F
+            }
+            T u → {
+                : s scheme ( string_data . u scheme )
+                ? & == 0 ( nurl_str_eq scheme `http` ) == 0 ( nurl_str_eq scheme `https` ) {
+                    ( url_free u )
+                    = result_kind 2
+                    = err_code 5
+                    = looping F
+                } {
+                    : i port ( url_port_or_default u )
+                    : String tgt ( url_request_target u )
+                    : *HcOrigin o ( __hc_origin c scheme ( string_data . u host ) port )
+                    // Copy the header list per attempt (each __hc_do consumes it).
+                    : ( Vec Header ) attempt ( __hc_clone_headers hdrs )
+                    : !HttpResponse HttpClientErr rr ( __hc_do c o ( string_data cur_method ) ( string_data tgt ) attempt body )
+                    ?? rr {
+                        F e → {
+                            = result_kind 2
+                            = err_code ( __hc_err_code e )
+                            = looping F
+                        }
+                        T resp → {
+                            ( __hc_capture_cookies c resp ( string_data . u host ) ( string_data tgt ) )
+                            : i sc . resp status
+                            : String loc ( __hc_header_value . resp headers `location` )
+                            : b redir & & != . c follow 0 ( __hc_is_redirect sc ) > ( string_len loc ) 0
+                            : b can < redirects . c max_redirects
+                            ? & redir can {
+                                : ?String nu ( _hp_resolve_redirect u ( string_data loc ) )
+                                ?? nu {
+                                    F _ → { ( http_response_free out ) = result_kind 1 = out resp = looping F }
+                                    T nus → {
+                                        ( http_response_free resp )
+                                        ( string_free cur_url )
+                                        = cur_url nus
+                                        = redirects + redirects 1
+                                        // 303, and 301/302 on a POST, become a bodyless GET.
+                                        : b to_get | == sc 303 & | == sc 301 == sc 302 != 0 ( nurl_str_eq ( string_data cur_method ) `POST` )
+                                        ? & to_get == 0 ( nurl_str_eq ( string_data cur_method ) `HEAD` ) {
+                                            ( string_free cur_method )
+                                            = cur_method ( string_from `GET` )
+                                        } {}
+                                    }
+                                }
+                            } {
+                                ? & redir ! can {
+                                    ( http_response_free resp )
+                                    = result_kind 2
+                                    = err_code 100  // too many redirects
+                                } {
+                                    ( http_response_free out )
+                                    = result_kind 1
+                                    = out resp
+                                }
+                                = looping F
+                            }
+                            ( string_free loc )
+                        }
+                    }
+                    ( string_free tgt )
+                    ( url_free u )
+                }
+            }
+        }
+    }
+    ( __hc_free_headers hdrs )
+    ( string_free cur_url )
+    ( string_free cur_method )
+    ? == result_kind 1 {
+        ^ @ !HttpResponse HttpClientErr { T out }
+    } {
+        ( http_response_free out )
+        ^ @ !HttpResponse HttpClientErr { F ? == err_code 100 # HttpClientErr HcTooManyRedirects ( __hc_conn_err err_code ) }
+    }
+}
+
+@ __hc_err_code HttpClientErr e → i {
+    ^ ?? e {
+        HcConnect → 1
+        HcTimeout → 2
+        HcTls → 3
+        HcDns → 4
+        HcInvalidUrl → 5
+        HcTooLarge → 7
+        _ → 6
+    }
+}
+
+@ __hc_clone_headers ( Vec Header ) hs → ( Vec Header ) {
+    : ( Vec Header ) out ( vec_new [Header] )
+    : i n ( vec_len [Header] hs )
+    : *Header d ( vec_data [Header] hs )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . d k
+        ( vec_push [Header] out ( header_new ( string_data . h name ) ( string_data . h value ) ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// ── Convenience verbs ─────────────────────────────────────────────────
+
+@ http_client_get * HttpClient c s url → !HttpResponse HttpClientErr {
+    ^ ( __hc_bodyless c `GET` url )
+}
+
+@ http_client_head * HttpClient c s url → !HttpResponse HttpClientErr {
+    ^ ( __hc_bodyless c `HEAD` url )
+}
+
+@ http_client_delete * HttpClient c s url → !HttpResponse HttpClientErr {
+    ^ ( __hc_bodyless c `DELETE` url )
+}
+
+// A verb with no request body — the empty body Vec is ours, so free it
+// once request has borrowed it.
+@ __hc_bodyless * HttpClient c s method s url → !HttpResponse HttpClientErr {
+    : ( Vec u ) empty ( vec_new [u] )
+    : !HttpResponse HttpClientErr r ( http_client_request c method url ( vec_new [Header] ) empty )
+    ( vec_free [u] empty )
+    ^ r
+}
+
+// POST/PUT/PATCH with a body and a Content-Type. `body` is borrowed.
+@ http_client_post * HttpClient c s url ( Vec u ) body s content_type → !HttpResponse HttpClientErr {
+    ^ ( __hc_body_verb c `POST` url body content_type )
+}
+
+@ http_client_put * HttpClient c s url ( Vec u ) body s content_type → !HttpResponse HttpClientErr {
+    ^ ( __hc_body_verb c `PUT` url body content_type )
+}
+
+@ http_client_patch * HttpClient c s url ( Vec u ) body s content_type → !HttpResponse HttpClientErr {
+    ^ ( __hc_body_verb c `PATCH` url body content_type )
+}
+
+@ __hc_body_verb * HttpClient c s method s url ( Vec u ) body s content_type → !HttpResponse HttpClientErr {
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ? > ( nurl_str_len content_type ) 0 { ( vec_push [Header] hs ( header_new `content-type` content_type ) ) } {}
+    ^ ( http_client_request c method url hs body )
+}
+
+// Post a string body (text / JSON).
+@ http_client_post_str * HttpClient c s url s body s content_type → !HttpResponse HttpClientErr {
+    : ( Vec u ) b ( bytes_from_str body )
+    : !HttpResponse HttpClientErr r ( http_client_post c url b content_type )
+    ( vec_free [u] b )
+    ^ r
+}
+
+// ── Response helpers (over the unified HttpResponse) ──────────────────
+
+@ http_client_status HttpResponse r → i { ^ . r status }
+
+// The response body as a borrowed String view (valid until free).
+@ http_client_body_str HttpResponse r → String {
+    ^ ( string_from_bytes ( vec_data [u] . r body ) ( vec_len [u] . r body ) )
+}
+
+@ http_client_header HttpResponse r s name → String {
+    ^ ( __hc_header_value . r headers name )
+}
+
+// ── Teardown ──────────────────────────────────────────────────────────
+
+@ http_client_free * HttpClient c → v {
+    : i n ( vec_len [i] . c origins )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [i] . c origins k ) {
+            T p → {
+                : *HcOrigin o # *HcOrigin p
+                ( __hc_origin_drop_conn o )
+                ( string_free . o key )
+                ( string_free . o host )
+                ( nurl_free # s o )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [i] . c origins )
+    ( cookie_jar_free . c jar )
+    ( string_free . c ua )
+    ( nurl_free # s c )
+}

--- a/packages/http-client/src/http_client.nu
+++ b/packages/http-client/src/http_client.nu
@@ -1,0 +1,32 @@
+// http-client — the unified HTTP client interface library for NURL.
+//
+// One include gives a consumer:
+//
+//   * the stdlib client surface — pure-NURL TLS 1.3 (X25519MLKEM768
+//     hybrid key exchange, ML-DSA and classical certificate chains),
+//     the HTTP/1.1 client, the HTTP/2 client, the RFC 6265 cookie jar,
+//     gzip / deflate — and
+//   * the `HttpClient` facade (client.nu) that wires them into one
+//     object which speaks whatever the server offers.
+//
+// Usage from a dependent package:
+//
+//     $ `deps/http-client/src/http_client.nu`
+//
+//     @ main → i {
+//         : *HttpClient c ( http_client_new )
+//         ?? ( http_client_get c `https://example.org/` ) {
+//             T r → {
+//                 ( nurl_print_int . r status )
+//                 ( http_response_free r )
+//             }
+//             F e → { ( nurl_eprintln ( http_client_err_name e ) ) }
+//         }
+//         ( http_client_free c )
+//         ^ 0
+//     }
+//
+// The intent mirrors the `http` package on the server side: this is THE
+// dependency anything needing an HTTP client reaches for.
+
+$ `client.nu`

--- a/packages/http-client/tests/client.nu
+++ b/packages/http-client/tests/client.nu
@@ -1,0 +1,144 @@
+// tests/client.nu — drive the HttpClient facade against the test server
+// (tests/server.nu) and print one PASS/FAIL line per behaviour. The shell
+// harness (client_test.sh) starts the server on a plaintext and a TLS
+// port and passes both here; this program does every assertion itself.
+//
+//   client --http-port N --https-port N
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/bytes.nu`
+$ `../src/http_client.nu`
+
+: ~ i pass 0
+: ~ i fail 0
+
+@ ok s name → v { ( nurl_print `  PASS ` ) ( nurl_println name ) = pass + pass 1 }
+
+@ bad s name s detail → v {
+    ( nurl_print `  FAIL ` ) ( nurl_print name ) ( nurl_print ` — ` ) ( nurl_println detail )
+    = fail + fail 1
+}
+
+@ base s scheme i port s path → String {
+    : String u ( string_from scheme )
+    ( string_push_str u `://127.0.0.1:` )
+    ( string_push_int u port )
+    ( string_push_str u path )
+    ^ u
+}
+
+// GET `path`, assert status and that the body contains `want` (or "" to
+// skip the body check). `proto_want` 0 = any, else 1 h1 / 2 h2.
+@ check_get * HttpClient c s name s scheme i port s path i status_want s want i proto_want → v {
+    : String url ( base scheme port path )
+    ?? ( http_client_get c ( string_data url ) ) {
+        T r → {
+            : String body ( http_client_body_str r )
+            : b st == . r status status_want
+            : b bm | == ( nurl_str_len want ) 0 >= ( nurl_str_find ( string_data body ) want ) 0
+            : b pm | == proto_want 0 == ( http_client_last_proto c ) proto_want
+            ? & & st bm pm { ( ok name ) } {
+                : String d ( string_new )
+                ( string_push_str d `status=` ) ( string_push_int d . r status )
+                ( string_push_str d ` proto=` ) ( string_push_int d ( http_client_last_proto c ) )
+                ( string_push_str d ` body=[` ) ( string_push_str d ( string_data body ) ) ( string_push_str d `]` )
+                ( bad name ( string_data d ) )
+                ( string_free d )
+            }
+            ( string_free body )
+            ( http_response_free r )
+        }
+        F e → { ( bad name ( http_client_err_name e ) ) }
+    }
+    ( string_free url )
+}
+
+@ run i http_port i https_port → v {
+    : *HttpClient c ( http_client_new )
+    ( http_client_set_verify c F )  // self-signed test cert
+
+    // ── plaintext HTTP/1.1 ──
+    ( check_get c `h1_root` `http` http_port `/` 200 `root` 1 )
+    ( check_get c `h1_reuse` `http` http_port `/dest` 200 `arrived` 1 )  // second req, pooled conn
+
+    // ── User-Agent default ──
+    : String uurl ( base `http` http_port `/ua` )
+    ?? ( http_client_get c ( string_data uurl ) ) {
+        T r → {
+            : String b ( http_client_body_str r )
+            ? >= ( nurl_str_find ( string_data b ) `nurl-http-client` ) 0 { ( ok `default_user_agent` ) } { ( bad `default_user_agent` ( string_data b ) ) }
+            ( string_free b ) ( http_response_free r )
+        }
+        F e → { ( bad `default_user_agent` ( http_client_err_name e ) ) }
+    }
+    ( string_free uurl )
+
+    // ── redirect chain (302 → 302 → 200) ──
+    ( check_get c `redirect_chain` `http` http_port `/redir1` 200 `arrived` 0 )
+    // relative redirect from a subpath merges against the base directory
+    ( check_get c `relative_redirect` `http` http_port `/a/b/deep` 200 `sibling` 0 )
+
+    // ── redirect cap ──
+    ( http_client_set_max_redirects c 0 )
+    : String rurl ( base `http` http_port `/redir1` )
+    ?? ( http_client_get c ( string_data rurl ) ) {
+        T r → { ( bad `redirect_cap` `expected error` ) ( http_response_free r ) }
+        F e → { ?? e { HcTooManyRedirects → { ( ok `redirect_cap` ) } _ → { ( bad `redirect_cap` ( http_client_err_name e ) ) } } }
+    }
+    ( string_free rurl )
+    ( http_client_set_max_redirects c 10 )
+
+    // ── cookies: set on one request, sent on the next ──
+    : String surl ( base `http` http_port `/setcookie` )
+    ?? ( http_client_get c ( string_data surl ) ) { T r → ( http_response_free r ) F _ → {} }
+    ( string_free surl )
+    ( check_get c `cookie_roundtrip` `http` http_port `/readcookie` 200 `sid=abc123` 0 )
+
+    // ── gzip body decoded transparently ──
+    ( check_get c `gzip_decode` `http` http_port `/gzip` 200 `lazy dog` 0 )
+
+    // ── POST body echo (h1) ──
+    : String eurl ( base `http` http_port `/echo` )
+    : ( Vec u ) body ( bytes_from_str `hello-post` )
+    ?? ( http_client_post c ( string_data eurl ) body `text/plain` ) {
+        T r → {
+            : String b ( http_client_body_str r )
+            ? ( nurl_str_eq ( string_data b ) `hello-post` ) { ( ok `post_echo` ) } { ( bad `post_echo` ( string_data b ) ) }
+            ( string_free b ) ( http_response_free r )
+        }
+        F e → { ( bad `post_echo` ( http_client_err_name e ) ) }
+    }
+    ( vec_free [u] body )
+    ( string_free eurl )
+
+    // ── TLS: ALPN picks HTTP/2, PQ key exchange, then h2 features ──
+    ? > https_port 0 {
+        ( check_get c `h2_root` `https` https_port `/` 200 `root` 2 )
+        ? ( http_client_last_pq c ) { ( ok `h2_post_quantum` ) } { ( bad `h2_post_quantum` `classical kx` ) }
+        ( check_get c `h2_reuse` `https` https_port `/dest` 200 `arrived` 2 )  // multiplexed reuse
+        ( check_get c `h2_gzip` `https` https_port `/gzip` 200 `lazy dog` 2 )
+        // cookies over h2
+        : String s2 ( base `https` https_port `/setcookie` )
+        ?? ( http_client_get c ( string_data s2 ) ) { T r → ( http_response_free r ) F _ → {} }
+        ( string_free s2 )
+        ( check_get c `h2_cookie` `https` https_port `/readcookie` 200 `sid=abc123` 2 )
+    } {}
+
+    ( http_client_free c )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `client` `http-client facade test` )
+    ( args_opt ap `http-port` 104 `N` `plaintext port` )
+    ( args_opt ap `https-port` 115 `N` `TLS port` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+    : ~ i hp 0
+    : ~ i sp 0
+    ?? ( args_value ap `http-port` ) { T v → { ?? ( string_to_int v ) { T x → = hp x F _ → {} } ( string_free v ) } F _ → {} }
+    ?? ( args_value ap `https-port` ) { T v → { ?? ( string_to_int v ) { T x → = sp x F _ → {} } ( string_free v ) } F _ → {} }
+    ( args_free ap )
+    ( run hp sp )
+    ( nurl_print `== client tests: PASS=` ) ( nurl_print_int pass )
+    ( nurl_print ` FAIL=` ) ( nurl_print_int fail ) ( nurl_print `\n` )
+    ^ ? == fail 0 0 1
+}

--- a/packages/http-client/tests/client_test.sh
+++ b/packages/http-client/tests/client_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/client_test.sh — build the HttpClient facade + a test
+#  server (on the `http` package) and drive the client against it
+#  over both plaintext (HTTP/1.1) and TLS (ALPN → HTTP/2): protocol
+#  selection, connection reuse, redirects, the redirect cap, cookies,
+#  gzip decoding, POST bodies, and post-quantum key exchange.
+#
+#  Run from the package dir:  ./tests/client_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t http-client-test.XXXXXX)"
+SRV_PLAIN=""; SRV_TLS=""
+cleanup() {
+    [ -n "$SRV_PLAIN" ] && kill "$SRV_PLAIN" 2>/dev/null
+    [ -n "$SRV_TLS" ] && kill "$SRV_TLS" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "[1/4] build tests/server.nu"
+if ! $NURL tests/server.nu "$WORK/server" >/dev/null 2>"$WORK/server.err"; then
+    echo "FAIL: could not build server:"; tail -12 "$WORK/server.err"; exit 1
+fi
+
+echo "[2/4] build tests/client.nu"
+if ! $NURL tests/client.nu "$WORK/client" >/dev/null 2>"$WORK/client.err"; then
+    echo "FAIL: could not build client:"; tail -12 "$WORK/client.err"; exit 1
+fi
+
+echo "[3/4] mint a self-signed cert + start servers"
+# Self-signed P-256 leaf for 127.0.0.1 via openssl (test-only).
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    -keyout "$WORK/key.pem" -out "$WORK/cert.pem" -days 1 -nodes \
+    -subj "/CN=127.0.0.1" >/dev/null 2>&1 || { echo "FAIL: openssl cert mint"; exit 1; }
+
+HTTP_PORT=$((21000 + RANDOM % 10000))
+HTTPS_PORT=$((HTTP_PORT + 1))
+"$WORK/server" --port "$HTTP_PORT" 2>"$WORK/srv-plain.err" &
+SRV_PLAIN=$!
+"$WORK/server" --port "$HTTPS_PORT" --tls --cert "$WORK/cert.pem" --key "$WORK/key.pem" 2>"$WORK/srv-tls.err" &
+SRV_TLS=$!
+
+# Wait for both to answer.
+for _ in $(seq 1 50); do
+    curl -s -o /dev/null "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null && break
+    sleep 0.1
+done
+for _ in $(seq 1 50); do
+    curl -sk -o /dev/null "https://127.0.0.1:$HTTPS_PORT/" 2>/dev/null && break
+    sleep 0.1
+done
+
+echo "[4/4] drive the facade"
+"$WORK/client" --http-port "$HTTP_PORT" --https-port "$HTTPS_PORT"
+RC=$?
+
+if [ "$RC" != 0 ]; then
+    echo "--- server (plaintext) stderr ---"; tail -8 "$WORK/srv-plain.err"
+    echo "--- server (TLS) stderr ---"; tail -8 "$WORK/srv-tls.err"
+fi
+exit $RC

--- a/packages/http-client/tests/server.nu
+++ b/packages/http-client/tests/server.nu
@@ -1,0 +1,149 @@
+// tests/server.nu — a small server built on the `http` package that the
+// client test drives. Same binary serves plaintext (HTTP/1.1) and, with
+// --tls, TLS (HTTP/2 or HTTP/1.1 by ALPN). Routes exercise every facade
+// feature: protocol echo, User-Agent echo, a redirect chain, cookies,
+// and a gzip-encoded body.
+//
+//   server --port N [--tls --cert P --key P]
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/compress.nu`
+$ `../../http/src/http.nu`
+
+@ h_root HttpRequest req Params p → HttpResponse {
+    ^ ( response_text 200 `root` )
+}
+
+@ h_ua HttpRequest req Params p → HttpResponse {
+    : String out ( string_from `ua=` )
+    ?? ( header_get . req headers `User-Agent` ) {
+        T v → { ( string_push_str out ( string_data v ) ) ( string_free v ) }
+        F _ → { ( string_push_str out `(none)` ) }
+    }
+    : HttpResponse r ( response_text 200 ( string_data out ) )
+    ( string_free out )
+    ^ r
+}
+
+// /redir1 → 302 /redir2 → 302 /dest
+@ h_redir1 HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_new 302 )
+    ( response_set_header r `Location` `/redir2` )
+    ^ r
+}
+
+@ h_redir2 HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_new 302 )
+    ( response_set_header r `Location` `/dest` )
+    ^ r
+}
+
+@ h_dest HttpRequest req Params p → HttpResponse {
+    ^ ( response_text 200 `arrived` )
+}
+
+// A relative redirect from a subpath (RFC 3986 §5.2 merge).
+@ h_deep_redir HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_new 302 )
+    ( response_set_header r `Location` `sib` )
+    ^ r
+}
+
+@ h_deep_sib HttpRequest req Params p → HttpResponse {
+    ^ ( response_text 200 `sibling` )
+}
+
+// POST that a 303 turns into a bodyless GET.
+@ h_post303 HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_new 303 )
+    ( response_set_header r `Location` `/dest` )
+    ^ r
+}
+
+@ h_setcookie HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_text 200 `set` )
+    ( response_set_header r `Set-Cookie` `sid=abc123; Path=/` )
+    ^ r
+}
+
+@ h_readcookie HttpRequest req Params p → HttpResponse {
+    : String out ( string_from `cookie=` )
+    ?? ( header_get . req headers `Cookie` ) {
+        T v → { ( string_push_str out ( string_data v ) ) ( string_free v ) }
+        F _ → { ( string_push_str out `(none)` ) }
+    }
+    : HttpResponse r ( response_text 200 ( string_data out ) )
+    ( string_free out )
+    ^ r
+}
+
+@ h_gzip HttpRequest req Params p → HttpResponse {
+    : ( Vec u ) plain ( bytes_from_str `the quick brown fox jumps over the lazy dog` )
+    : HttpResponse r ( response_new 200 )
+    ?? ( gzip_compress plain ) {
+        T gz → {
+            ( response_set_header r `Content-Encoding` `gzip` )
+            ( response_set_body_bytes r gz )
+            ( vec_free [u] gz )
+        }
+        F _ → { ( response_set_body_bytes r plain ) }
+    }
+    ( vec_free [u] plain )
+    ^ r
+}
+
+@ h_echo_body HttpRequest req Params p → HttpResponse {
+    : HttpResponse r ( response_new 200 )
+    ( response_set_body_bytes r . req body )
+    ^ r
+}
+
+@ routes * HttpApp a → v {
+    ( http_app_get a `/` \ HttpRequest req Params p → HttpResponse { ^ ( h_root req p ) } )
+    ( http_app_get a `/ua` \ HttpRequest req Params p → HttpResponse { ^ ( h_ua req p ) } )
+    ( http_app_get a `/redir1` \ HttpRequest req Params p → HttpResponse { ^ ( h_redir1 req p ) } )
+    ( http_app_get a `/redir2` \ HttpRequest req Params p → HttpResponse { ^ ( h_redir2 req p ) } )
+    ( http_app_get a `/dest` \ HttpRequest req Params p → HttpResponse { ^ ( h_dest req p ) } )
+    ( http_app_get a `/a/b/deep` \ HttpRequest req Params p → HttpResponse { ^ ( h_deep_redir req p ) } )
+    ( http_app_get a `/a/b/sib` \ HttpRequest req Params p → HttpResponse { ^ ( h_deep_sib req p ) } )
+    ( http_app_post a `/post303` \ HttpRequest req Params p → HttpResponse { ^ ( h_post303 req p ) } )
+    ( http_app_get a `/setcookie` \ HttpRequest req Params p → HttpResponse { ^ ( h_setcookie req p ) } )
+    ( http_app_get a `/readcookie` \ HttpRequest req Params p → HttpResponse { ^ ( h_readcookie req p ) } )
+    ( http_app_get a `/gzip` \ HttpRequest req Params p → HttpResponse { ^ ( h_gzip req p ) } )
+    ( http_app_post a `/echo` \ HttpRequest req Params p → HttpResponse { ^ ( h_echo_body req p ) } )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `server` `http-client test server` )
+    ( args_opt ap `port` 112 `N` `bind port on 127.0.0.1` )
+    ( args_flag ap `tls` 116 `serve TLS` )
+    ( args_opt ap `cert` 99 `P` `cert PEM` )
+    ( args_opt ap `key` 107 `P` `key PEM` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+
+    : ~ i port 0
+    ?? ( args_value ap `port` ) {
+        T v → { ?? ( string_to_int v ) { T x → { = port x } F _ → {} } ( string_free v ) }
+        F _ → {}
+    }
+
+    : *HttpApp a ( http_app_new )
+    ( http_app_quiet a )
+    // Keep the test hermetic: no UDP/QUIC twin, no Alt-Svc.
+    ( http_app_set_http3 a 0 )
+    ( routes a )
+
+    : ~ i rc 0
+    ? ( args_present ap `tls` ) {
+        : String cert ( args_value_or ap `cert` `` )
+        : String key ( args_value_or ap `key` `` )
+        = rc ( http_app_listen_tls a `127.0.0.1` port ( string_data cert ) ( string_data key ) )
+        ( string_free cert ) ( string_free key )
+    } {
+        = rc ( http_app_listen a `127.0.0.1` port )
+    }
+    ( http_app_free a )
+    ( args_free ap )
+    ^ rc
+}

--- a/stdlib/ext/anthropic.nu
+++ b/stdlib/ext/anthropic.nu
@@ -221,6 +221,7 @@ $ `stdlib/ext/json.nu`
         HttpDns → @ ClaudeErr { ClaudeHttpDns }
         HttpInvalidUrl → @ ClaudeErr { ClaudeHttpInvalidUrl }
         HttpOther → @ ClaudeErr { ClaudeHttpOther }
+        HttpTooLarge → @ ClaudeErr { ClaudeHttpOther }
     }
 }
 

--- a/stdlib/ext/cluster.nu
+++ b/stdlib/ext/cluster.nu
@@ -121,6 +121,7 @@ $ `stdlib/ext/http_server.nu`
         HttpDns → @ ClusterErr { ClNet }
         HttpInvalidUrl → @ ClusterErr { ClNet }
         HttpOther → @ ClusterErr { ClNet }
+        HttpTooLarge → @ ClusterErr { ClNet }
     }
 }
 

--- a/stdlib/ext/compress.nu
+++ b/stdlib/ext/compress.nu
@@ -124,6 +124,14 @@ $ `stdlib/std/zstd.nu`  // pure-NURL Zstandard (RFC 8878)
 }
 
 @ zlib_decompress ( Vec u ) src → !( Vec u ) CompressErr {
+    ^ ( zlib_decompress_max src 0 )
+}
+
+// zlib_decompress with an output cap (0 = unlimited): the decoder stops
+// with CompressBufTooSmall the moment the output would pass `max_out` —
+// the decompression-bomb guard an HTTP client needs before it trusts a
+// Content-Encoding: deflate body.
+@ zlib_decompress_max ( Vec u ) src i max_out → !( Vec u ) CompressErr {
     : i n ( vec_len [u] src )
     ? <= n 0 {
         ^ @ !( Vec u ) CompressErr { T ( vec_new [u] ) }
@@ -133,11 +141,20 @@ $ `stdlib/std/zstd.nu`  // pure-NURL Zstandard (RFC 8878)
     : ( Vec u ) raw ( vec_new [u] )
     : *u sp ( vec_data [u] src )
     ( bytes_extend_raw raw # s + # i sp 2 - n 6 )
-    : !( Vec u ) DeflateErr r ( inflate raw )
+    : !( Vec u ) DeflateErr r ( inflate_max raw max_out )
     ( vec_free [u] raw )
     ?? r {
-        F e → ^ @ !( Vec u ) CompressErr { F ( __df_to_compress_err e ) }
+        F e → ^ @ !( Vec u ) CompressErr { F ( __df_to_compress_err_cap e ) }
         T out → ^ @ !( Vec u ) CompressErr { T out }
+    }
+}
+
+// __df_to_compress_err, with the cap (DeflateBadLength from inflate_max)
+// named for what it is.
+@ __df_to_compress_err_cap DeflateErr e → CompressErr {
+    ^ ?? e {
+        DeflateBadLength → # CompressErr CompressBufTooSmall
+        _ → ( __df_to_compress_err e )
     }
 }
 
@@ -172,6 +189,12 @@ $ `stdlib/std/zstd.nu`  // pure-NURL Zstandard (RFC 8878)
 }
 
 @ gzip_decompress ( Vec u ) src → !( Vec u ) CompressErr {
+    ^ ( gzip_decompress_max src 0 )
+}
+
+// gzip_decompress with an output cap (0 = unlimited) — see
+// zlib_decompress_max.
+@ gzip_decompress_max ( Vec u ) src i max_out → !( Vec u ) CompressErr {
     : i n ( vec_len [u] src )
     ? <= n 0 {
         ^ @ !( Vec u ) CompressErr { T ( vec_new [u] ) }
@@ -181,7 +204,7 @@ $ `stdlib/std/zstd.nu`  // pure-NURL Zstandard (RFC 8878)
     // Accept a zlib stream too (matches zlib's inflateInit2(15+32) auto-
     // detect): non-gzip-magic input is routed to zlib_decompress.
     ? | != # i . sp 0 31 != # i . sp 1 139 {
-        ^ ( zlib_decompress src )
+        ^ ( zlib_decompress_max src max_out )
     } {}
     ? < n 18 { ^ @ !( Vec u ) CompressErr { F CompressData } } {}
     : i flg # i . sp 3
@@ -201,10 +224,10 @@ $ `stdlib/std/zstd.nu`  // pure-NURL Zstandard (RFC 8878)
     ? >= p - n 8 { ^ @ !( Vec u ) CompressErr { F CompressData } } {}
     : ( Vec u ) raw ( vec_new [u] )
     ( bytes_extend_raw raw # s + # i sp p - - n 8 p )
-    : !( Vec u ) DeflateErr r ( inflate raw )
+    : !( Vec u ) DeflateErr r ( inflate_max raw max_out )
     ( vec_free [u] raw )
     ?? r {
-        F e → ^ @ !( Vec u ) CompressErr { F ( __df_to_compress_err e ) }
+        F e → ^ @ !( Vec u ) CompressErr { F ( __df_to_compress_err_cap e ) }
         T out → ^ @ !( Vec u ) CompressErr { T out }
     }
 }

--- a/stdlib/ext/http.nu
+++ b/stdlib/ext/http.nu
@@ -104,7 +104,7 @@ $ `stdlib/ext/http_pure.nu`
 // Variants are prefixed (`Http*`) because NURL enum variants live in a
 // flat global namespace — `Other` and `NotFound` already belong to
 // IoErr, so reusing them here would collide at link time.
-: | HttpErr { HttpConnect HttpTimeout HttpTls HttpDns HttpInvalidUrl HttpOther }
+: | HttpErr { HttpConnect HttpTimeout HttpTls HttpDns HttpInvalidUrl HttpOther HttpTooLarge }
 
 : Header { String name String value }
 
@@ -202,6 +202,7 @@ $ `stdlib/ext/http_pure.nu`
         ? == ek 3 { ^ @ !Response HttpErr { F # HttpErr HttpTls } } {}
         ? == ek 4 { ^ @ !Response HttpErr { F # HttpErr HttpDns } } {}
         ? == ek 5 { ^ @ !Response HttpErr { F # HttpErr HttpInvalidUrl } } {}
+        ? == ek 7 { ^ @ !Response HttpErr { F # HttpErr HttpTooLarge } } {}
         ^ @ !Response HttpErr { F # HttpErr HttpOther }
     } {}
     : s rp # s raw
@@ -215,29 +216,30 @@ $ `stdlib/ext/http_pure.nu`
 }
 
 // Same as http_request but with explicit per-call timeouts in
-// milliseconds. The timeout arguments are accepted for source
-// compatibility but are not yet honoured by the pure transport (a future
-// step will wire socket-level deadlines in).
+// milliseconds. `timeout_ms` is the deadline for every socket read and
+// write of the exchange (a stalled server answers HttpTimeout, not a
+// hang); 0 = none. `connect_timeout_ms` is accepted for the day the TCP
+// dial itself gets a deadline — today the dial is the OS's (the TLS
+// handshake already has its own 20 s read deadline).
 //
 // Dispatch: the pure-NURL HTTP/1.1 client in stdlib/ext/http_pure.nu
 // (TLS via stdlib/std/tls.nu for https, raw TCP otherwise).
 @ http_request_to s method s url s body s headers_blob i timeout_ms i connect_timeout_ms
 → !Response HttpErr {
     // s-body path: recover length via strlen (text/JSON callers).
-    // (timeouts are not yet honoured by the pure transport.)
-    : i raw ( hp_perform url method # *u body ( nurl_str_len body ) headers_blob 1 -1 1 `nurl-http/0.1` )
+    : i raw ( hp_perform url method # *u body ( nurl_str_len body ) headers_blob 1 -1 1 `nurl-http/0.1` timeout_ms )
     ^ ( __http_dispatch raw )
 }
 
 // Full-control entry point: every transport knob comes from `opt`
 // (see HttpOptions). follow_redirects / max_redirects / verify_tls /
-// user_agent are honoured by the pure transport; the two timeouts are
-// not yet wired in.
+// user_agent / timeout_ms are honoured by the pure transport;
+// connect_timeout_ms is not yet (see http_request_to).
 @ http_request_with_opts s method s url s body s headers_blob HttpOptions opt
 → !Response HttpErr {
     : s ua_in . opt user_agent
     : s ua ? & != # i ua_in 0 != ( nurl_str_len ua_in ) 0 ua_in `nurl-http/0.1`
-    : i raw ( hp_perform url method # *u body ( nurl_str_len body ) headers_blob . opt follow_redirects . opt max_redirects . opt verify_tls ua )
+    : i raw ( hp_perform url method # *u body ( nurl_str_len body ) headers_blob . opt follow_redirects . opt max_redirects . opt verify_tls ua . opt timeout_ms )
     ^ ( __http_dispatch raw )
 }
 
@@ -328,7 +330,7 @@ $ `stdlib/ext/http_pure.nu`
 // embedded NUL bytes survive end to end.
 @ http_request_bytes_to s method s url ( Vec u ) body s headers_blob
 i timeout_ms i connect_timeout_ms → !Response HttpErr {
-    : i raw ( hp_perform url method ( vec_data [u] body ) ( vec_len [u] body ) headers_blob 1 -1 1 `nurl-http/0.1` )
+    : i raw ( hp_perform url method ( vec_data [u] body ) ( vec_len [u] body ) headers_blob 1 -1 1 `nurl-http/0.1` timeout_ms )
     ^ ( __http_dispatch raw )
 }
 
@@ -450,6 +452,7 @@ i timeout_ms i connect_timeout_ms → !Response HttpErr {
         HttpDns → `HttpDns`
         HttpInvalidUrl → `HttpInvalidUrl`
         HttpOther → `HttpOther`
+        HttpTooLarge → `HttpTooLarge`
     }
 }
 
@@ -508,6 +511,7 @@ i timeout_ms i connect_timeout_ms → !Response HttpErr {
         ? == ek 3 { ^ @ !HttpStream HttpErr { F # HttpErr HttpTls } } {}
         ? == ek 4 { ^ @ !HttpStream HttpErr { F # HttpErr HttpDns } } {}
         ? == ek 5 { ^ @ !HttpStream HttpErr { F # HttpErr HttpInvalidUrl } } {}
+        ? == ek 7 { ^ @ !HttpStream HttpErr { F # HttpErr HttpTooLarge } } {}
         ^ @ !HttpStream HttpErr { F # HttpErr HttpOther }
     } {}
     ^ @ !HttpStream HttpErr { T @ HttpStream { raw } }
@@ -516,7 +520,7 @@ i timeout_ms i connect_timeout_ms → !Response HttpErr {
 @ http_stream_open_to s method s url s body s headers_blob
 i timeout_ms i connect_timeout_ms
 → !HttpStream HttpErr {
-    : *HttpStreamState st ( hp_stream_open method url # *u body ( nurl_str_len body ) headers_blob 1 -1 1 `nurl-http/0.1` )
+    : *HttpStreamState st ( hp_stream_open method url # *u body ( nurl_str_len body ) headers_blob 1 -1 1 `nurl-http/0.1` timeout_ms )
     ^ ( __http_stream_dispatch_open # i st )
 }
 
@@ -526,7 +530,7 @@ i timeout_ms i connect_timeout_ms
 @ http_stream_open_bytes_to s method s url ( Vec u ) body s headers_blob
 i timeout_ms i connect_timeout_ms
 → !HttpStream HttpErr {
-    : *HttpStreamState st ( hp_stream_open method url ( vec_data [u] body ) ( vec_len [u] body ) headers_blob 1 -1 1 `nurl-http/0.1` )
+    : *HttpStreamState st ( hp_stream_open method url ( vec_data [u] body ) ( vec_len [u] body ) headers_blob 1 -1 1 `nurl-http/0.1` timeout_ms )
     ^ ( __http_stream_dispatch_open # i st )
 }
 

--- a/stdlib/ext/http_pure.nu
+++ b/stdlib/ext/http_pure.nu
@@ -18,9 +18,21 @@
 //     feeds a stateful chunked-transfer decoder, so SSE / chunked bodies
 //     stream live rather than buffering to completion.
 //
+//   * Connection reuse: `hp_stream_open` (URL in, redirects followed) is
+//     the one-shot path and asks the server to close; `hp_stream_open_on`
+//     runs one exchange over a caller-owned HttpConn with keep-alive, and
+//     `hp_stream_release` hands the transport back when the response left
+//     it reusable (framed body fully read, no `Connection: close`, no
+//     stray bytes) — the pool an HTTP client builds on.
+//   * Timeouts: `hp_conn_set_timeout` puts a read/write deadline on the
+//     socket (SO_RCVTIMEO/SO_SNDTIMEO through nurl_tcp_set_timeout), and
+//     a deadline that fires surfaces as error 2 (timeout), distinct from
+//     a dead peer.
+//
 // Error codes are the NURL_HTTP_ERR_* integers from stdlib/runtime.c §14
-// (0 ok, 1 connect, 2 timeout, 3 tls, 4 dns, 5 invalid-url, 6 other), so
-// http.nu maps them straight onto HttpErr without translation.
+// (0 ok, 1 connect, 2 timeout, 3 tls, 4 dns, 5 invalid-url, 6 other,
+// 7 response body over the caller's cap), so http.nu maps them straight
+// onto HttpErr without translation.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -179,13 +191,46 @@ $ `stdlib/std/thread.nu`
     ^ @ !HttpConn i { T @ HttpConn { 0 fd # *TlsConn 0 skey } }
 }
 
+// Wrap a TLS connection the caller established itself (for instance
+// with an ALPN offer, see tls_attach_full) as an HttpConn. The session
+// ticket it receives is cached for host:port when the conn closes, like
+// the ones hp_conn_open opens.
+@ hp_conn_from_tls * TlsConn tc s host i port → HttpConn {
+    ^ @ HttpConn { 1 0 tc ( __hp_sess_key host port ) }
+}
+
+// The cached resumption session for host:port (empty when none): what a
+// caller dialing TLS itself offers, so its handshakes resume too.
+@ hp_session_lookup s host i port → ( Vec u ) {
+    : String key ( __hp_sess_key host port )
+    : ( Vec u ) sess ( __hp_sess_get key )
+    ( string_free key )
+    ^ sess
+}
+
+// Store a session exported from a connection the caller closed itself.
+@ hp_session_store s host i port ( Vec u ) blob → v {
+    ? == ( vec_len [u] blob ) 0 { ^ v } {}
+    : String key ( __hp_sess_key host port )
+    ( __hp_sess_put key blob )
+    ( string_free key )
+}
+
+// Read/write deadline in milliseconds for every socket operation on
+// this transport (0 = none). A deadline that fires reads back as error
+// 2 (timeout) from hp_conn_read_some / the stream state.
+@ hp_conn_set_timeout HttpConn c i ms → v {
+    : i fd ? != . c is_tls 0 . . c tc fd . c fd
+    ? > fd 0 { ( nurl_tcp_set_timeout fd ms ) } {}
+}
+
 // Write all of `data` to the transport. Returns 0 on success, else a
 // NURL_HTTP_ERR_* code.
 @ hp_conn_write HttpConn c ( Vec u ) data → i {
     ? != . c is_tls 0 {
         ?? ( tls_write . c tc data ) {
             T _ → ^ 0
-            F _ → ^ 6
+            F _ → ^ ? == ( nurl_tcp_err_kind . . c tc fd ) 7 2 6
         }
     } {}
     : i fd . c fd
@@ -194,7 +239,7 @@ $ `stdlib/std/thread.nu`
     : ~ i off 0
     ~ < off n {
         : i wn ( nurl_tcp_write fd # s + # i dp off - n off )
-        ? <= wn 0 { ^ 6 } {}
+        ? <= wn 0 { ^ ? == ( nurl_tcp_err_kind fd ) 7 2 6 } {}
         = off + off wn
     }
     ^ 0
@@ -204,10 +249,11 @@ $ `stdlib/std/thread.nu`
 //   1  → bytes were appended
 //   0  → clean end of stream (EOF)
 //  -1  → transport error
+//  -2  → the read deadline (hp_conn_set_timeout) fired
 @ hp_conn_read_some HttpConn c ( Vec u ) acc → i {
     ? != . c is_tls 0 {
         ?? ( tls_read . c tc 16384 ) {
-            F _ → ^ -1
+            F _ → ^ ? == ( nurl_tcp_err_kind . . c tc fd ) 7 -2 -1
             T chunk → {
                 : i got ( vec_len [u] chunk )
                 ? > got 0 { ( bytes_extend_bytes acc chunk ) } {}
@@ -219,7 +265,7 @@ $ `stdlib/std/thread.nu`
     : i fd . c fd
     : s scratch # s ( nurl_alloc 16384 )
     : i n ( nurl_tcp_read fd scratch 16384 )
-    ? < n 0 { ( nurl_free scratch ) ^ -1 } {}
+    ? < n 0 { ( nurl_free scratch ) ^ ? == ( nurl_tcp_err_kind fd ) 7 -2 -1 } {}
     ? == n 0 { ( nurl_free scratch ) ^ 0 } {}
     ( bytes_extend_raw acc scratch n )
     ( nurl_free scratch )
@@ -252,7 +298,7 @@ $ `stdlib/std/thread.nu`
     ( Vec String ) hvalues  // response header values (parallel to hnames)
     i headers_done
     i chunked  // 1 = Transfer-Encoding: chunked
-    i chunk_state  // 0 need-size, 1 in-body, 3 need-crlf, 2 done
+    i chunk_state  // 0 need-size, 1 in-body, 3 need-crlf, 4 trailers, 2 done
     i chunk_remaining
     i has_clen  // 1 = a Content-Length header was present
     i content_remaining  // bytes of body still expected (Content-Length)
@@ -260,6 +306,10 @@ $ `stdlib/std/thread.nu`
     i finished  // body fully decoded
     i status
     i err_kind
+    i conn_close  // 1 = the transport cannot carry another request (Connection: close, HTTP/1.0, read-to-EOF body)
+    i no_body  // 1 = this response has no body by definition (HEAD, 1xx, 204, 304)
+    i body_max  // decoded-body cap in bytes; 0 = unlimited; over → err 7
+    i body_total  // decoded body bytes handed out so far (against body_max)
 }
 
 // ── small byte / text helpers ───────────────────────────────────────
@@ -290,13 +340,42 @@ $ `stdlib/std/thread.nu`
 
 // ── request building ────────────────────────────────────────────────
 
+// T iff the caller's header blob already carries a `name:` line (case-
+// insensitive, at a line start) — then the default for that header is
+// the caller's business, not ours.
+@ _hp_blob_has s blob s lname → b {
+    ? | == # i blob 0 == ( nurl_str_len blob ) 0 { ^ F } {}
+    : String lb ( __hp_to_lower blob )
+    : s ld ( string_data lb )
+    : i ln ( nurl_str_len ld )
+    : i nl ( nurl_str_len lname )
+    : ~ i k 0
+    : ~ b hit F
+    ~ & ! hit <= + k nl ln {
+        ? | == k 0 == ( nurl_str_get ld - k 1 ) 10 {
+            : ~ i j 0
+            : ~ b same T
+            ~ & same < j nl {
+                ? != ( nurl_str_get ld + k j ) ( nurl_str_get lname j ) { = same F } {}
+                = j + j 1
+            }
+            ? & same < + k nl ln { = hit == ( nurl_str_get ld + k nl ) 58 } {}
+        } {}
+        = k + k 1
+    }
+    ( string_free lb )
+    ^ hit
+}
+
 // Build the raw request bytes for one request. body_ptr/body_len carry an
 // arbitrary (possibly binary) body; "" / 0 for none. headers_blob is the
 // caller's CRLF-delimited "Name: Value" lines (Content-Type, Authorization,
-// …) — Host / User-Agent / Connection / Content-Length / Accept-Encoding
-// are added here.
+// …) — Host / User-Agent / Content-Length are added here, Accept-Encoding
+// (identity: this layer decodes nothing) and Connection unless the blob
+// already carries them. `keepalive` 0 asks the server to close after this
+// response (the one-shot path); 1 leaves the HTTP/1.1 default, persistent.
 @ __hp_build_request s method s host i port i is_https s target
-* u body_ptr i body_len s headers_blob s ua → ( Vec u ) {
+* u body_ptr i body_len s headers_blob s ua i keepalive → ( Vec u ) {
     : ( Vec u ) req ( vec_new [u] )
     ( bytes_extend_str req method )
     ( bytes_extend_str req ` ` )
@@ -313,12 +392,20 @@ $ `stdlib/std/thread.nu`
     } {}
     ( bytes_extend_str req `\r\n` )
 
-    ( bytes_extend_str req `User-Agent: ` )
-    ( bytes_extend_str req ua )
-    ( bytes_extend_str req `\r\n` )
-    // We do not implement content decoding, so refuse compressed bodies.
-    ( bytes_extend_str req `Accept-Encoding: identity\r\n` )
-    ( bytes_extend_str req `Connection: close\r\n` )
+    // User-Agent: `ua` unless the caller's blob already names one.
+    ? & > ( nurl_str_len ua ) 0 ! ( _hp_blob_has headers_blob `user-agent` ) {
+        ( bytes_extend_str req `User-Agent: ` )
+        ( bytes_extend_str req ua )
+        ( bytes_extend_str req `\r\n` )
+    } {}
+    // This layer decodes nothing, so refuse compressed bodies unless the
+    // caller negotiates (and decodes) an encoding itself.
+    ? ( _hp_blob_has headers_blob `accept-encoding` ) {} {
+        ( bytes_extend_str req `Accept-Encoding: identity\r\n` )
+    }
+    ? & == keepalive 0 ! ( _hp_blob_has headers_blob `connection` ) {
+        ( bytes_extend_str req `Connection: close\r\n` )
+    } {}
 
     ? > body_len 0 {
         ( bytes_extend_str req `Content-Length: ` )
@@ -343,13 +430,13 @@ $ `stdlib/std/thread.nu`
 
 // ── header parsing ──────────────────────────────────────────────────
 
-// Find the end of the header block (index just past "\r\n\r\n") in raw,
-// or -1 if not present yet.
-@ __hp_find_header_end ( Vec u ) raw → i {
+// Find the end of the header block (index just past "\r\n\r\n") in raw
+// at/after `from`, or -1 if not present yet.
+@ __hp_find_header_end ( Vec u ) raw i from → i {
     : i n ( vec_len [u] raw )
-    ? < n 4 { ^ -1 } {}
+    ? < - n from 4 { ^ -1 } {}
     : *u d ( vec_data [u] raw )
-    : ~ i k 0
+    : ~ i k from
     ~ <= k - n 4 {
         ? & & == # i . d k 13 == # i . d + k 1 10
         & == # i . d + k 2 13 == # i . d + k 3 10 {
@@ -360,12 +447,19 @@ $ `stdlib/std/thread.nu`
     ^ -1
 }
 
-// Parse status line + headers from raw[0..hdr_end] into the state.
+// Parse status line + headers from raw[rawpos..hdr_end] into the state,
+// and settle the framing facts the body decoder and the connection pool
+// live by: HTTP/1.0 or `Connection: close` → the transport dies after
+// this response; HEAD / 1xx / 204 / 304 → no body follows (RFC 9112
+// §6.3); neither Content-Length nor chunked → body runs to EOF, so the
+// transport dies too.
 @ __hp_parse_headers * HttpStreamState st i hdr_end → v {
     : *u d ( vec_data [u] . st raw )
-    : String block ( string_from_bytes d hdr_end )
+    : i from . st rawpos
+    : String block ( string_from_bytes # *u + # i d from - hdr_end from )
     : ( Vec String ) lines ( string_split block `\r\n` )
     : i nl ( vec_len [String] lines )
+    : ~ b keep_alive_hdr F
 
     // Status line: "HTTP/1.1 200 OK".
     ? > nl 0 {
@@ -376,6 +470,7 @@ $ `stdlib/std/thread.nu`
             : s rest # s + # i sld + sp 1
             = . st status ( nurl_str_to_int rest )
         } {}
+        ? ( nurl_str_starts sld `HTTP/1.0` ) { = . st conn_close 1 } {}
     } {}
 
     : ~ i li 1
@@ -406,6 +501,12 @@ $ `stdlib/std/thread.nu`
                     = . st has_clen 1
                     = . st content_remaining ( nurl_str_to_int value )
                 } {}
+                ? ( nurl_str_eq lnm `connection` ) {
+                    : String lval ( __hp_to_lower value )
+                    ? >= ( nurl_str_find ( string_data lval ) `close` ) 0 { = . st conn_close 1 } {}
+                    ? >= ( nurl_str_find ( string_data lval ) `keep-alive` ) 0 { = keep_alive_hdr T } {}
+                    ( string_free lval )
+                } {}
                 ( string_free lname )
             } {}
         } {}
@@ -416,6 +517,28 @@ $ `stdlib/std/thread.nu`
     ( string_free block )
     = . st rawpos hdr_end
     = . st headers_done 1
+
+    // HTTP/1.0 with an explicit keep-alive stays open (we sent 1.1).
+    : i sc . st status
+    ? & == . st conn_close 1 keep_alive_hdr {
+        ? ( __hp_status_no_body sc ) { = . st conn_close 0 } { ? | != . st has_clen 0 != . st chunked 0 { = . st conn_close 0 } {} }
+    } {}
+    ? | != . st no_body 0 ( __hp_status_no_body sc ) {
+        = . st no_body 1
+        = . st finished 1
+    } {
+        ? & == . st chunked 0 == . st has_clen 0 {
+            = . st conn_close 1  // body is delimited by EOF
+        } {}
+        ? & != . st has_clen 0 <= . st content_remaining 0 { = . st finished 1 } {}
+    }
+}
+
+// Responses that carry no body whatever the headers say (RFC 9112 §6.3
+// rules 1-2): informational, 204 No Content, 304 Not Modified.
+@ __hp_status_no_body i sc → b {
+    ? & >= sc 100 < sc 200 { ^ T } {}
+    ^ | == sc 204 == sc 304
 }
 
 @ __hp_free_strings ( Vec String ) v → v {
@@ -469,6 +592,7 @@ $ `stdlib/std/thread.nu`
         : *u d ( vec_data [u] . st raw )
         ( bytes_extend_raw . st body # s + # i d . st rawpos take )
         = . st rawpos + . st rawpos take
+        = . st body_total + . st body_total take
         ? != . st has_clen 0 {
             = . st content_remaining - . st content_remaining take
             ? <= . st content_remaining 0 { = . st finished 1 } {}
@@ -489,7 +613,7 @@ $ `stdlib/std/thread.nu`
                     : i size ( __hp_parse_chunk_size st . st rawpos nl )
                     = . st rawpos + nl 2
                     ? == size 0 {
-                        = . st chunk_state 2
+                        = . st chunk_state 4
                     } {
                         = . st chunk_remaining size
                         = . st chunk_state 1
@@ -503,15 +627,30 @@ $ `stdlib/std/thread.nu`
                         : *u d ( vec_data [u] . st raw )
                         ( bytes_extend_raw . st body # s + # i d . st rawpos take )
                         = . st rawpos + . st rawpos take
+                        = . st body_total + . st body_total take
                         = . st chunk_remaining - . st chunk_remaining take
                         ? <= . st chunk_remaining 0 { = . st chunk_state 3 } {}
                     }
                 } {
-                    // state 3: consume the CRLF that terminates a chunk body.
-                    : i avail - n . st rawpos
-                    ? < avail 2 { = looping F } {
-                        = . st rawpos + . st rawpos 2
-                        = . st chunk_state 0
+                    ? == state 3 {
+                        // consume the CRLF that terminates a chunk body.
+                        : i avail - n . st rawpos
+                        ? < avail 2 { = looping F } {
+                            = . st rawpos + . st rawpos 2
+                            = . st chunk_state 0
+                        }
+                    } {
+                        // state 4: the trailer section after the last
+                        // chunk (RFC 9112 §7.1.2) — zero or more field
+                        // lines, then an empty line. Trailer fields are
+                        // consumed and dropped; the empty line ends the
+                        // message, and only then is the transport clean.
+                        : i nl ( __hp_find_crlf . st raw . st rawpos )
+                        ? < nl 0 { = looping F } {
+                            : b empty == nl . st rawpos
+                            = . st rawpos + nl 2
+                            ? empty { = . st chunk_state 2 } {}
+                        }
                     }
                 } } }
     }
@@ -549,47 +688,97 @@ $ `stdlib/std/thread.nu`
 
 // ── stream lifecycle ────────────────────────────────────────────────
 
-// Pump one socket read + decode pass. Sets finished/eof/err on the state.
+// Pump: decode what is already buffered; when that neither completes
+// the body nor yields new body bytes, do ONE socket read and decode
+// again. Sets finished/eof/err on the state. Decoding first matters on
+// a keep-alive connection: the body usually arrives with the headers,
+// and a read issued before decoding it would wait for bytes the server
+// — itself waiting for our next request — will never send.
 @ hp_stream_pump * HttpStreamState st → v {
     ? != . st finished 0 { ^ v } {}
     ? != . st err_kind 0 { = . st finished 1 ^ v } {}
+    : i had ( vec_len [u] . st body )
+    ( __hp_decode_available st )
+    ? & > . st body_max 0 > . st body_total . st body_max {
+        = . st err_kind 7
+        = . st finished 1
+        ^ v
+    } {}
+    ? | != . st finished 0 > ( vec_len [u] . st body ) had { ( __hp_compact st ) ^ v } {}
     : i r ( hp_conn_read_some . st conn . st raw )
     ? < r 0 {
-        = . st err_kind 6
+        = . st err_kind ? == r -2 2 6
         = . st finished 1
         ^ v
     } {}
     ? == r 0 {
         = . st eof 1
-        // Flush whatever remains, then we are done.
+        = . st conn_close 1
+        // Flush whatever remains, then we are done. A framed body cut
+        // short by EOF is an error, not a short body.
         ( __hp_decode_available st )
+        ? & != . st has_clen 0 > . st content_remaining 0 { = . st err_kind 6 } {}
+        ? & != . st chunked 0 != . st chunk_state 2 { = . st err_kind 6 } {}
         = . st finished 1
         ^ v
     } {}
     ( __hp_decode_available st )
+    ? & > . st body_max 0 > . st body_total . st body_max {
+        = . st err_kind 7
+        = . st finished 1
+        ^ v
+    } {}
     ( __hp_compact st )
 }
 
-// Drive reads until headers are parsed (or the transport dies). Returns
-// 0 on success, else a NURL_HTTP_ERR_* code.
+// Drive reads until the final response's headers are parsed (or the
+// transport dies). Interim 1xx responses (100 Continue, 103 Early Hints)
+// are consumed and skipped — RFC 9110 §15.2, a client must be able to
+// receive any number of them before the final response. Returns 0 on
+// success, else a NURL_HTTP_ERR_* code.
 @ __hp_read_headers * HttpStreamState st → i {
     : ~ b looping T
     ~ looping {
-        : i he ( __hp_find_header_end . st raw )
+        : i he ( __hp_find_header_end . st raw . st rawpos )
         ? >= he 0 {
             ( __hp_parse_headers st he )
-            = looping F
+            ? ( __hp_interim st ) {} { = looping F }
         } {
             : i r ( hp_conn_read_some . st conn . st raw )
-            ? < r 0 { ^ 6 } {}
+            ? < r 0 { ^ ? == r -2 2 6 } {}
             ? == r 0 {
                 // EOF before headers completed.
-                : i he2 ( __hp_find_header_end . st raw )
-                ? >= he2 0 { ( __hp_parse_headers st he2 ) = looping F } { ^ 6 }
+                : i he2 ( __hp_find_header_end . st raw . st rawpos )
+                ? >= he2 0 {
+                    ( __hp_parse_headers st he2 )
+                    ? ( __hp_interim st ) { ^ 6 } { = looping F }
+                } { ^ 6 }
             } {}
         }
     }
     ^ 0
+}
+
+// After parsing a header block: T when it was an interim 1xx (other than
+// 101 Switching Protocols, which ends HTTP/1.1 on the connection) — the
+// block is dropped and the state reset so the next one parses fresh.
+@ __hp_interim * HttpStreamState st → b {
+    : i sc . st status
+    ? | < sc 100 >= sc 200 { ^ F } {}
+    ? == sc 101 { ^ F } {}
+    ( __hp_free_strings . st hnames )
+    ( __hp_free_strings . st hvalues )
+    = . st hnames ( vec_new [String] )
+    = . st hvalues ( vec_new [String] )
+    = . st headers_done 0
+    = . st finished 0
+    = . st no_body 0
+    = . st conn_close 0
+    = . st chunked 0
+    = . st has_clen 0
+    = . st content_remaining 0
+    = . st status 0
+    ^ T
 }
 
 @ __hp_state_new HttpConn c → *HttpStreamState {
@@ -610,16 +799,82 @@ $ `stdlib/std/thread.nu`
     = . st finished 0
     = . st status 0
     = . st err_kind 0
+    = . st conn_close 0
+    = . st no_body 0
+    = . st body_max 0
+    = . st body_total 0
     ^ st
 }
 
+// Cap the decoded body; a response that grows past it ends with error 7
+// (the transport is then unusable — the rest of the body is unread).
+@ hp_stream_set_body_max * HttpStreamState st i max → v {
+    = . st body_max max
+}
+
+// One request/response exchange over a caller-owned transport, HTTP/1.1
+// keep-alive semantics (no `Connection: close` from us). No redirects:
+// a redirect is a complete response like any other, and the caller —
+// who owns the transport and the per-origin pool — decides where the
+// next request goes. `host`/`port`/`is_https` shape the Host header;
+// `target` is the request-target ("/path?query"). Headers are read
+// before this returns; the state is never null. Afterwards
+// hp_stream_release gives the transport back if it is still usable.
+@ hp_stream_open_on HttpConn conn s method s host i port i is_https s target
+* u body_ptr i body_len s headers_blob s ua → *HttpStreamState {
+    : *HttpStreamState st ( __hp_state_new conn )
+    ? ( nurl_str_eq method `HEAD` ) { = . st no_body 1 } {}
+    : ( Vec u ) req ( __hp_build_request method host port is_https target body_ptr body_len headers_blob ua 1 )
+    : i werr ( hp_conn_write conn req )
+    ( vec_free [u] req )
+    ? != werr 0 {
+        = . st err_kind werr
+        = . st finished 1
+        ^ st
+    } {}
+    : i herr ( __hp_read_headers st )
+    ? != herr 0 {
+        = . st err_kind herr
+        = . st finished 1
+    } {}
+    ^ st
+}
+
+// Detach the transport from a finished stream: Some(conn) when the
+// response left it reusable — body fully decoded, no error, no
+// `Connection: close`, no EOF-delimited body, and no stray bytes after
+// the body — else the transport is closed here. The state is freed
+// either way.
+@ hp_stream_release * HttpStreamState st → ?HttpConn {
+    : b clean & & == . st err_kind 0 != . st finished 0 == . st conn_close 0
+    : b drained == . st rawpos ( vec_len [u] . st raw )
+    ? & clean drained {
+        : HttpConn c . st conn
+        ( vec_free [u] . st raw )
+        ( vec_free [u] . st body )
+        ( __hp_free_strings . st hnames )
+        ( __hp_free_strings . st hvalues )
+        ( nurl_free # s st )
+        ^ @ ?HttpConn { T c }
+    } {}
+    ( hp_stream_close st )
+    ^ @ ?HttpConn { F # HttpConn 0 }
+}
+
 // Open a stream: parse the URL, connect, send the request, read headers,
-// following redirects up to `maxredir` when `follow` is set. Returns a
-// heap *HttpStreamState (never null); transport failures are recorded in
-// the state's err_kind with finished=1.
+// following redirects up to `maxredir` when `follow` is set. A 303, and a
+// 301/302 answering a POST, turn the next request into a body-less GET
+// (RFC 9110 §15.4.4 / §15.4.2-3 — what every browser does); 307/308
+// replay method and body. `timeout_ms` > 0 is the per-socket-operation
+// deadline (error 2 when it fires). Returns a heap *HttpStreamState
+// (never null); transport failures are recorded in the state's err_kind
+// with finished=1.
 @ hp_stream_open s method s url * u body_ptr i body_len s headers_blob
-i follow i maxredir i verify s ua → *HttpStreamState {
+i follow i maxredir i verify s ua i timeout_ms → *HttpStreamState {
     : ~ String cur_url ( string_from url )
+    : ~ String cur_method ( string_from method )
+    : ~ * u cur_body body_ptr
+    : ~ i cur_len body_len
     : ~ i redirects 0
     : ~ i result_p 0
     : ~ b looping T
@@ -648,8 +903,10 @@ i follow i maxredir i verify s ua → *HttpStreamState {
                         = looping F
                     }
                     T conn → {
+                        ? > timeout_ms 0 { ( hp_conn_set_timeout conn timeout_ms ) } {}
                         : *HttpStreamState st ( __hp_state_new conn )
-                        : ( Vec u ) req ( __hp_build_request method ( string_data . u host ) port is_https ( string_data tgt ) body_ptr body_len headers_blob ua )
+                        ? ( nurl_str_eq ( string_data cur_method ) `HEAD` ) { = . st no_body 1 } {}
+                        : ( Vec u ) req ( __hp_build_request ( string_data cur_method ) ( string_data . u host ) port is_https ( string_data tgt ) cur_body cur_len headers_blob ua 0 )
                         : i werr ( hp_conn_write conn req )
                         ( vec_free [u] req )
                         ? != werr 0 {
@@ -671,7 +928,7 @@ i follow i maxredir i verify s ua → *HttpStreamState {
                                 : b have_loc > ( string_len loc ) 0
                                 : b can_redir < redirects ? >= maxredir 0 maxredir 32
                                 ? & & is_redir have_loc can_redir {
-                                    : ?String nu ( __hp_resolve_redirect u ( string_data loc ) )
+                                    : ?String nu ( _hp_resolve_redirect u ( string_data loc ) )
                                     ?? nu {
                                         F _ → { = result_p # i st = looping F }
                                         T nus → {
@@ -679,6 +936,13 @@ i follow i maxredir i verify s ua → *HttpStreamState {
                                             ( string_free cur_url )
                                             = cur_url nus
                                             = redirects + redirects 1
+                                            : b to_get | == sc 303 & | == sc 301 == sc 302 != 0 ( nurl_str_eq ( string_data cur_method ) `POST` )
+                                            ? & to_get == 0 ( nurl_str_eq ( string_data cur_method ) `HEAD` ) {
+                                                ( string_free cur_method )
+                                                = cur_method ( string_from `GET` )
+                                                = cur_body # *u 0
+                                                = cur_len 0
+                                            } {}
                                         }
                                     }
                                 } {
@@ -696,6 +960,7 @@ i follow i maxredir i verify s ua → *HttpStreamState {
         }
     }
     ( string_free cur_url )
+    ( string_free cur_method )
     ^ # *HttpStreamState result_p
 }
 
@@ -723,29 +988,102 @@ i follow i maxredir i verify s ua → *HttpStreamState {
     ^ ( string_new )
 }
 
-// Resolve a (possibly relative) Location against the current URL.
-@ __hp_resolve_redirect Url base s loc → ?String {
+// Resolve a Location against the current URL — RFC 3986 §5.2 reference
+// resolution: absolute URLs as they are, "//host/x" takes the scheme,
+// "/x" the origin, and a relative path merges with the base path's
+// directory; "?q" keeps the base path; dot segments are removed; a
+// fragment never travels to the server.
+@ _hp_resolve_redirect Url base s loc → ?String {
     : i ll ( nurl_str_len loc )
     ? == ll 0 { ^ @ ?String { F # String 0 } } {}
     ? | ( nurl_str_starts loc `http://` ) ( nurl_str_starts loc `https://` ) {
-        ^ @ ?String { T ( string_from loc ) }
+        ^ @ ?String { T ( __hp_strip_fragment loc ) }
     } {}
     : String out ( string_new )
     ( string_push_str out ( string_data . base scheme ) )
-    ( string_push_str out `://` )
+    ( string_push_str out `:` )
+    ? ( nurl_str_starts loc `//` ) {
+        ( string_push_str out loc )
+        : String r ( __hp_strip_fragment ( string_data out ) )
+        ( string_free out )
+        ^ @ ?String { T r }
+    } {}
+    ( string_push_str out `//` )
     ( string_push_str out ( string_data . base host ) )
     : i port . base port
     ? >= port 0 {
         ( string_push_str out `:` )
         ( string_push_str out ( nurl_str_int port ) )
     } {}
-    ? == ( nurl_str_get loc 0 ) 47 {
-        ( string_push_str out loc )  // root-relative
+    : s bpath ( string_data . base path )
+    ? == ( nurl_str_get loc 0 ) 63 {
+        // "?query": the base path, new query.
+        ( string_push_str out ? > ( nurl_str_len bpath ) 0 bpath `/` )
+        ( string_push_str out loc )
     } {
-        ( string_push_str out `/` )
-        ( string_push_str out loc )  // best-effort relative
+        : String merged ( string_new )
+        ? == ( nurl_str_get loc 0 ) 47 {
+            ( string_push_str merged loc )
+        } {
+            // Directory of the base path (through its last "/"), then loc.
+            : i bl ( nurl_str_len bpath )
+            : ~ i cut - bl 1
+            ~ & >= cut 0 != ( nurl_str_get bpath cut ) 47 { = cut - cut 1 }
+            ? >= cut 0 { ( string_push_str merged ( nurl_str_slice bpath 0 + cut 1 ) ) } { ( string_push_str merged `/` ) }
+            ( string_push_str merged loc )
+        }
+        : String dotless ( __hp_remove_dot_segments ( string_data merged ) )
+        ( string_push_str out ( string_data dotless ) )
+        ( string_free dotless )
+        ( string_free merged )
     }
-    ^ @ ?String { T out }
+    : String r ( __hp_strip_fragment ( string_data out ) )
+    ( string_free out )
+    ^ @ ?String { T r }
+}
+
+@ __hp_strip_fragment s in → String {
+    : i h ( nurl_str_find in `#` )
+    ^ ? >= h 0 ( string_from ( nurl_str_slice in 0 h ) ) ( string_from in )
+}
+
+// RFC 3986 §5.2.4 on "path?query": "." and ".." segments are resolved in
+// the path part; the query rides along untouched.
+@ __hp_remove_dot_segments s in → String {
+    : i q ( nurl_str_find in `?` )
+    : i plen ? >= q 0 q ( nurl_str_len in )
+    : ( Vec String ) segs ( vec_new [String] )
+    : ~ i k 0
+    : ~ b trailing_slash F
+    ~ < k plen {
+        : ~ i e k
+        ~ & < e plen != ( nurl_str_get in e ) 47 { = e + e 1 }
+        : s seg ( nurl_str_slice in k - e k )
+        ? ( nurl_str_eq seg `..` ) {
+            : i n ( vec_len [String] segs )
+            ? > n 0 { ?? ( vec_pop [String] segs ) { T x → ( string_free x ) F _ → {} } } {}
+            = trailing_slash T
+        } {
+            ? ( nurl_str_eq seg `.` ) { = trailing_slash T } {
+                ? > - e k 0 { ( vec_push [String] segs ( string_from seg ) ) = trailing_slash F } { = trailing_slash T }
+            }
+        }
+        = k + e 1
+    }
+    : String out ( string_new )
+    : i n ( vec_len [String] segs )
+    ? == n 0 { ( string_push_str out `/` ) } {}
+    : ~ i i 0
+    ~ < i n {
+        ( string_push_str out `/` )
+        : String sg ( __hp_vec_string_at segs i )
+        ( string_push_str out ( string_data sg ) )
+        = i + i 1
+    }
+    ? & > n 0 | trailing_slash == ( nurl_str_get in - plen 1 ) 47 { ( string_push_str out `/` ) } {}
+    ? >= q 0 { ( string_push_str out ( nurl_str_slice in q - ( nurl_str_len in ) q ) ) } {}
+    ( __hp_free_strings segs )
+    ^ out
 }
 
 // Free everything the state owns.
@@ -765,12 +1103,12 @@ i follow i maxredir i verify s ua → *HttpStreamState {
 //   slot 0 status, 1 err_kind, 2 header_count, 3 headers*, 4 body*, 5 body_len.
 // Returns the i64 heap pointer (0 only on the response-struct alloc fail).
 @ hp_perform s url s method * u body_ptr i body_len s headers_blob
-i follow i maxredir i verify s ua → i {
+i follow i maxredir i verify s ua i timeout_ms → i {
     : i resp # i ( nurl_zalloc 48 )
     ? == resp 0 { ^ 0 } {}
     : *u rp # *u resp
 
-    : *HttpStreamState st ( hp_stream_open method url body_ptr body_len headers_blob follow maxredir verify ua )
+    : *HttpStreamState st ( hp_stream_open method url body_ptr body_len headers_blob follow maxredir verify ua timeout_ms )
 
     // Pump body to completion.
     ~ == . st finished 0 { ( hp_stream_pump st ) }
@@ -831,6 +1169,20 @@ i follow i maxredir i verify s ua → i {
 
 @ hp_stream_finished * HttpStreamState st → i {
     ^ . st finished
+}
+
+// 1 when the response declared (or framed) the transport as single-use.
+@ hp_stream_conn_close * HttpStreamState st → i {
+    ^ . st conn_close
+}
+
+// Take ownership of the fully-decoded body, leaving the stream with a
+// fresh empty one. For the buffered/facade path that assembles its own
+// response object after pumping to completion.
+@ hp_stream_body_take * HttpStreamState st → ( Vec u ) {
+    : ( Vec u ) out . st body
+    = . st body ( vec_new [u] )
+    ^ out
 }
 
 // Headers are parsed at open; this just reports the status (0 if the

--- a/stdlib/std/deflate.nu
+++ b/stdlib/std/deflate.nu
@@ -199,6 +199,16 @@ $ `stdlib/std/bytes.nu`
     i bitcnt
     ( Vec u ) out
     i err
+    i max_out  // stop (err 6) once `out` grows past this; 0 = unlimited
+}
+
+// The decompression-bomb guard, checked after every emitted byte run:
+// 1 KB of DEFLATE can expand to ~1 MB, so a cap enforced only after the
+// fact is no cap at all — the memory is already gone.
+@ __infl_over_cap * InflState st → b {
+    ? <= . st max_out 0 { ^ F } {}
+    ? > ( vec_len [u] . st out ) . st max_out { = . st err 6 ^ T } {}
+    ^ F
 }
 
 : Huff {
@@ -322,6 +332,7 @@ $ `stdlib/std/bytes.nu`
 ( Vec i ) lenbase ( Vec i ) lenext ( Vec i ) distbase ( Vec i ) distext → v {
     : ~ b done F
     ~ & ! done == . st err 0 {
+        ? ( __infl_over_cap st ) { = done T } {}
         : i sym ( __infl_decode st lencode )
         ? < sym 0 { = . st err 2 } {
             ? == sym 256 { = done T } {
@@ -481,6 +492,7 @@ $ `stdlib/std/bytes.nu`
                                 = k + k 1
                             }
                             = . st pos + . st pos blen
+                            : b _cap ( __infl_over_cap st )
                         }
                     }
                 } {
@@ -504,6 +516,13 @@ $ `stdlib/std/bytes.nu`
 
 // Inflate a complete raw DEFLATE stream into bytes.
 @ inflate ( Vec u ) src → !( Vec u ) DeflateErr {
+    ^ ( inflate_max src 0 )
+}
+
+// inflate with an output cap: decoding stops with DeflateBadLength as
+// soon as the output would exceed `max_out` bytes (0 = unlimited) — the
+// guard against a decompression bomb, enforced while decoding, not after.
+@ inflate_max ( Vec u ) src i max_out → !( Vec u ) DeflateErr {
     : *InflState st ( nurl_alloc Z InflState )
     = . st data ( vec_data [u] src )
     = . st len ( vec_len [u] src )
@@ -512,6 +531,7 @@ $ `stdlib/std/bytes.nu`
     = . st bitcnt 0
     = . st out ( vec_new [u] )
     = . st err 0
+    = . st max_out max_out
 
     ( __inflate_run st 0 )
 
@@ -542,6 +562,7 @@ $ `stdlib/std/bytes.nu`
     = . st bitcnt 0
     = . st out history
     = . st err 0
+    = . st max_out ? > max_out 0 + oldlen max_out 0
 
     ( __inflate_run st 1 )
 
@@ -576,6 +597,7 @@ $ `stdlib/std/bytes.nu`
     ? == e 2 { ^ # DeflateErr DeflateBadCode } {}
     ? == e 4 { ^ # DeflateErr DeflateBadDist } {}
     ? == e 5 { ^ # DeflateErr DeflateTruncated } {}
+    ? == e 6 { ^ # DeflateErr DeflateBadLength } {}
     ^ # DeflateErr DeflateOther
 }
 

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -498,11 +498,12 @@ $ `stdlib/std/pkey.nu`
     }
 }
 
-// As tcp_connect_tls, but offers a single ALPN protocol (e.g. "h2").
-// After connecting, the negotiated protocol is read with
-// tcp_alpn_protocol — empty if the server declined ALPN. With verify the
-// chain is validated AND the ALPN handshake runs; on TLS 1.2 servers the
-// pure stack does not parse ALPN, so callers requiring h2 should check.
+// As tcp_connect_tls, but offers ALPN protocols — one ("h2") or a
+// preference list ("h2 http/1.1", most preferred first, RFC 7301). After
+// connecting, the negotiated protocol is read with tcp_alpn_protocol —
+// empty if the server declined ALPN. With verify the chain is validated
+// AND the ALPN handshake runs; on TLS 1.2 servers the pure stack does
+// not parse ALPN, so callers requiring h2 should check.
 @ tcp_connect_tls_alpn s host i port s server_name i verify s alpn → !TcpConn NetErr {
     : i raw ( nurl_tcp_connect host port )
     ? <= raw 0 { ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake } } {}
@@ -511,6 +512,38 @@ $ `stdlib/std/pkey.nu`
         F _ → ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake }
         T tc → ^ @ !TcpConn NetErr { T @ TcpConn { # s 0 1 # i tc } }
     }
+}
+
+// tcp_connect_tls_alpn with a resumption offer as well: `sess` is what
+// tcp_tls_session_export returned from an earlier connection to the same
+// server (empty = full handshake). ALPN, resumption and verification in
+// one call — what an HTTP client that pools connections needs, since the
+// one-knob variants each leave one of the three out.
+@ tcp_connect_tls_full s host i port s server_name i verify s alpn ( Vec u ) sess → !TcpConn NetErr {
+    : i raw ( nurl_tcp_connect host port )
+    ? <= raw 0 { ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake } } {}
+    : !*TlsConn TlsErr r ( tls_attach_full raw server_name alpn sess verify )
+    ?? r {
+        F _ → ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake }
+        T tc → ^ @ !TcpConn NetErr { T @ TcpConn { # s 0 1 # i tc } }
+    }
+}
+
+// Wrap a TLS connection the caller established itself (tls_attach_full /
+// tls_connect_full — say, to read the ALPN pick before deciding which
+// protocol stack to hand the socket to) as a client TcpConn (kind 1).
+// The TcpConn owns it from here: tcp_close_conn closes it.
+@ tcp_conn_from_tls * TlsConn tc → TcpConn {
+    ^ @ TcpConn { # s 0 1 # i tc }
+}
+
+// The resumption session of a TLS client conn (tls_session_export): offer
+// it to tcp_connect_tls_full on the next connection to the same server.
+// Empty for plaintext conns and when the server issued no ticket.
+@ tcp_tls_session_export TcpConn c → ( Vec u ) {
+    : i tp ( __conn_tlsptr c )
+    ? == tp 0 { ^ ( vec_new [u] ) } {}
+    ^ ( tls_session_export # *TlsConn tp )
 }
 
 // Register a per-hostname cert/key pair on a TLS listener for Server

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -659,20 +659,21 @@ $ `stdlib/std/async_ffi.nu`
     ( vec_free [u] entry )
     ( vec_free [u] ks )
 
-    // application_layer_protocol_negotiation (0x0010), one protocol
-    // (RFC 7301). Only emitted when a protocol was requested (e.g. "h2");
-    // otherwise the ext is omitted and the connect behaves exactly as before.
-    : i al ( nurl_str_len alpn )
-    ? > al 0 {
+    // application_layer_protocol_negotiation (0x0010), RFC 7301: the
+    // protocols we speak, most preferred first ("h2 http/1.1" — the same
+    // space-separated form the server's listener takes). Only emitted
+    // when at least one protocol was requested; otherwise the extension
+    // is omitted and the connect behaves exactly as before.
+    : ( Vec u ) alp_list ( tls_alpn_pack alpn )
+    ? > ( vec_len [u] alp_list ) 0 {
         : ( Vec u ) alp ( vec_new [u] )
-        ( _tls_u16 alp + al 1 )  // ProtocolNameList length
-        ( vec_push [u] alp # u al )  // protocol name length
-        : ~ i ak 0
-        ~ < ak al { ( vec_push [u] alp # u ( nurl_str_get alpn ak ) ) = ak + ak 1 }
+        ( _tls_u16 alp ( vec_len [u] alp_list ) )  // ProtocolNameList length
+        ( _tls_cat alp alp_list )
         ( _tls_u16 ext 16 )
         ( _blk16 ext alp )
         ( vec_free [u] alp )
     } {}
+    ( vec_free [u] alp_list )
 
     // ── resumption (RFC 8446 §4.2.9 + §4.2.11) ──
     // psk_key_exchange_modes goes in EVERY hello, offer or not: it is
@@ -1008,6 +1009,65 @@ $ `stdlib/std/async_ffi.nu`
 // an empty Vec if the server sent no ALPN extension. Message layout:
 // [type:1][len:3][exts_len:2] then exts; ALPN ext (0x0010) data is
 // [list_len:2][name_len:1][name…].
+// Pack a space-separated protocol list ("h2 http/1.1") into ALPN wire
+// form: [len:1][name] per entry, in the given order — the ProtocolNameList
+// body of RFC 7301 §3.1, used by both the client's offer and the server's
+// listener preference. Names longer than 255 bytes cannot be encoded and
+// are dropped; empty tokens are skipped.
+@ tls_alpn_pack s list → ( Vec u ) {
+    : ( Vec u ) out ( vec_new [u] )
+    : i n ( nurl_str_len list )
+    : ~ i p 0
+    ~ < p n {
+        ~ & < p n == ( nurl_str_get list p ) 32 { = p + p 1 }
+        : i start p
+        ~ & < p n != ( nurl_str_get list p ) 32 { = p + p 1 }
+        : i tl - p start
+        ? & > tl 0 <= tl 255 {
+            ( vec_push [u] out # u tl )
+            : ~ i k start
+            ~ < k p { ( vec_push [u] out # u ( nurl_str_get list k ) ) = k + k 1 }
+        } {}
+    }
+    ^ out
+}
+
+// T iff `sel` (a bare protocol name) is one of the entries of the
+// space-separated offer `list`.
+@ _alpn_offered s list ( Vec u ) sel → b {
+    : ( Vec u ) packed ( tls_alpn_pack list )
+    : i n ( vec_len [u] packed )
+    : i sl ( vec_len [u] sel )
+    : ~ i p 0
+    : ~ b found F
+    ~ & ! found < p n {
+        : i tl ( _t_bget packed p )
+        ? == tl sl {
+            : ~ i k 0
+            : ~ b same T
+            ~ & same < k tl {
+                ? != ( _t_bget packed + + p 1 k ) ( _t_bget sel k ) { = same F } {}
+                = k + k 1
+            }
+            = found same
+        } {}
+        = p + + p 1 tl
+    }
+    ( vec_free [u] packed )
+    ^ found
+}
+
+// Send a fatal alert (RFC 8446 §6) under the current write keys — during
+// the server flight those are the handshake keys, so the peer can read
+// it. Best effort: the connection is being torn down either way.
+@ __send_alert * TlsConn c i desc → v {
+    : ( Vec u ) alert ( vec_with_cap [u] 2 )
+    ( vec_push [u] alert # u 2 )
+    ( vec_push [u] alert # u desc )
+    : !v TlsErr _w ( __send_encrypted c 21 alert )
+    ( vec_free [u] alert )
+}
+
 @ __ee_alpn ( Vec u ) msg → ( Vec u ) {
     : ( Vec u ) out ( vec_new [u] )
     : i n ( vec_len [u] msg )
@@ -1036,9 +1096,11 @@ $ `stdlib/std/async_ffi.nu`
     ^ out
 }
 
-// Core client handshake. `alpn` is a single ALPN protocol to offer (e.g.
-// "h2"); empty means no ALPN extension is sent. The negotiated protocol
-// (from the server's EncryptedExtensions) is stored in `c.alpn_sel`.
+// Core client handshake. `alpn` is the space-separated list of ALPN
+// protocols to offer, most preferred first (e.g. "h2 http/1.1"); empty
+// means no ALPN extension is sent. The negotiated protocol (from the
+// server's EncryptedExtensions, checked to be one we offered) is stored
+// in `c.alpn_sel`.
 @ __tls_handshake i raw s server_name s alpn ( Vec u ) sess → !*TlsConn TlsErr {
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
@@ -1231,10 +1293,19 @@ $ `stdlib/std/async_ffi.nu`
                     } {}
                     ? == t 8 {
                         // EncryptedExtensions — pick up the negotiated ALPN.
+                        // The server must pick from OUR list (RFC 7301
+                        // §3.2); anything else is a protocol violation
+                        // answered with no_application_protocol (120).
                         : ( Vec u ) sel ( __ee_alpn msg )
                         ? > ( vec_len [u] sel ) 0 {
-                            ( vec_free [u] . c alpn_sel )
-                            = . c alpn_sel sel
+                            ? ( _alpn_offered alpn sel ) {
+                                ( vec_free [u] . c alpn_sel )
+                                = . c alpn_sel sel
+                            } {
+                                ( vec_free [u] sel )
+                                ( __send_alert c 120 )
+                                = flighterr 1
+                            }
                         } { ( vec_free [u] sel ) }
                     } {}
                     ( _tls_cat tr msg )
@@ -1301,9 +1372,10 @@ $ `stdlib/std/async_ffi.nu`
     ^ r
 }
 
-// Like tls_attach but offers a single ALPN protocol (e.g. "h2"). After a
-// successful handshake the negotiated protocol is readable via
-// tls_alpn_selected (empty if the server declined ALPN). Insecure variant.
+// Like tls_attach but offers ALPN protocols ("h2" or a preference list
+// "h2 http/1.1"). After a successful handshake the negotiated protocol is
+// readable via tls_alpn_selected (empty if the server declined ALPN).
+// Insecure variant.
 @ tls_attach_alpn i raw s server_name s alpn → !*TlsConn TlsErr {
     : ( Vec u ) nosess ( vec_new [u] )
     : !*TlsConn TlsErr r ( __tls_handshake raw server_name alpn nosess )
@@ -1430,6 +1502,24 @@ $ `stdlib/std/async_ffi.nu`
 @ tls_attach_alpn_verify i raw s server_name s alpn → !*TlsConn TlsErr {
     : !*TlsConn TlsErr r ( tls_attach_alpn raw server_name alpn )
     ^ ( __verify_conn r server_name )
+}
+
+// Every client knob in one call: upgrade an already-connected socket to
+// TLS offering the ALPN list `alpn` ("" = none) AND the resumption
+// session `sess` (empty = none), verifying the chain / hostname when
+// `verify` is non-zero. The one-knob variants above are this with a
+// blank somewhere; an HTTP client that wants to resume a session on the
+// same connection it negotiates HTTP/2 over needs all of them at once.
+@ tls_attach_full i raw s server_name s alpn ( Vec u ) sess i verify → !*TlsConn TlsErr {
+    : !*TlsConn TlsErr r ( __tls_handshake raw server_name alpn sess )
+    ? != verify 0 { ^ ( __verify_conn r server_name ) } {}
+    ^ r
+}
+
+// tls_attach_full over a fresh TCP connection to host:port.
+@ tls_connect_full s host i port s server_name s alpn ( Vec u ) sess i verify → !*TlsConn TlsErr {
+    : i raw ( nurl_tcp_connect host port )
+    ^ ( tls_attach_full raw server_name alpn sess verify )
 }
 
 // Shared post-handshake verification used by both tls_connect and

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -1324,26 +1324,8 @@ $ `stdlib/std/aes_gcm.nu`
     ^ r
 }
 
-// Pack a space-separated protocol list ("h2 http/1.1") into ALPN wire
-// form: [len:1][name] per entry, in the given order. Names longer than
-// 255 bytes cannot be encoded and are dropped; empty tokens are skipped.
-@ tls_alpn_pack s list → ( Vec u ) {
-    : ( Vec u ) out ( vec_new [u] )
-    : i n ( nurl_str_len list )
-    : ~ i p 0
-    ~ < p n {
-        ~ & < p n == ( nurl_str_get list p ) 32 { = p + p 1 }
-        : i start p
-        ~ & < p n != ( nurl_str_get list p ) 32 { = p + p 1 }
-        : i tl - p start
-        ? & > tl 0 <= tl 255 {
-            ( vec_push [u] out # u tl )
-            : ~ i k start
-            ~ < k p { ( vec_push [u] out # u ( nurl_str_get list k ) ) = k + k 1 }
-        } {}
-    }
-    ^ out
-}
+// `tls_alpn_pack` (the wire form of a "h2 http/1.1" list) lives in
+// tls.nu: the client offers with it, the listener prefers with it.
 
 // Accept a TLS 1.3 connection with an RSA leaf certificate, signing the
 // CertificateVerify with RSASSA-PSS (rsa_pss_rsae_sha256). `rsa_n` /


### PR DESCRIPTION
`packages/http-client` is to the client what `packages/http` is to the server: one dependency, one `HttpClient`, requests over whichever protocol the server offers.

```nurl
$ `deps/http-client/src/http_client.nu`
: *HttpClient c ( http_client_new )
?? ( http_client_get c `https://example.org/` ) { T r → … F e → … }
```

## What one client gives you, unconfigured
- **Automatic protocol** — an `https` origin is dialled with ALPN `h2 http/1.1`; whichever the server picks is what it speaks (HTTP/2 multiplexed, or HTTP/1.1 keep-alive). Plaintext `http` is HTTP/1.1.
- **Post-quantum TLS** — the stdlib client offers X25519MLKEM768 first and verifies ML-DSA chains, so a PQ server is used as such automatically (`http_client_last_pq`).
- **Per-origin connection pooling** + **TLS session resumption**.
- **Redirects** (up to `max_redirects`; 303 and 301/302-on-POST → bodyless GET; relative `Location` per RFC 3986 §5.2).
- **Cookies** — a wired-in RFC 6265 jar.
- **gzip/deflate** decoded transparently, with a decompression-bomb output cap.
- Unified `HttpResponse` + `HttpClientErr`, `http_client_last_proto`/`_last_pq`.

## Root-level stdlib fixes (no package workarounds; `ext/http.nu` consumers inherit them)
- **`std/tls.nu`** — the client's ALPN offer is now a preference **list**; the server's pick is validated to be one offered (RFC 7301 §3.2, else a `no_application_protocol` alert). New one-call `tls_attach_full` / `tls_connect_full` (ALPN + resumption + verify). `tls_alpn_pack` moved here so offer and listener share it.
- **`std/net.nu`** — `tcp_connect_tls_full`, `tcp_tls_session_export`, `tcp_conn_from_tls`.
- **`ext/http_pure.nu`** — HTTP/1.1 keep-alive (`hp_stream_open_on` / `hp_stream_release`, `Connection`-aware pooling), **honoured** read/write deadlines, a response-body cap, interim-1xx skipping, chunked-trailer consumption, RFC 3986 §5.2 redirect resolution with 303/POST→GET downgrade, and `Accept-Encoding`/`User-Agent`/`Connection` defaults that yield to caller-set headers. The pump decodes buffered bytes before reading — without which a keep-alive connection deadlocks.
- **`ext/http.nu`** — `timeout_ms` is now honoured (was accepted-and-dropped); new `HttpTooLarge`.
- **`std/deflate.nu` + `ext/compress.nu`** — `inflate_max` / `zlib_decompress_max` / `gzip_decompress_max` cap the output **while** decoding (the guard a client needs before trusting a `Content-Encoding` body).

## Tests
- `packages/http-client/tests/client_test.sh` drives the facade against a `packages/http` server over both plaintext (h1) and TLS (h2): protocol selection, connection reuse, redirects + cap, cookies, gzip, POST, PQ handshake — **14/14, LSan clean**. `examples/fetch.nu` fetches example.org over HTTP/2 with a post-quantum handshake.
- `compiler/tests/tls_alpn_server.nu` extended with ALPN-list cases + an offer-matcher codec check; new `compiler/tests/http_keepalive.nu` pins reuse, framing, deadlines, the body cap and redirect resolution.

## Gates
Full corpus green (standalone), h2spec gate PASS (server ALPN unaffected), stdlib-symbol / package-import / version / builtins-doc gates OK.

## Not in this PR
HTTP/3 over QUIC is not yet a **client** role in the stdlib (the server side is complete); the facade gains it behind the same `Alt-Svc`-driven upgrade when it lands, without an API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)