### PR TITLE
TLS client machine, QUIC client role, HTTP/3 client — packages/http-client speaks HTTP/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **QUIC client role** — `std/quic_conn.nu` now plays either side
+  (`quic_conn_new_client`, `quic_conn_open_bidi`, `quic_conn_is_pq`,
+  `quic_conn_confirmed`, `quic_conn_new_token`, the peer's close code
+  and reason), `std/quic_tls.nu` gains the CRYPTO-frame driver of the
+  client TLS machine (`QuicTlsCli` over `CliHs`, with certificate
+  verification through `std/tls_verify.nu`), and `std/quic_client.nu`
+  is the socket + loop around one client connection
+  (`quic_client_connect` / `_step` / `_wait_readable` / `_close`). The
+  client honours Retry (integrity tag checked, new DCID and Initial
+  keys, the token in every Initial, the ClientHello sent again with the
+  packet number continuing), Version Negotiation (ignored when it lists
+  v1 or arrives after any processed packet, otherwise the attempt ends),
+  NEW_TOKEN, HANDSHAKE_DONE (confirmation, Handshake keys dropped),
+  pads every datagram that carries an Initial to 1200 bytes and drops
+  Initial keys on its first Handshake packet; it sends an empty
+  legacy_session_id (RFC 9001 §8.4 — Google's and Cloudflare's servers
+  refuse the TCP-style 32-byte one with `UNEXPECTED_COMPATIBILITY_MODE`).
+  `compiler/tests/quic_client_server.nu` is the first QUIC handshake in
+  the repo that completes with NURL on both ends — X25519MLKEM768
+  asserted on both, a bidirectional stream echoed with FIN, a clean
+  close seen by the server, and the self-signed server refused with
+  `CRYPTO_ERROR(bad_certificate)` when verification is on;
+  `quic_client_retry.nu` pins the Retry / VN behaviour sans-IO. Against
+  cloudflare-quic.com, www.google.com, quic.nginx.org and
+  www.facebook.com (verification on, system roots) the client completes
+  the handshake with a post-quantum key exchange and sees HANDSHAKE_DONE.
+
 ### Changed
 
 - **The TLS 1.3 client handshake is a message-level machine, `CliHs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HTTP/3 client, and `packages/http-client` speaks it** —
+  `ext/http3_client.nu` is the client half of RFC 9114 over the QUIC
+  client (`h3_client_connect` / `h3_client_request`: control and QPACK
+  streams, a request per bidirectional stream, 1xx skipped, trailers
+  accepted, GOAWAY and stream refusals reported by code). The facade
+  moves an origin onto QUIC once a response advertises
+  `Alt-Svc: h3=":port"` (parsed and cached per origin with its `ma`),
+  or straight away with `http_client_set_h3 c 1`; a QUIC attempt that
+  fails falls back to TCP for that origin, and `http_client_last_proto`
+  reports 3. `packages/http-client` 0.2.0; `examples/fetch.nu --h3`.
+  `fetch --h3 https://cloudflare-quic.com/`, google and quic.nginx.org
+  answer `HTTP/3 (post-quantum) — status 200`. The package suite grows
+  to 25 checks (Alt-Svc switch, QUIC-first, cookies / gzip / redirects /
+  POST over h3, fall-back when no UDP listener answers);
+  `compiler/tests/http3_client_server.nu` drives the client against
+  `ext/http3_server.nu` in-process.
+
+### Fixed
+
+- **QPACK name-reference encoding** (`ext/http3_qpack.nu`): a field
+  whose name is in the static table but whose value is not was encoded
+  with index `2 − k` instead of `−(k + 2)` (a prefix-arity slip), so
+  `:authority` went on the wire as `age`, `accept` as `:status`, and
+  the HTTP/3 server's `date` as `age`. The codec test's "name-only"
+  case was an exact hit and never exercised the path; it now round-trips
+  `:authority`, `:path`, `date` and `accept` with foreign values. Found
+  by the first HTTP/3 request between two NURL ends.
+
 - **QUIC client role** — `std/quic_conn.nu` now plays either side
   (`quic_conn_new_client`, `quic_conn_open_bidi`, `quic_conn_is_pq`,
   `quic_conn_confirmed`, `quic_conn_new_token`, the peer's close code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The TLS 1.3 client handshake is a message-level machine, `CliHs`
+  (`std/tls.nu`)** — the split the server got in `SrvHs` for HTTP/3:
+  whole handshake messages go in (`_cli_hs_server_hello`,
+  `_cli_hs_message`), the ClientHello and client Finished come out
+  (`out_ch`, `out_fin`), the traffic secrets are read straight off the
+  machine, and a driver may add a ClientHello extension and require one
+  back in EncryptedExtensions (`_cli_hs_set_ext` — how QUIC will carry
+  `quic_transport_parameters`). `__tls_handshake` is now the record
+  layer around it: same bytes on the wire (h2spec 146/146, every tls_*
+  and http2 test unchanged, `packages/http-client` 14/14, example.org
+  over HTTP/2 + X25519MLKEM768), with the transcript hashed
+  incrementally and snapshotted at the checkpoints instead of
+  re-hashed from scratch five times. Handshake failures the client
+  detects are now said with the matching alert (illegal_parameter,
+  decrypt_error, missing_extension, …) before the close, not only
+  no_application_protocol; a server flight carrying a hello, ticket,
+  EndOfEarlyData or KeyUpdate before the Finished is refused as
+  unexpected_message. The TLS 1.2 fallback is unchanged (hands over
+  after the ServerHello, verified against `openssl s_server -tls1_2`).
+
 ### Added
 
 - **`packages/http-client` — the unified HTTP *client* facade, the

--- a/compiler/tests/http3_client_server.nu
+++ b/compiler/tests/http3_client_server.nu
@@ -1,0 +1,169 @@
+// http3_client_server.nu — HTTP/3 with NURL on both ends:
+// `ext/http3_client.nu` (client) against `ext/http3_server.nu` (the
+// server the HTTP stack puts beside every TLS listener), no other
+// implementation involved.
+//
+// Asserted: the QUIC handshake completes on ALPN "h3" with an
+// X25519MLKEM768 key exchange; a GET gets its status, a header and its
+// body back; a POST body reaches the handler and comes back; the
+// response's `content-type` arrives lower-cased as HTTP/3 wants; a
+// second request rides the same connection; a 404 is a normal response,
+// not an error; the connection closes cleanly (the server's event 3).
+//
+// Server on an OS thread (http3_server_run blocks), client on the main
+// thread, like tls_pq_hybrid.nu.
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/udp.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http3_server.nu`
+$ `stdlib/ext/http3_client.nu`
+
+: ~ i g_requests 0
+
+@ label s k s v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ label_int s k i v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` )
+}
+
+@ handler HttpRequest req → HttpResponse {
+    = g_requests + g_requests 1
+    : s path ( string_data . req path )
+    ? != 0 ( nurl_str_eq path `/` ) {
+        : HttpResponse r ( response_new 200 )
+        ( response_set_header r `Content-Type` `text/plain` )
+        ( response_set_header r `X-Served-By` `nurl-h3` )
+        : ( Vec u ) b ( bytes_from_str `hello over h3` )
+        ( bytes_extend_bytes . r body b )
+        ( vec_free [u] b )
+        ^ r
+    } {}
+    ? != 0 ( nurl_str_eq path `/echo` ) {
+        : HttpResponse r ( response_new 200 )
+        ( bytes_extend_bytes . r body . req body )
+        ^ r
+    } {}
+    ^ ( response_new 404 )
+}
+
+@ header_of HttpResponse r s name → String {
+    : i n ( vec_len [Header] . r headers )
+    : *Header d ( vec_data [Header] . r headers )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . d k
+        ? != 0 ( nurl_str_eq ( string_data . h name ) name ) { ^ ( string_from ( string_data . h value ) ) } {}
+        = k + k 1
+    }
+    ^ ( string_new )
+}
+
+@ client_round → v {
+    : *H3Client cl ( h3_client_connect `127.0.0.1` 18963 `localhost` 0 5000 )
+    ? == # i cl 0 { ( label `connect` `NO-SOCKET` ) ^ } {}
+    ( label `connect` ? ( h3_client_connected cl ) `OK` `FAIL` )
+    ? ! ( h3_client_connected cl ) { ( label_int `close_code` ( h3_client_close_code cl ) ) ( h3_client_free cl ) ^ } {}
+    ( label `pq` ? ( h3_client_is_pq cl ) `T` `F` )
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `Accept` `text/plain` ) )
+    : ( Vec u ) nobody ( vec_new [u] )
+    ?? ( h3_client_request cl `GET` `https` `localhost` `/` hs nobody 5000 ) {
+        T r → {
+            ( label_int `get_status` . r status )
+            : String ct ( header_of r `content-type` )
+            ( label `get_content_type` ( string_data ct ) )
+            ( string_free ct )
+            : String by ( header_of r `x-served-by` )
+            ( label `get_served_by` ( string_data by ) )
+            ( string_free by )
+            : String body ( string_from_bytes ( vec_data [u] . r body ) ( vec_len [u] . r body ) )
+            ( label `get_body` ( string_data body ) )
+            ( string_free body )
+            ( http_response_free r )
+        }
+        F e → { ( label `get` ( h3_client_err_name e ) ) ( label_int `get_refusal` ( h3_client_last_refusal cl ) ) }
+    }
+    : ( Vec u ) payload ( bytes_from_str `posted bytes` )
+    ?? ( h3_client_request cl `POST` `https` `localhost` `/echo` hs payload 5000 ) {
+        T r → {
+            ( label_int `post_status` . r status )
+            ( label `post_echo` ? ( bytes_eq . r body payload ) `T` `F` )
+            ( http_response_free r )
+        }
+        F e → { ( label `post` ( h3_client_err_name e ) ) }
+    }
+    ?? ( h3_client_request cl `GET` `https` `localhost` `/missing` hs nobody 5000 ) {
+        T r → {
+            ( label_int `missing_status` . r status )
+            ( http_response_free r )
+        }
+        F e → { ( label `missing` ( h3_client_err_name e ) ) }
+    }
+    ( label `alive_after_three` ? ( h3_client_alive cl ) `T` `F` )
+    ( vec_free [u] payload )
+    ( vec_free [u] nobody )
+    ( vec_free_with [Header] hs \ Header hh → v { ( header_free hh ) } )
+    ( h3_client_close cl )
+    ( h3_client_free cl )
+}
+
+@ run → v {
+    : X509SelfSigned cert ( x509_selfsigned_p256 `localhost` 1 )
+    : s cp `/tmp/nurl_http3_client_server.crt`
+    : s kp `/tmp/nurl_http3_client_server.key`
+    ?? ( write_file cp ( string_data . cert cert_pem ) ) { T _ → {} F _ → { ( label `cert_write` `FAIL` ) } }
+    ?? ( write_file kp ( string_data . cert key_pem ) ) { T _ → {} F _ → { ( label `key_write` `FAIL` ) } }
+    ( x509_selfsigned_free cert )
+    : *QuicCreds creds ( http3_creds_load cp kp )
+    ? == # i creds 0 { ( label `creds` `FAIL` ) ^ } {}
+    : !UdpSocket NetErr sr ( udp_bind `127.0.0.1` 18963 )
+    ?? sr {
+        T sock → {
+            : ( Vec u ) prefs ( tls_alpn_pack `h3` )
+            : *QuicTp stp ( http3_default_tp )
+            : ( @ HttpResponse HttpRequest ) hf \ HttpRequest req → HttpResponse { ^ ( handler req ) }
+            : *H3Server srv ( http3_server_new sock creds prefs stp hf 1048576 )
+            : ( @ v ) server \ → v { ( http3_server_run srv ) }
+            : !Thread ThreadErr st ( thread_spawn server )
+            ?? st {
+                T t → {
+                    ( sleep_ms 100 )
+                    ( client_round )
+                    ( sleep_ms 100 )
+                    ( http3_server_stop srv )
+                    ( thread_join t )
+                    : *u server_env # *u server 1
+                    ( nurl_free # s server_env )
+                }
+                F _ → { ( label `spawn` `FAIL` ) }
+            }
+            ( label_int `server_requests` g_requests )
+            ( label_int `server_accepted` ( http3_server_accepted srv ) )
+            ( http3_server_free srv )
+            : *u hf_env # *u hf 1
+            ( nurl_free # s hf_env )
+            ( quic_tp_free stp )
+            ( vec_free [u] prefs )
+            ( udp_close sock )
+        }
+        F _ → { ( label `udp_bind` `FAIL` ) }
+    }
+    ( quic_creds_free creds )
+}
+
+@ main → i {
+    ( run )
+    ^ 0
+}

--- a/compiler/tests/http3_qpack_codec.nu
+++ b/compiler/tests/http3_qpack_codec.nu
@@ -153,6 +153,36 @@ $ `stdlib/ext/http3_qpack.nu`
     }
     ( vec_free [u] enc )
 
+    // ── name-only static hits: the name is in the table, the value is
+    // not — `:authority` is index 0, which a "-(k+2)" encoding must keep
+    // apart from "no hit"; `date` (6) and `accept` (29) sit where an
+    // off-by-two lands on `age` and `:status` (this was a real bug: the
+    // HTTP/3 client's :authority reached the server as `age`) ──
+    : ( Vec Header ) nm ( vec_new [Header] )
+    ( vec_push [Header] nm ( header_new `:authority` `localhost` ) )
+    ( vec_push [Header] nm ( header_new `:path` `/x` ) )
+    ( vec_push [Header] nm ( header_new `date` `Tue, 01 Jan 2030 00:00:00 GMT` ) )
+    ( vec_push [Header] nm ( header_new `accept` `text/plain` ) )
+    : ( Vec u ) enc2 ( qpack_encode_section nm )
+    ( free_hs nm )
+    // 0x50 | index with a 4-bit prefix: :authority → 0x50, :path → 0x51
+    = fails + fails ( check_int `nameref_authority_byte` ( __qpk_bget_pub enc2 2 ) 80 )
+    ?? ( qpack_decode_section enc2 ) {
+        T hs → {
+            = fails + fails ( check_int `nm_count` ( vec_len [Header] hs ) 4 )
+            = fails + fails ( check_str `nm_0n` ( hdr_name hs 0 ) `:authority` )
+            = fails + fails ( check_str `nm_0v` ( hdr_value hs 0 ) `localhost` )
+            = fails + fails ( check_str `nm_1n` ( hdr_name hs 1 ) `:path` )
+            = fails + fails ( check_str `nm_1v` ( hdr_value hs 1 ) `/x` )
+            = fails + fails ( check_str `nm_2n` ( hdr_name hs 2 ) `date` )
+            = fails + fails ( check_str `nm_3n` ( hdr_name hs 3 ) `accept` )
+            = fails + fails ( check_str `nm_3v` ( hdr_value hs 3 ) `text/plain` )
+            ( free_hs hs )
+        }
+        F code → { = fails + fails ( check_int `nm_decode` code 0 ) }
+    }
+    ( vec_free [u] enc2 )
+
     // ── refusals (h3spec QPACK cases) ────────────────────────────
     = fails + fails ( expect_decode_err `invalid_static_index` `0000ff24` 512 )
     = fails + fails ( expect_decode_err `dynamic_indexed` `000080` 512 )

--- a/compiler/tests/outputs/http3_client_server.txt
+++ b/compiler/tests/outputs/http3_client_server.txt
@@ -1,0 +1,16 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+connect=OK
+pq=T
+get_status=200
+get_content_type=text/plain
+get_served_by=nurl-h3
+get_body=hello over h3
+post_status=200
+post_echo=T
+missing_status=404
+alive_after_three=T
+server_requests=3
+server_accepted=1

--- a/compiler/tests/outputs/http3_qpack_codec.txt
+++ b/compiler/tests/outputs/http3_qpack_codec.txt
@@ -33,6 +33,15 @@ rt_1n: PASS
 rt_1v: PASS
 rt_2n: PASS
 rt_2v: PASS
+nameref_authority_byte: PASS
+nm_count: PASS
+nm_0n: PASS
+nm_0v: PASS
+nm_1n: PASS
+nm_1v: PASS
+nm_2n: PASS
+nm_3n: PASS
+nm_3v: PASS
 invalid_static_index: PASS
 dynamic_indexed: PASS
 post_base_indexed: PASS

--- a/compiler/tests/outputs/quic_client_retry.txt
+++ b/compiler/tests/outputs/quic_client_retry.txt
@@ -1,0 +1,22 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+initial_datagrams=2
+initial_len=1200
+initial_type=Initial
+initial_dcid_len=8
+initial_token_len=0
+odcid_is_ours=T
+bad_tag_ignored=T
+retried_datagrams=2
+retried_len=1200
+retried_dcid_is_retry_scid=T
+retried_carries_token=T
+retried_pn=2
+retried_crypto_at_0=T
+second_retry_ignored=T
+state_after_late_vn=0
+vn_with_v1_state=0
+vn_without_v1_state=4
+vn_without_v1_sent_after=0

--- a/compiler/tests/outputs/quic_client_server.txt
+++ b/compiler/tests/outputs/quic_client_server.txt
@@ -1,0 +1,19 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+connect=OK
+alpn=echo
+client_pq=T
+stream_open=OK
+stream_send=OK
+echo=hello over quic
+echo_fin=T
+confirmed=T
+close=OK
+verify_selfsigned=REFUSED 298
+verify_stream=NONE
+server_alpn=echo
+server_pq=T
+server_echoed=T
+server_saw_close=T

--- a/compiler/tests/quic_client_retry.nu
+++ b/compiler/tests/quic_client_retry.nu
@@ -1,0 +1,196 @@
+// quic_client_retry.nu — the client role of std/quic_conn.nu on the
+// two server answers that arrive before any packet can be decrypted,
+// driven sans-IO (datagrams built with std/quic_packet.nu, no socket):
+//
+//   * Retry (RFC 9000 §17.2.5): a Retry with a good integrity tag
+//     changes the DCID to the Retry's SCID, puts the token in every
+//     following Initial, sends the ClientHello again, and continues the
+//     packet-number space (the second Initial is packet 1, not 0); a
+//     second Retry is ignored, and so is one with a bad tag or one that
+//     names our own DCID.
+//   * Version Negotiation (§6.2): one that lists version 1 is a fake
+//     and ignored; one without it ends the attempt (closed, nothing
+//     sent); one arriving after a Retry — i.e. after the client has
+//     acted on a server packet — is ignored too.
+//
+// The first datagram is also checked to be what §14.1 and §7.2 ask of a
+// client Initial: 1200 bytes, an 8-byte DCID we chose, no token.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/udp.nu`
+$ `stdlib/std/quic_packet.nu`
+$ `stdlib/std/quic_tp.nu`
+$ `stdlib/std/quic_conn.nu`
+
+@ label s k s v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ label_int s k i v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` )
+}
+
+@ hx s raw → ( Vec u ) {
+    ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) }
+}
+
+// Every datagram the connection wants to send right now, concatenated
+// — the hybrid ClientHello spans two Initials. `first` gets the first.
+@ drain * QuicConn c i now ( Vec u ) first → i {
+    : ~ i n 0
+    : ~ i more 1
+    ~ != more 0 {
+        : ( Vec u ) d ( quic_conn_send c now )
+        ? == ( vec_len [u] d ) 0 { = more 0 } {
+            ? == n 0 { ( bytes_extend_bytes first d ) } {}
+            = n + n 1
+        }
+        ( vec_free [u] d )
+    }
+    ^ n
+}
+
+@ fresh_client * QuicTp tp → *QuicConn {
+    : ( Vec u ) peer ( udp_addr_new )
+    : *QuicConn c ( quic_conn_new_client peer `localhost` `h3` tp 0 1000 )
+    ( vec_free [u] peer )
+    ^ c
+}
+
+// A Version Negotiation packet for the client's first Initial.
+@ vn_for ( Vec u ) initial ( Vec i ) versions → ( Vec u ) {
+    : *QuicHdr h ( quic_hdr_parse initial 0 8 )
+    : ( Vec u ) dcid ( quic_hdr_dcid h initial )
+    : ( Vec u ) scid ( quic_hdr_scid h initial )
+    : ( Vec u ) vn ( quic_vn_build scid dcid versions )
+    ( vec_free [u] scid ) ( vec_free [u] dcid ) ( quic_hdr_free h )
+    ^ vn
+}
+
+@ run_retry → v {
+    : *QuicTp tp ( quic_tp_new )
+    = . tp initial_max_data 65536
+    = . tp initial_max_stream_data_bidi_local 16384
+    = . tp initial_max_stream_data_bidi_remote 16384
+    = . tp initial_max_stream_data_uni 16384
+    = . tp initial_max_streams_bidi 4
+    = . tp initial_max_streams_uni 3
+    : *QuicConn c ( fresh_client tp )
+    : ( Vec u ) peer ( udp_addr_new )
+    : ( Vec u ) d1 ( vec_new [u] )
+    ( label_int `initial_datagrams` ( drain c 1000 d1 ) )
+    ( label_int `initial_len` ( vec_len [u] d1 ) )
+    : *QuicHdr h1 ( quic_hdr_parse d1 0 8 )
+    ( label `initial_type` ? == . h1 ptype 0 `Initial` `OTHER` )
+    ( label_int `initial_dcid_len` . h1 dcid_len )
+    ( label_int `initial_token_len` . h1 token_len )
+    : ( Vec u ) odcid ( quic_hdr_dcid h1 d1 )
+    : ( Vec u ) cscid ( quic_hdr_scid h1 d1 )
+    ( quic_hdr_free h1 )
+    ( label `odcid_is_ours` ? ( bytes_eq odcid ( quic_conn_odcid c ) ) `T` `F` )
+
+    // a Retry from the server: new SCID, a token, the tag over our ODCID
+    : ( Vec u ) rscid ( hx `a1a2a3a4a5a6a7a8` )
+    : ( Vec u ) token ( hx `746f6b656e2d31` )
+    : ( Vec u ) retry ( quic_retry_build cscid rscid odcid token )
+    // ... first a corrupted one (tag wrong): must be ignored
+    : ( Vec u ) bad ( bytes_slice retry 0 ( vec_len [u] retry ) )
+    : i lastk - ( vec_len [u] bad ) 1
+    : i lastv ?? ( vec_get [u] bad lastk ) { T x → # i x F → 0 }
+    : b _s ( vec_set [u] bad lastk # u ^^ lastv 255 )
+    ( quic_conn_recv c bad peer 1001 )
+    : ( Vec u ) after_bad ( vec_new [u] )
+    : i nbad ( drain c 1002 after_bad )
+    ( label `bad_tag_ignored` ? & == nbad 0 == ( quic_conn_state c ) 0 `T` `F` )
+    ( vec_free [u] after_bad ) ( vec_free [u] bad )
+    // ... then the real one
+    ( quic_conn_recv c retry peer 1003 )
+    : ( Vec u ) d2 ( vec_new [u] )
+    ( label_int `retried_datagrams` ( drain c 1004 d2 ) )
+    ( label_int `retried_len` ( vec_len [u] d2 ) )
+    : *QuicHdr h2 ( quic_hdr_parse d2 0 8 )
+    : ( Vec u ) d2dcid ( quic_hdr_dcid h2 d2 )
+    : ( Vec u ) d2tok ( quic_hdr_token h2 d2 )
+    ( label `retried_dcid_is_retry_scid` ? ( bytes_eq d2dcid rscid ) `T` `F` )
+    ( label `retried_carries_token` ? ( bytes_eq d2tok token ) `T` `F` )
+    // the packet number continues (§17.2.5.3): remove header protection
+    // with the Initial keys of the new DCID and read it
+    : *QuicKeys k ( quic_initial_keys rscid T )
+    : ( Vec u ) pkt ( bytes_slice d2 0 . h2 end )
+    : i pn_len ( quic_hp_remove k pkt . h2 pn_off )
+    : i pn ( quic_pn_read pkt . h2 pn_off pn_len )
+    ( label_int `retried_pn` pn )
+    // and it carries the ClientHello again: the payload decrypts and
+    // starts with a CRYPTO frame at offset 0 (0x06 0x00)
+    : ( Vec u ) hdr ( bytes_slice pkt 0 + . h2 pn_off pn_len )
+    : ( Vec u ) body ( bytes_slice pkt + . h2 pn_off pn_len ( vec_len [u] pkt ) )
+    ?? ( quic_open k pn hdr body ) {
+        T pl → {
+            : i b0 ?? ( vec_get [u] pl 0 ) { T x → # i x F → -1 }
+            : i b1 ?? ( vec_get [u] pl 1 ) { T x → # i x F → -1 }
+            ( label `retried_crypto_at_0` ? & == b0 6 == b1 0 `T` `F` )
+            ( vec_free [u] pl )
+        }
+        F → { ( label `retried_crypto_at_0` `NO-DECRYPT` ) }
+    }
+    ( vec_free [u] body ) ( vec_free [u] hdr ) ( vec_free [u] pkt ) ( quic_keys_free k )
+    ( vec_free [u] d2tok ) ( vec_free [u] d2dcid ) ( quic_hdr_free h2 )
+    // a second Retry is ignored (§17.2.5.2)
+    : ( Vec u ) rscid2 ( hx `b1b2b3b4b5b6b7b8` )
+    : ( Vec u ) retry2 ( quic_retry_build cscid rscid2 odcid token )
+    ( quic_conn_recv c retry2 peer 1005 )
+    : ( Vec u ) d3 ( vec_new [u] )
+    : i n3 ( drain c 1006 d3 )
+    ( label `second_retry_ignored` ? == n3 0 `T` `F` )
+    ( vec_free [u] d3 ) ( vec_free [u] retry2 ) ( vec_free [u] rscid2 )
+    // a Version Negotiation after the Retry is ignored too (§6.2)
+    : ( Vec i ) vers ( vec_new [i] )
+    ( vec_push [i] vers 2 )
+    : ( Vec u ) vn ( vn_for d1 vers )
+    ( quic_conn_recv c vn peer 1007 )
+    ( label_int `state_after_late_vn` ( quic_conn_state c ) )
+    ( vec_free [u] vn ) ( vec_free [i] vers )
+    ( vec_free [u] d2 ) ( vec_free [u] retry ) ( vec_free [u] token ) ( vec_free [u] rscid )
+    ( vec_free [u] cscid ) ( vec_free [u] odcid ) ( vec_free [u] d1 ) ( vec_free [u] peer )
+    ( quic_conn_free c )
+    ( quic_tp_free tp )
+}
+
+@ run_vn → v {
+    : *QuicTp tp ( quic_tp_new )
+    = . tp initial_max_data 65536
+    = . tp initial_max_streams_bidi 4
+    : ( Vec u ) peer ( udp_addr_new )
+    // lists version 1: a fake, ignored
+    : *QuicConn c1 ( fresh_client tp )
+    : ( Vec u ) i1 ( vec_new [u] )
+    : i _n1 ( drain c1 1000 i1 )
+    : ( Vec i ) v1 ( vec_new [i] )
+    ( vec_push [i] v1 1 ) ( vec_push [i] v1 2 )
+    : ( Vec u ) vn1 ( vn_for i1 v1 )
+    ( quic_conn_recv c1 vn1 peer 1001 )
+    ( label_int `vn_with_v1_state` ( quic_conn_state c1 ) )
+    ( vec_free [u] vn1 ) ( vec_free [i] v1 ) ( vec_free [u] i1 ) ( quic_conn_free c1 )
+    // no version in common: the attempt ends, nothing more is sent
+    : *QuicConn c2 ( fresh_client tp )
+    : ( Vec u ) i2 ( vec_new [u] )
+    : i _n2 ( drain c2 1000 i2 )
+    : ( Vec i ) v2 ( vec_new [i] )
+    ( vec_push [i] v2 2 ) ( vec_push [i] v2 4278190335 )
+    : ( Vec u ) vn2 ( vn_for i2 v2 )
+    ( quic_conn_recv c2 vn2 peer 1001 )
+    ( label_int `vn_without_v1_state` ( quic_conn_state c2 ) )
+    : ( Vec u ) after ( vec_new [u] )
+    ( label_int `vn_without_v1_sent_after` ( drain c2 1002 after ) )
+    ( vec_free [u] after ) ( vec_free [u] vn2 ) ( vec_free [i] v2 ) ( vec_free [u] i2 ) ( quic_conn_free c2 )
+    ( vec_free [u] peer )
+    ( quic_tp_free tp )
+}
+
+@ main → i {
+    ( run_retry )
+    ( run_vn )
+    ^ 0
+}

--- a/compiler/tests/quic_client_server.nu
+++ b/compiler/tests/quic_client_server.nu
@@ -1,0 +1,205 @@
+// quic_client_server.nu — the first QUIC handshake that COMPLETES with
+// NURL on both ends: `std/quic_client.nu` (client role of
+// std/quic_conn.nu over the `CliHs` TLS machine) against
+// `std/quic_server.nu` (the listener the HTTP/3 server uses), no other
+// implementation involved.
+//
+// What is asserted, not assumed:
+//   * the handshake completes and the ALPN both sides report is the one
+//     offered ("echo");
+//   * the key exchange is X25519MLKEM768 on BOTH ends (a handshake that
+//     quietly fell back to X25519 would also "complete");
+//   * a client-opened bidirectional stream carries data + FIN to the
+//     server and the echo + FIN back — 1-RTT keys in both directions;
+//   * the server's HANDSHAKE_DONE confirms the client's handshake;
+//   * a clean close reaches the server (its event 3 fires);
+//   * with certificate verification ON, the self-signed server is
+//     refused with CRYPTO_ERROR(bad_certificate) = 0x12a and nothing
+//     is sent on the stream — the failure is loud, not a downgrade.
+//
+// Server on an OS thread (quic_server_run blocks), client on the main
+// thread, like tls_pq_hybrid.nu.
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/udp.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/std/quic_tp.nu`
+$ `stdlib/std/quic_conn.nu`
+$ `stdlib/std/quic_server.nu`
+$ `stdlib/std/quic_client.nu`
+$ `stdlib/ext/http3_server.nu`
+
+: ~ i g_server_pq 0
+: ~ i g_server_alpn_ok 0
+: ~ i g_server_gone 0
+: ~ i g_server_echoed 0
+
+@ label s k s v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ label_int s k i v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` )
+}
+
+// The server's application: echo every bidirectional stream back, FIN
+// for FIN.
+@ on_event i cp i ev → v {
+    : *QuicConn c # *QuicConn cp
+    ? == ev 1 {
+        : ( Vec u ) want ( bytes_from_str `echo` )
+        ? ( bytes_eq ( quic_conn_alpn c ) want ) { = g_server_alpn_ok 1 } {}
+        ( vec_free [u] want )
+        ? ( quic_conn_is_pq c ) { = g_server_pq 1 } {}
+        ^
+    } {}
+    ? == ev 3 { = g_server_gone 1 ^ } {}
+    ? != ev 2 { ^ } {}
+    : ( Vec i ) ids ( quic_conn_take_readable c )
+    : ~ i k 0
+    ~ < k ( vec_len [i] ids ) {
+        : i id ?? ( vec_get [i] ids k ) { T x → x F → 0 }
+        : ( Vec u ) data ( quic_conn_stream_recv c id 65536 )
+        : b fin ( quic_conn_stream_fin c id )
+        ? | > ( vec_len [u] data ) 0 fin {
+            : i _n ( quic_conn_stream_send c id data fin )
+            = g_server_echoed 1
+        } {}
+        ? fin { ( quic_conn_stream_done c id ) } {}
+        ( vec_free [u] data )
+        = k + k 1
+    }
+    ( vec_free [i] ids )
+}
+
+@ run → v {
+    : X509SelfSigned cert ( x509_selfsigned_p256 `localhost` 1 )
+    : s cp `/tmp/nurl_quic_client_server.crt`
+    : s kp `/tmp/nurl_quic_client_server.key`
+    ?? ( write_file cp ( string_data . cert cert_pem ) ) { T _ → {} F _ → { ( label `cert_write` `FAIL` ) } }
+    ?? ( write_file kp ( string_data . cert key_pem ) ) { T _ → {} F _ → { ( label `key_write` `FAIL` ) } }
+    ( x509_selfsigned_free cert )
+    : *QuicCreds creds ( http3_creds_load cp kp )
+    ? == # i creds 0 { ( label `creds` `FAIL` ) ^ } {}
+    : !UdpSocket NetErr sr ( udp_bind `127.0.0.1` 18962 )
+    ?? sr {
+        T sock → {
+            : ( Vec u ) prefs ( tls_alpn_pack `echo` )
+            : *QuicTp stp ( http3_default_tp )
+            : ( @ v i i ) ev \ i cp i e → v { ( on_event cp e ) }
+            : *QuicServer srv ( quic_server_new sock creds prefs stp ev )
+            : ( @ v ) server \ → v { ( quic_server_run srv ) }
+            : !Thread ThreadErr st ( thread_spawn server )
+            ?? st {
+                T t → {
+                    ( sleep_ms 100 )
+                    ( client_round )
+                    ( client_round_verify )
+                    ( quic_server_stop srv )
+                    ( thread_join t )
+                    : *u server_env # *u server 1
+                    ( nurl_free # s server_env )
+                }
+                F _ → { ( label `spawn` `FAIL` ) }
+            }
+            ( label `server_alpn` ? == g_server_alpn_ok 1 `echo` `OTHER` )
+            ( label `server_pq` ? == g_server_pq 1 `T` `F` )
+            ( label `server_echoed` ? == g_server_echoed 1 `T` `F` )
+            ( label `server_saw_close` ? == g_server_gone 1 `T` `F` )
+            ( quic_server_free srv )
+            : *u ev_env # *u ev 1
+            ( nurl_free # s ev_env )
+            ( quic_tp_free stp )
+            ( vec_free [u] prefs )
+            ( udp_close sock )
+        }
+        F _ → { ( label `udp_bind` `FAIL` ) }
+    }
+    ( quic_creds_free creds )
+}
+
+// verify = 0: the self-signed leaf is accepted; everything else is checked.
+@ client_round → v {
+    : *QuicTp tp ( quic_client_default_tp )
+    : *QuicClient cl ( quic_client_connect `127.0.0.1` 18962 `localhost` `echo` tp 0 5000 )
+    ? == # i cl 0 { ( label `connect` `NO-SOCKET` ) ( quic_tp_free tp ) ^ } {}
+    : *QuicConn c ( quic_client_conn cl )
+    ( label `connect` ? ( quic_client_connected cl ) `OK` `FAIL` )
+    ? ( quic_client_connected cl ) {
+        : ( Vec u ) want ( bytes_from_str `echo` )
+        ( label `alpn` ? ( bytes_eq ( quic_conn_alpn c ) want ) `echo` `OTHER` )
+        ( vec_free [u] want )
+        ( label `client_pq` ? ( quic_conn_is_pq c ) `T` `F` )
+        : i sid ( quic_conn_open_bidi c )
+        ( label `stream_open` ? == sid 0 `OK` `FAIL` )
+        : ( Vec u ) msg ( bytes_from_str `hello over quic` )
+        : i sent ( quic_conn_stream_send c sid msg T )
+        ( label `stream_send` ? == sent ( vec_len [u] msg ) `OK` `SHORT` )
+        ( quic_client_pump cl )
+        // the echo, possibly in pieces, until its FIN
+        : ( Vec u ) got ( vec_new [u] )
+        : ~ i fin 0
+        : ~ i tries 0
+        ~ & == fin 0 < tries 50 {
+            ? ( quic_client_wait_readable cl 2000 ) {
+                : ( Vec i ) ids ( quic_conn_take_readable c )
+                ( vec_free [i] ids )
+                : ( Vec u ) part ( quic_conn_stream_recv c sid 65536 )
+                ( bytes_extend_bytes got part )
+                ( vec_free [u] part )
+                ? ( quic_conn_stream_fin c sid ) { = fin 1 } {}
+            } { = tries 50 }
+            = tries + tries 1
+        }
+        ( label `echo` ? ( bytes_eq got msg ) `hello over quic` `MISMATCH` )
+        ( label `echo_fin` ? == fin 1 `T` `F` )
+        ( vec_free [u] got )
+        ( vec_free [u] msg )
+        ( quic_conn_stream_done c sid )
+        // HANDSHAKE_DONE rides in the server's first 1-RTT packets; by
+        // the time the echo is back it has been seen.
+        ( label `confirmed` ? ( quic_conn_confirmed c ) `T` `F` )
+        : ( Vec u ) reason ( vec_new [u] )
+        ( quic_client_close cl 1 0 reason 2000 )
+        ( vec_free [u] reason )
+        ( label `close` ? >= ( quic_conn_state c ) 2 `OK` `FAIL` )
+    } {
+        ( label_int `connect_close_code` ( quic_conn_close_code c ) )
+    }
+    ( quic_client_free cl )
+    ( quic_tp_free tp )
+}
+
+// verify = 1: a self-signed certificate is not trusted; the handshake
+// must fail with CRYPTO_ERROR(bad_certificate) and open no stream.
+@ client_round_verify → v {
+    : *QuicTp tp ( quic_client_default_tp )
+    : *QuicClient cl ( quic_client_connect `127.0.0.1` 18962 `localhost` `echo` tp 1 5000 )
+    ? == # i cl 0 { ( label `verify_selfsigned` `NO-SOCKET` ) ( quic_tp_free tp ) ^ } {}
+    : *QuicConn c ( quic_client_conn cl )
+    ? ( quic_client_connected cl ) {
+        ( label `verify_selfsigned` `ACCEPTED` )
+    } {
+        ( nurl_print `verify_selfsigned=REFUSED ` )
+        ( nurl_print ( nurl_str_int ( quic_conn_close_code c ) ) )
+        ( nurl_print `\n` )
+    }
+    ( label `verify_stream` ? < ( quic_conn_open_bidi c ) 0 `NONE` `OPENED` )
+    // let the CONNECTION_CLOSE out so the server's connection goes too
+    : ( Vec u ) reason ( vec_new [u] )
+    ( quic_client_close cl 0 0 reason 1000 )
+    ( vec_free [u] reason )
+    ( quic_client_free cl )
+    ( quic_tp_free tp )
+}
+
+@ main → i {
+    ( run )
+    ^ 0
+}

--- a/compiler/tests/quic_client_server.nu
+++ b/compiler/tests/quic_client_server.nu
@@ -101,6 +101,22 @@ $ `stdlib/ext/http3_server.nu`
                     ( sleep_ms 100 )
                     ( client_round )
                     ( client_round_verify )
+                    // The server's own drain timer (RFC 9000 §10.2, 3xPTO from
+                    // when it saw our CONNECTION_CLOSE) is what fires event 3 —
+                    // not anything the client can see. On a real OS thread
+                    // that has already happened by now; under a cooperative
+                    // scheduler (the "no libc" build's unikernel/net/sockets.nu)
+                    // the server only advances when this fiber yields, and
+                    // scheduling gaps look like loss to its RTT estimate, so
+                    // PTO can back off to several seconds. Give it up to 15s,
+                    // yielding in short slices (sleep_ms is what drives the
+                    // server coroutine forward there) — a no-op wait on a
+                    // thread where it is already done.
+                    : ~ i waited 0
+                    ~ & == g_server_gone 0 < waited 15000 {
+                        ( sleep_ms 100 )
+                        = waited + waited 100
+                    }
                     ( quic_server_stop srv )
                     ( thread_join t )
                     : *u server_env # *u server 1

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -202,7 +202,9 @@ The whole stack is pure NURL. `std/quic_packet.nu` (packet protection,
 header protection, Initial secrets, Retry tag — byte-exact against RFC 9001
 Appendix A), `std/quic_frame.nu`, `std/quic_tp.nu` (transport parameters),
 `std/quic_tls.nu` (RFC 9001 §4: the TLS 1.3 handshake fed from CRYPTO
-frames — the same message-level machine `std/tls_server.nu` uses for TCP),
+frames — the same message-level machine `std/tls_server.nu` uses for TCP;
+the client side has its twin, `CliHs` in `std/tls.nu`, which the TCP
+record layer drives today and a QUIC client role can drive the same way),
 `std/quic_recovery.nu` (RFC 9002: RTT, loss detection, PTO, NewReno),
 `std/quic_conn.nu` (the connection: every frame, stream states, both
 flow-control levels, connection IDs, key update, close/drain, idle,

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -213,7 +213,10 @@ Version Negotiation); the same connection in its client role
 (`quic_conn_new_client`, `quic_conn_open_bidi` — Retry, Version
 Negotiation, NEW_TOKEN and HANDSHAKE_DONE handled, certificate verified
 through `std/tls_verify.nu`) with `std/quic_client.nu` as its socket and
-loop (`quic_client_connect` / `_wait_readable` / `_close`); `ext/http3_qpack.nu` (RFC 9204, static table +
+loop (`quic_client_connect` / `_wait_readable` / `_close`) and
+`ext/http3_client.nu` on top — an HTTP/3 client (`h3_client_connect` /
+`h3_client_request`) that `packages/http-client` switches to when a
+response advertises `Alt-Svc: h3`; `ext/http3_qpack.nu` (RFC 9204, static table +
 literals — this endpoint advertises a zero-size dynamic table),
 `ext/http3_frame.nu`, `ext/http3_conn.nu` (control / QPACK streams,
 request streams → `HttpRequest`), `ext/http3_server.nu`. A program that

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -204,12 +204,16 @@ Appendix A), `std/quic_frame.nu`, `std/quic_tp.nu` (transport parameters),
 `std/quic_tls.nu` (RFC 9001 §4: the TLS 1.3 handshake fed from CRYPTO
 frames — the same message-level machine `std/tls_server.nu` uses for TCP;
 the client side has its twin, `CliHs` in `std/tls.nu`, which the TCP
-record layer drives today and a QUIC client role can drive the same way),
+record layer and `QuicTlsCli` in the same file both drive),
 `std/quic_recovery.nu` (RFC 9002: RTT, loss detection, PTO, NewReno),
 `std/quic_conn.nu` (the connection: every frame, stream states, both
 flow-control levels, connection IDs, key update, close/drain, idle,
 anti-amplification), `std/quic_server.nu` (UDP listener, connection table,
-Version Negotiation); `ext/http3_qpack.nu` (RFC 9204, static table +
+Version Negotiation); the same connection in its client role
+(`quic_conn_new_client`, `quic_conn_open_bidi` — Retry, Version
+Negotiation, NEW_TOKEN and HANDSHAKE_DONE handled, certificate verified
+through `std/tls_verify.nu`) with `std/quic_client.nu` as its socket and
+loop (`quic_client_connect` / `_wait_readable` / `_close`); `ext/http3_qpack.nu` (RFC 9204, static table +
 literals — this endpoint advertises a zero-size dynamic table),
 `ext/http3_frame.nu`, `ext/http3_conn.nu` (control / QPACK streams,
 request streams → `HttpRequest`), `ext/http3_server.nu`. A program that

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -36,8 +36,9 @@ $ `deps/http-client/src/http_client.nu`
 | Feature | How |
 | --- | --- |
 | **Automatic protocol** | an `https` origin is dialled with ALPN `h2 http/1.1`; whichever the server picks is what the client speaks — HTTP/2 multiplexed, or HTTP/1.1 with keep-alive. Plaintext `http` is HTTP/1.1. |
+| **HTTP/3** | a response carrying `Alt-Svc: h3=":443"` moves the origin's next request onto QUIC (`stdlib/ext/http3_client.nu`, pure NURL: Retry, Version Negotiation, NEW_TOKEN, HANDSHAKE_DONE all honoured); `http_client_set_h3 c 1` tries QUIC first without waiting for Alt-Svc, `2` never uses it. A QUIC attempt that fails (no UDP path, a middlebox, a server that stopped) falls back to TCP for that origin and stays there. |
 | **Post-quantum TLS** | the stdlib client offers X25519MLKEM768 first and verifies ML-DSA (44/65/87) certificate chains, so a post-quantum server is used as such automatically. `http_client_last_pq c` reports it. |
-| **Connection pooling** | one live connection per `(scheme, host, port)` — the h2 connection is multiplexed, the h1 connection is kept alive and reused. |
+| **Connection pooling** | one live connection per `(scheme, host, port)` — the h2 connection is multiplexed, the h1 connection is kept alive and reused, the h3 connection carries every request as its own QUIC stream. |
 | **TLS session resumption** | tickets are cached per host and offered on the next connection, so a repeat visit skips the certificate and the signature. |
 | **Redirects** | 3xx are followed (up to `max_redirects`); a 303, and a 301/302 on a POST, become a bodyless GET, exactly as browsers do. Relative `Location`s resolve per RFC 3986 §5.2. |
 | **Cookies** | a built-in RFC 6265 jar stores `Set-Cookie` and sends `Cookie` on matching requests. |
@@ -48,6 +49,7 @@ $ `deps/http-client/src/http_client.nu`
 ```nurl
 : *HttpClient c ( http_client_new )
 ( http_client_set_verify c F )          // pinned / self-signed / test servers
+( http_client_set_h3 c 1 )              // QUIC first (0: after Alt-Svc — default; 2: never)
 ( http_client_set_timeout c 5000 )      // per read/write deadline, ms (0 = none)
 ( http_client_set_max_redirects c 3 )
 ( http_client_set_decompress c F )       // leave bodies as the wire carried them
@@ -76,7 +78,7 @@ the `http` server package builds, with `http_client_status`,
 ## Evidence
 
 ```nurl
-( http_client_last_proto c )   // 1 HTTP/1.1, 2 HTTP/2, 0 none yet
+( http_client_last_proto c )   // 1 HTTP/1.1, 2 HTTP/2, 3 HTTP/3, 0 none yet
 ( http_client_last_pq c )      // T when the key exchange was post-quantum
 ```
 
@@ -99,9 +101,11 @@ is complete); when it lands, this facade gains it behind the same
 ## Tests
 
 `./tests/client_test.sh` builds a server on the `http` package and drives
-the facade against it over both plaintext and TLS: protocol selection,
-connection reuse, redirects and the redirect cap, cookies, gzip decoding,
-POST bodies, and post-quantum key exchange. Requires `openssl` (to mint a
+the facade against it over plaintext, TLS (HTTP/2 by ALPN) and QUIC
+(HTTP/3 after Alt-Svc, and QUIC-first): protocol selection, connection
+reuse, redirects and the redirect cap, cookies, gzip decoding, POST
+bodies, post-quantum key exchange, and the fall-back to TCP when no UDP
+listener answers. Requires `openssl` (to mint a
 test certificate) and `curl` (readiness probe).
 
 ## License

--- a/packages/http-client/examples/fetch.nu
+++ b/packages/http-client/examples/fetch.nu
@@ -6,6 +6,7 @@
 // redirects, carries cookies and decodes gzip — none of it configured.
 //
 //   nurlpkg install http-client        # then:  fetch https://example.org/
+//                                      #        fetch --h3 https://cloudflare-quic.com/
 //   # or in a checkout:
 //   ./nurl.sh packages/http-client/examples/fetch.nu /tmp/fetch
 //   /tmp/fetch https://example.org/
@@ -14,6 +15,7 @@ $ `stdlib/std/args.nu`
 $ `../src/http_client.nu`
 
 @ proto_name i p → s {
+    ? == p 3 { ^ `HTTP/3` } {}
     ? == p 2 { ^ `HTTP/2` } {}
     ? == p 1 { ^ `HTTP/1.1` } {}
     ^ `none`
@@ -22,6 +24,7 @@ $ `../src/http_client.nu`
 @ main → i {
     : ArgParser ap ( args_new `fetch` `fetch a URL with the HttpClient facade` )
     ( args_flag ap `insecure` 107 `skip TLS verification` )
+    ( args_flag ap `h3` 51 `try HTTP/3 (QUIC) first instead of waiting for Alt-Svc` )
     ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
     : ( Vec String ) pos ( args_positionals ap )
     ? == ( vec_len [String] pos ) 0 {
@@ -33,6 +36,7 @@ $ `../src/http_client.nu`
 
     : *HttpClient c ( http_client_new )
     ? ( args_present ap `insecure` ) { ( http_client_set_verify c F ) } {}
+    ? ( args_present ap `h3` ) { ( http_client_set_h3 c 1 ) } {}
 
     : ~ i rc 0
     ?? ( http_client_get c ( string_data url ) ) {

--- a/packages/http-client/nurl.toml
+++ b/packages/http-client/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-client"
-version = "0.1.0"
-description = "The unified HTTP client interface for NURL — one dependency for anything that needs to FETCH over HTTP. A single importable facade over the stdlib client stack (pure-NURL TLS 1.3 with post-quantum key exchange and ML-DSA certificates, the HTTP/1.1 keep-alive client, the multiplexed HTTP/2 client, cookies, gzip/deflate): an `HttpClient` that speaks whichever protocol the server offers — HTTP/2 or HTTP/1.1 by ALPN — pools connections per origin, resumes TLS sessions, follows redirects, keeps a cookie jar and decodes compressed bodies, so `( http_client_new )` and `( http_client_get c url )` are a complete client."
+version = "0.2.0"
+description = "The unified HTTP client interface for NURL — one dependency for anything that needs to FETCH over HTTP. A single importable facade over the stdlib client stack (pure-NURL TLS 1.3 with post-quantum key exchange and ML-DSA certificates, the HTTP/1.1 keep-alive client, the multiplexed HTTP/2 client, the HTTP/3-over-QUIC client, cookies, gzip/deflate): an `HttpClient` that speaks whichever protocol the server offers — HTTP/2 or HTTP/1.1 by ALPN, HTTP/3 once Alt-Svc advertises it (or QUIC-first on request) — pools connections per origin, resumes TLS sessions, follows redirects, keeps a cookie jar and decodes compressed bodies, so `( http_client_new )` and `( http_client_get c url )` are a complete client."
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/packages/http-client/src/client.nu
+++ b/packages/http-client/src/client.nu
@@ -22,9 +22,13 @@
 // Protocol selection is automatic and needs nothing configured: an
 // https origin is dialled with ALPN "h2 http/1.1", and whichever the
 // server picks is what the client speaks — HTTP/2 multiplexed over one
-// connection, or HTTP/1.1 with keep-alive. The negotiated protocol and
-// whether the key exchange was post-quantum are readable after each
-// request (`http_client_last_proto` / `http_client_last_pq`).
+// connection, or HTTP/1.1 with keep-alive. A server that advertises
+// HTTP/3 (`Alt-Svc: h3=":443"`) gets the next request over QUIC
+// (`ext/http3_client.nu`), and a QUIC attempt that fails falls back to
+// TCP for that origin (`http_client_set_h3`: 0 follow Alt-Svc — the
+// default, 1 try QUIC first, 2 never). The negotiated protocol (1, 2 or
+// 3) and whether the key exchange was post-quantum are readable after
+// each request (`http_client_last_proto` / `http_client_last_pq`).
 //
 // Memory model: `http_client_new` returns a heap `*HttpClient`; free it
 // with `http_client_free`, which closes every pooled connection. A
@@ -42,6 +46,7 @@ $ `stdlib/ext/http_pure.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_client.nu`
+$ `stdlib/ext/http3_client.nu`
 $ `stdlib/ext/cookies.nu`
 $ `stdlib/ext/compress.nu`
 
@@ -99,9 +104,11 @@ $ `stdlib/ext/compress.nu`
 // ── Pooled origin ─────────────────────────────────────────────────────
 //
 // One live connection per (scheme, host, port). `proto` records what the
-// origin negotiated: 0 nothing yet, 1 HTTP/1.1, 2 HTTP/2. For h2 the
-// pooled connection is the multiplexed H2Client; for h1 it is one idle
-// keep-alive HttpConn, present only while `has_h1` is 1.
+// origin negotiated: 0 nothing yet, 1 HTTP/1.1, 2 HTTP/2, 3 HTTP/3. For
+// h2 the pooled connection is the multiplexed H2Client; for h1 it is one
+// idle keep-alive HttpConn, present only while `has_h1` is 1; for h3 it
+// is the QUIC connection in H3Client, beside whatever TCP connection
+// the origin still holds.
 : HcOrigin {
     String key  // "scheme://host:port"
     String host
@@ -111,6 +118,11 @@ $ `stdlib/ext/compress.nu`
     i has_h2 H2Client h2
     i has_h1 HttpConn h1
     i pq  // 1 = the TLS key exchange for this origin was post-quantum
+    i has_h3 * H3Client h3
+    i alt_h3_port  // the port an Alt-Svc named for h3 (0 none seen)
+    i alt_h3_until  // ... valid until this wall-clock second
+    i h3_failed  // 1 = a QUIC attempt failed here; TCP from now on
+    i pq_tcp  // the TCP connection's post-quantum evidence, kept beside h3's
 }
 
 // ── Client ────────────────────────────────────────────────────────────
@@ -124,8 +136,9 @@ $ `stdlib/ext/compress.nu`
     i decompress  // request + decode gzip/deflate (1) or leave bodies raw (0)
     i body_max  // response body cap in bytes; 0 = unlimited
     String ua
+    i h3_mode  // 0 follow Alt-Svc (default) · 1 try QUIC first · 2 never
     // Evidence from the most recent request.
-    i last_proto  // 1 h1, 2 h2, 0 none yet
+    i last_proto  // 1 h1, 2 h2, 3 h3, 0 none yet
     i last_pq  // 1 = post-quantum key exchange
 }
 
@@ -140,6 +153,7 @@ $ `stdlib/ext/compress.nu`
     = . c decompress 1
     = . c body_max 0
     = . c ua ( string_from `nurl-http-client/0.1` )
+    = . c h3_mode 0
     = . c last_proto 0
     = . c last_pq 0
     ^ c
@@ -173,6 +187,11 @@ $ `stdlib/ext/compress.nu`
 }
 
 // The protocol / key-exchange facts of the most recent request.
+// HTTP/3: 0 (default) use QUIC once an origin's response has advertised
+// it with `Alt-Svc: h3=...`; 1 try QUIC first on every https origin
+// (falling back to TCP when the attempt fails); 2 never.
+@ http_client_set_h3 * HttpClient c i mode → v { = . c h3_mode mode }
+
 @ http_client_last_proto * HttpClient c → i { ^ . c last_proto }
 
 @ http_client_last_pq * HttpClient c → b { ^ != . c last_pq 0 }
@@ -224,6 +243,11 @@ $ `stdlib/ext/compress.nu`
     = . o has_h2 0
     = . o has_h1 0
     = . o pq 0
+    = . o has_h3 0
+    = . o alt_h3_port 0
+    = . o alt_h3_until 0
+    = . o h3_failed 0
+    = . o pq_tcp 0
     ( vec_push [i] . c origins # i o )
     ^ o
 }
@@ -238,7 +262,16 @@ $ `stdlib/ext/compress.nu`
         ( hp_conn_close . o h1 )
         = . o has_h1 0
     } {}
+    ( __hc_origin_drop_h3 o )
     = . o proto 0
+}
+
+@ __hc_origin_drop_h3 * HcOrigin o → v {
+    ? != . o has_h3 0 {
+        ( h3_client_close . o h3 )
+        ( h3_client_free . o h3 )
+        = . o has_h3 0
+    } {}
 }
 
 // ── Establishing a connection for an origin ───────────────────────────
@@ -257,7 +290,7 @@ $ `stdlib/ext/compress.nu`
         ?? tr {
             F e → { ^ ?? e { TlsBadCert → 3 TlsConnect → 1 _ → 3 } }
             T tc → {
-                = . o pq ? ( tls_is_post_quantum tc ) 1 0
+                = . o pq_tcp ? ( tls_is_post_quantum tc ) 1 0
                 : b is_h2 ( tls_alpn_is tc `h2` )
                 ? is_h2 {
                     : TcpConn conn ( tcp_conn_from_tls tc )
@@ -354,17 +387,136 @@ $ `stdlib/ext/compress.nu`
 // Returns the unified HttpResponse or an HttpClientErr. `user` headers
 // are BORROWED-consumed (freed here). `body` is BORROWED.
 @ __hc_do * HttpClient c * HcOrigin o s method s path ( Vec Header ) user ( Vec u ) body → !HttpResponse HttpClientErr {
+    // HTTP/3 first when the origin advertised it (or QUIC-first was asked
+    // for), unless a QUIC attempt already failed here.
+    ? & & != . o is_https 0 != . c h3_mode 2 == . o h3_failed 0 {
+        : b want | == . c h3_mode 1 & > . o alt_h3_port 0 > . o alt_h3_until ( now_seconds )
+        ? & want == . o has_h3 0 { ( __hc_h3_connect c o ) } {}
+        ? & want != . o has_h3 0 {
+            = . c last_proto 3
+            = . c last_pq . o pq
+            : ~ i h3e 0
+            ?? ( __hc_do_h3 c o method path user body ) {
+                T r → { ( __hc_free_headers user ) ^ @ !HttpResponse HttpClientErr { T r } }
+                F e → { = h3e e }
+            }
+            ? == h3e 4 { ( __hc_free_headers user ) ^ @ !HttpResponse HttpClientErr { F # HttpClientErr HcTooLarge } } {}
+            // the connection is gone, timed out, broke or refused the
+            // request: TCP for this origin from now on
+            ( __hc_origin_drop_h3 o )
+            = . o h3_failed 1
+        } {}
+    } {}
     : i ce ( __hc_ensure_conn c o )
     ? != ce 0 {
         ( __hc_free_headers user )
         ^ @ !HttpResponse HttpClientErr { F ( __hc_conn_err ce ) }
     } {}
     = . c last_proto . o proto
-    = . c last_pq . o pq
+    = . c last_pq . o pq_tcp
     ? == . o proto 2 {
         ^ ( __hc_do_h2 c o method path user body )
     } {}
     ^ ( __hc_do_h1 c o method path user body )
+}
+
+// ── HTTP/3 ────────────────────────────────────────────────────────────
+
+// Dial QUIC to the origin (on the Alt-Svc port when one was named). A
+// failed attempt marks the origin TCP-only.
+@ __hc_h3_connect * HttpClient c * HcOrigin o → v {
+    : i port ? > . o alt_h3_port 0 . o alt_h3_port . o port
+    : i tmo ? > . c timeout_ms 0 . c timeout_ms 10000
+    : *H3Client cl ( h3_client_connect ( string_data . o host ) port ( string_data . o host ) . c verify tmo )
+    ? == # i cl 0 { = . o h3_failed 1 ^ } {}
+    ? ! ( h3_client_connected cl ) { ( h3_client_free cl ) = . o h3_failed 1 ^ } {}
+    ? > . c body_max 0 { ( h3_client_set_body_max cl . c body_max ) } {}
+    = . o has_h3 1
+    = . o h3 cl
+    = . o pq ? ( h3_client_is_pq cl ) 1 0
+}
+
+// One request over the origin's QUIC connection. `user` is borrowed —
+// the caller still owns it, so a failure can retry over TCP with the
+// same list. The error is the H3ClientErr code (see ext/http3_client.nu).
+@ __hc_do_h3 * HttpClient c * HcOrigin o s method s path ( Vec Header ) user ( Vec u ) body → !HttpResponse i {
+    : ( Vec Header ) hs ( __hc_clone_headers user )
+    ? ! ( __hc_hlist_has hs `cookie` ) {
+        : String ck ( cookie_jar_header . c jar ( string_data . o host ) path T ( now_seconds ) )
+        ? > ( string_len ck ) 0 { ( vec_push [Header] hs ( header_new `cookie` ( string_data ck ) ) ) } {}
+        ( string_free ck )
+    } {}
+    ? & != . c decompress 0 ! ( __hc_hlist_has hs `accept-encoding` ) {
+        ( vec_push [Header] hs ( header_new `accept-encoding` `gzip, deflate` ) )
+    } {}
+    ? ! ( __hc_hlist_has hs `user-agent` ) {
+        ( vec_push [Header] hs ( header_new `user-agent` ( string_data . c ua ) ) )
+    } {}
+    : i tmo ? > . c timeout_ms 0 . c timeout_ms 60000
+    : !HttpResponse i rr ( h3_client_request . o h3 method `https` ( string_data . o host ) path hs body tmo )
+    ( __hc_free_headers hs )
+    ?? rr {
+        F e → { ^ @ !HttpResponse i { F e } }
+        T resp → {
+            : HttpResponse dec ( __hc_decode_response c resp )
+            ^ @ !HttpResponse i { T dec }
+        }
+    }
+}
+
+// `Alt-Svc` (RFC 7838): remember an h3 alternative on the same host —
+// `h3=":443"; ma=86400` — for the origin; `clear` forgets it. An
+// alternative on another host is not followed (its certificate would
+// have to be checked for THIS origin; the same host is the common case).
+@ __hc_capture_alt_svc * HttpClient c * HcOrigin o HttpResponse r → v {
+    : String v ( __hc_header_value . r headers `alt-svc` )
+    : s av ( string_data v )
+    : i n ( nurl_str_len av )
+    ? == n 0 { ( string_free v ) ^ } {}
+    ? ( _hc_eq_ci av `clear` ) { = . o alt_h3_port 0 ( string_free v ) ^ } {}
+    : ~ i p 0
+    : ~ i found_port 0
+    : ~ i ma 86400
+    : ~ i done 0
+    ~ & == done 0 < p n {
+        // one alternative: proto "=" quoted-authority *( ";" param )
+        ~ & < p n | == ( nurl_str_get av p ) 32 == ( nurl_str_get av p ) 44 { = p + p 1 }
+        : i ps p
+        ~ & < p n != ( nurl_str_get av p ) 61 { = p + p 1 }
+        : i pe p
+        ? >= p n { = done 1 } {
+            = p + p 1
+            : b is_h3 & == - pe ps 2 & == ( nurl_str_get av ps ) 104 == ( nurl_str_get av + ps 1 ) 51
+            // the authority, in quotes: [host]:port
+            : ~ i port 0
+            : ~ i same_host T
+            ? & < p n == ( nurl_str_get av p ) 34 {
+                = p + p 1
+                ? & < p n != ( nurl_str_get av p ) 58 { = same_host F } {}
+                ~ & < p n != ( nurl_str_get av p ) 58 { = p + p 1 }
+                ? < p n { = p + p 1 } {}
+                ~ & < p n & >= ( nurl_str_get av p ) 48 <= ( nurl_str_get av p ) 57 { = port + * port 10 - ( nurl_str_get av p ) 48 = p + p 1 }
+                ~ & < p n != ( nurl_str_get av p ) 34 { = p + p 1 }
+                ? < p n { = p + p 1 } {}
+            } {}
+            // parameters up to the next comma: ma=N is the one we read
+            : ~ i this_ma 86400
+            ~ & < p n != ( nurl_str_get av p ) 44 {
+                ? & == ( nurl_str_get av p ) 109 & < + p 2 n & == ( nurl_str_get av + p 1 ) 97 == ( nurl_str_get av + p 2 ) 61 {
+                    = p + p 3
+                    : ~ i mv 0
+                    ~ & < p n & >= ( nurl_str_get av p ) 48 <= ( nurl_str_get av p ) 57 { = mv + * mv 10 - ( nurl_str_get av p ) 48 = p + p 1 }
+                    = this_ma mv
+                } { = p + p 1 }
+            }
+            ? is_h3 { ? same_host { ? & > port 0 == found_port 0 { = found_port port = ma this_ma } {} } {} } {}
+        }
+    }
+    ? > found_port 0 {
+        = . o alt_h3_port found_port
+        = . o alt_h3_until + ( now_seconds ) ma
+    } {}
+    ( string_free v )
 }
 
 @ __hc_free_headers ( Vec Header ) user → v {
@@ -439,6 +591,9 @@ $ `stdlib/ext/compress.nu`
     } {}
     ? & != . c decompress 0 ! ( __hc_hlist_has hs `accept-encoding` ) {
         ( vec_push [Header] hs ( header_new `accept-encoding` `gzip, deflate` ) )
+    } {}
+    ? ! ( __hc_hlist_has hs `user-agent` ) {
+        ( vec_push [Header] hs ( header_new `user-agent` ( string_data . c ua ) ) )
     } {}
     : ( Vec u ) bcopy ( vec_new [u] )
     ( bytes_extend_bytes bcopy body )
@@ -628,6 +783,7 @@ $ `stdlib/ext/compress.nu`
                         }
                         T resp → {
                             ( __hc_capture_cookies c resp ( string_data . u host ) ( string_data tgt ) )
+                            ? != . o is_https 0 { ( __hc_capture_alt_svc c o resp ) } {}
                             : i sc . resp status
                             : String loc ( __hc_header_value . resp headers `location` )
                             : b redir & & != . c follow 0 ( __hc_is_redirect sc ) > ( string_len loc ) 0

--- a/packages/http-client/tests/client.nu
+++ b/packages/http-client/tests/client.nu
@@ -28,7 +28,7 @@ $ `../src/http_client.nu`
 }
 
 // GET `path`, assert status and that the body contains `want` (or "" to
-// skip the body check). `proto_want` 0 = any, else 1 h1 / 2 h2.
+// skip the body check). `proto_want` 0 = any, else 1 h1 / 2 h2 / 3 h3.
 @ check_get * HttpClient c s name s scheme i port s path i status_want s want i proto_want → v {
     : String url ( base scheme port path )
     ?? ( http_client_get c ( string_data url ) ) {
@@ -56,6 +56,9 @@ $ `../src/http_client.nu`
 @ run i http_port i https_port → v {
     : *HttpClient c ( http_client_new )
     ( http_client_set_verify c F )  // self-signed test cert
+    // TCP only for this client: the TLS server advertises HTTP/3 with
+    // Alt-Svc, and these checks are about h1 / h2
+    ( http_client_set_h3 c 2 )
 
     // ── plaintext HTTP/1.1 ──
     ( check_get c `h1_root` `http` http_port `/` 200 `root` 1 )
@@ -125,6 +128,53 @@ $ `../src/http_client.nu`
     } {}
 
     ( http_client_free c )
+
+    ? > https_port 0 {
+        // ── HTTP/3 by Alt-Svc (the default): the first request goes over
+        // TCP (h2) and brings `Alt-Svc: h3=":port"`; the next one is QUIC ──
+        : *HttpClient a ( http_client_new )
+        ( http_client_set_verify a F )
+        ( check_get a `altsvc_first_h2` `https` https_port `/` 200 `root` 2 )
+        ( check_get a `altsvc_then_h3` `https` https_port `/dest` 200 `arrived` 3 )
+        ? ( http_client_last_pq a ) { ( ok `h3_post_quantum` ) } { ( bad `h3_post_quantum` `classical kx` ) }
+        ( check_get a `h3_reuse` `https` https_port `/` 200 `root` 3 )
+        ( check_get a `h3_gzip` `https` https_port `/gzip` 200 `lazy dog` 3 )
+        ( check_get a `h3_redirect` `https` https_port `/redir1` 200 `arrived` 3 )
+        : String s3 ( base `https` https_port `/setcookie` )
+        ?? ( http_client_get a ( string_data s3 ) ) { T r → ( http_response_free r ) F _ → {} }
+        ( string_free s3 )
+        ( check_get a `h3_cookie` `https` https_port `/readcookie` 200 `sid=abc123` 3 )
+        ( check_get a `h3_user_agent` `https` https_port `/ua` 200 `nurl-http-client` 3 )
+        : String e3 ( base `https` https_port `/echo` )
+        : ( Vec u ) b3 ( bytes_from_str `hello-h3-post` )
+        ?? ( http_client_post a ( string_data e3 ) b3 `text/plain` ) {
+            T r → {
+                : String b ( http_client_body_str r )
+                ? & != 0 ( nurl_str_eq ( string_data b ) `hello-h3-post` ) == ( http_client_last_proto a ) 3 { ( ok `h3_post_echo` ) } { ( bad `h3_post_echo` ( string_data b ) ) }
+                ( string_free b ) ( http_response_free r )
+            }
+            F e → { ( bad `h3_post_echo` ( http_client_err_name e ) ) }
+        }
+        ( vec_free [u] b3 )
+        ( string_free e3 )
+        ( http_client_free a )
+
+        // ── QUIC first: no Alt-Svc needed, the first request is HTTP/3 ──
+        : *HttpClient q ( http_client_new )
+        ( http_client_set_verify q F )
+        ( http_client_set_h3 q 1 )
+        ( check_get q `quic_first_h3` `https` https_port `/` 200 `root` 3 )
+        ( http_client_free q )
+
+        // ── QUIC first against a port with no UDP listener: falls back to
+        // TCP and stays there ──
+        : *HttpClient f ( http_client_new )
+        ( http_client_set_verify f F )
+        ( http_client_set_h3 f 1 )
+        ( http_client_set_timeout f 1500 )
+        ( check_get f `quic_fallback_plain` `http` http_port `/` 200 `root` 1 )
+        ( http_client_free f )
+    } {}
 }
 
 @ main → i {

--- a/packages/http-client/tests/server.nu
+++ b/packages/http-client/tests/server.nu
@@ -130,8 +130,8 @@ $ `../../http/src/http.nu`
 
     : *HttpApp a ( http_app_new )
     ( http_app_quiet a )
-    // Keep the test hermetic: no UDP/QUIC twin, no Alt-Svc.
-    ( http_app_set_http3 a 0 )
+    // The TLS listener keeps its UDP/QUIC twin and its Alt-Svc: the
+    // client's HTTP/3 path is driven against it.
     ( routes a )
 
     : ~ i rc 0

--- a/stdlib/ext/http3_client.nu
+++ b/stdlib/ext/http3_client.nu
@@ -1,0 +1,591 @@
+// stdlib/ext/http3_client.nu — HTTP/3 (RFC 9114) CLIENT over one QUIC
+// connection (`std/quic_client.nu`): the mirror of `ext/http3_conn.nu`,
+// which drives the server half. Our control and QPACK streams open at
+// connect, a request is one bidirectional stream (HEADERS, DATA, FIN),
+// the response comes back the same way and is handed over as the
+// `HttpResponse` the HTTP/1.1 and HTTP/2 clients produce.
+//
+//   ( h3_client_connect host port server_name verify timeout_ms ) → *H3Client
+//                                            0 when the name does not resolve or no socket could be
+//                                            bound; otherwise `h3_client_connected` says whether the
+//                                            QUIC handshake completed (with ALPN "h3") and
+//                                            `h3_client_close_code` why not
+//   ( h3_client_connected cl )            → b
+//   ( h3_client_alive cl )                → b     still usable for requests (not closing, no GOAWAY, no failure)
+//   ( h3_client_is_pq cl )                → b     the key exchange was X25519MLKEM768
+//   ( h3_client_close_code cl )           → i     the QUIC close code (-1 none)
+//   ( h3_client_request cl method scheme authority path headers body timeout_ms )
+//                                         → !HttpResponse i   OWNED response; the error is an
+//                                            H3ClientErr code: 1 not connected / connection gone ·
+//                                            2 timed out · 3 protocol error (the connection is closed
+//                                            with the HTTP/3 code) · 4 response too large · 5 refused
+//                                            (the server's GOAWAY or a stream reset)
+//   ( h3_client_close cl )                → v     H3_NO_ERROR application close, driven to the peer
+//   ( h3_client_free cl )                 → v
+//   ( h3_client_set_body_max cl n )       → v     response body cap (default 64 MiB)
+//   ( h3_client_last_refusal cl )         → i     the HTTP/3 code of the server's last stream reset (-1 none)
+//
+// `headers` is BORROWED (the caller keeps it); pseudo-headers are
+// added here; hop-by-hop fields are dropped (§4.2); names go on the
+// wire lower-case. `body` is BORROWED. One request at a time — the
+// facade serialises its requests, like it does on HTTP/2.
+//
+// Server push is never enabled (no MAX_PUSH_ID); a push stream is a
+// connection error, as the RFC says. QPACK runs with a zero-size
+// dynamic table both ways (this endpoint advertises 0 and never inserts).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/quic_varint.nu`
+$ `stdlib/std/quic_tp.nu`
+$ `stdlib/std/quic_conn.nu`
+$ `stdlib/std/quic_client.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http3_frame.nu`
+$ `stdlib/ext/http3_qpack.nu`
+
+: H3CStream {
+    i id
+    i kind  // 0 request · 1 control · 3 QPACK encoder · 4 QPACK decoder · 5 ignored · -1 unknown yet
+    ( Vec u ) buf
+    i state  // request: 0 awaiting HEADERS · 1 headers seen · 2 trailers seen
+    i status
+    ( Vec Header ) headers
+    ( Vec u ) body
+    i done
+    i err  // H3ClientErr code once the stream failed (0 none)
+}
+
+: H3Client {
+    * QuicClient qc
+    * QuicConn c
+    ( Vec i ) streams
+    i ctl_out
+    i enc_out
+    i dec_out
+    i peer_control
+    i peer_qenc
+    i peer_qdec
+    i peer_settings
+    i max_field_section
+    i body_max
+    i failed
+    i goaway_id  // the server's GOAWAY: request streams ≥ this were not processed (-1 none)
+    i last_refusal  // the HTTP/3 code of the last RESET_STREAM / STOP_SENDING the server sent on a request (-1 none)
+}
+
+@ h3c_default_max_field_section → i { ^ 65536 }
+
+@ h3_client_err_name i e → s {
+    ? == e 1 { ^ `H3NotConnected` } {}
+    ? == e 2 { ^ `H3Timeout` } {}
+    ? == e 3 { ^ `H3Protocol` } {}
+    ? == e 4 { ^ `H3TooLarge` } {}
+    ? == e 5 { ^ `H3Refused` } {}
+    ^ `H3Ok`
+}
+
+@ __h3c_stream_new i id i kind → *H3CStream {
+    : *H3CStream s # *H3CStream ( nurl_alloc Z H3CStream )
+    = . s id id
+    = . s kind kind
+    = . s buf ( vec_new [u] )
+    = . s state 0
+    = . s status 0
+    = . s headers ( vec_new [Header] )
+    = . s body ( vec_new [u] )
+    = . s done 0
+    = . s err 0
+    ^ s
+}
+
+@ __h3c_stream_free * H3CStream s → v {
+    ( vec_free [u] . s buf )
+    ( vec_free_with [Header] . s headers \ Header hh → v { ( header_free hh ) } )
+    ( vec_free [u] . s body )
+    ( nurl_free # s s )
+}
+
+@ __h3c_ri ( Vec i ) v i k → i {
+    ?? ( vec_get [i] v k ) { T x → x F → 0 }
+}
+
+@ __h3c_stream_get * H3Client h i id → *H3CStream {
+    : ~ i k 0
+    ~ < k ( vec_len [i] . h streams ) {
+        : *H3CStream s # *H3CStream ( __h3c_ri . h streams k )
+        ? == . s id id { ^ s } {}
+        = k + k 1
+    }
+    ^ # *H3CStream 0
+}
+
+@ __h3c_stream_drop * H3Client h i id → v {
+    : ( Vec i ) keep ( vec_new [i] )
+    : ~ i k 0
+    ~ < k ( vec_len [i] . h streams ) {
+        : *H3CStream s # *H3CStream ( __h3c_ri . h streams k )
+        ? == . s id id { ( __h3c_stream_free s ) } { ( vec_push [i] keep # i s ) }
+        = k + k 1
+    }
+    ( vec_free [i] . h streams )
+    = . h streams keep
+}
+
+// A connection error: close with the HTTP/3 code (application close).
+@ __h3c_fail * H3Client h i code → v {
+    ? != . h failed 0 { ^ } {}
+    = . h failed 1
+    : ( Vec u ) reason ( vec_new [u] )
+    ( quic_conn_close . h c 1 code reason )
+    ( vec_free [u] reason )
+    ( quic_client_pump . h qc )
+}
+
+// The transport parameters an HTTP/3 client advertises: the server may
+// open no bidirectional stream (§6.1) and three unidirectional ones
+// (control + 2 QPACK).
+@ __h3c_tp → *QuicTp {
+    : *QuicTp tp ( quic_client_default_tp )
+    = . tp initial_max_streams_bidi 0
+    = . tp initial_max_streams_uni 3
+    ^ tp
+}
+
+@ h3_client_connect s host i port s server_name i verify i timeout_ms → *H3Client {
+    : *QuicTp tp ( __h3c_tp )
+    : *QuicClient qc ( quic_client_connect host port server_name `h3` tp verify timeout_ms )
+    ( quic_tp_free tp )
+    ? == # i qc 0 { ^ # *H3Client 0 } {}
+    : *H3Client h # *H3Client ( nurl_alloc Z H3Client )
+    = . h qc qc
+    = . h c ( quic_client_conn qc )
+    = . h streams ( vec_new [i] )
+    = . h ctl_out -1
+    = . h enc_out -1
+    = . h dec_out -1
+    = . h peer_control -1
+    = . h peer_qenc -1
+    = . h peer_qdec -1
+    = . h peer_settings 0
+    = . h max_field_section ( h3c_default_max_field_section )
+    = . h body_max 67108864
+    = . h failed 0
+    = . h goaway_id -1
+    = . h last_refusal -1
+    ? ( quic_client_connected qc ) {
+        // our unidirectional streams: control (type 0x00 + SETTINGS),
+        // QPACK encoder (0x02) and decoder (0x03), each just its type byte
+        : *QuicConn c . h c
+        = . h ctl_out ( quic_conn_open_uni c )
+        = . h enc_out ( quic_conn_open_uni c )
+        = . h dec_out ( quic_conn_open_uni c )
+        ? >= . h ctl_out 0 {
+            : ( Vec u ) cb ( vec_new [u] )
+            ( quic_varint_push cb ( h3_st_control ) )
+            ( h3_push_settings cb ( h3c_default_max_field_section ) )
+            : i _n ( quic_conn_stream_send c . h ctl_out cb F )
+            ( vec_free [u] cb )
+        } {}
+        ? >= . h enc_out 0 {
+            : ( Vec u ) e ( vec_new [u] )
+            ( quic_varint_push e ( h3_st_qpack_encoder ) )
+            : i _n ( quic_conn_stream_send c . h enc_out e F )
+            ( vec_free [u] e )
+        } {}
+        ? >= . h dec_out 0 {
+            : ( Vec u ) d ( vec_new [u] )
+            ( quic_varint_push d ( h3_st_qpack_decoder ) )
+            : i _n ( quic_conn_stream_send c . h dec_out d F )
+            ( vec_free [u] d )
+        } {}
+        ( quic_client_pump qc )
+    } {}
+    ^ h
+}
+
+@ h3_client_connected * H3Client h → b { ^ ( quic_client_connected . h qc ) }
+
+@ h3_client_alive * H3Client h → b {
+    ? != . h failed 0 { ^ F } {}
+    ? >= . h goaway_id 0 { ^ F } {}
+    ^ == ( quic_conn_state . h c ) 1
+}
+
+@ h3_client_is_pq * H3Client h → b { ^ ( quic_conn_is_pq . h c ) }
+
+@ h3_client_close_code * H3Client h → i { ^ ( quic_conn_close_code . h c ) }
+
+@ h3_client_set_body_max * H3Client h i n → v { = . h body_max n }
+
+// The HTTP/3 error code of the server's last RESET_STREAM / STOP_SENDING
+// on a request stream (-1 none) — why a request was refused.
+@ h3_client_last_refusal * H3Client h → i { ^ . h last_refusal }
+
+@ h3_client_close * H3Client h → v {
+    ? >= ( quic_conn_state . h c ) 2 { ^ } {}
+    : ( Vec u ) reason ( vec_new [u] )
+    ( quic_client_close . h qc 1 ( h3_err_no_error ) reason 500 )
+    ( vec_free [u] reason )
+}
+
+@ h3_client_free * H3Client h → v {
+    ? == # i h 0 { ^ } {}
+    : ~ i k 0
+    ~ < k ( vec_len [i] . h streams ) {
+        ( __h3c_stream_free # *H3CStream ( __h3c_ri . h streams k ) )
+        = k + k 1
+    }
+    ( vec_free [i] . h streams )
+    ( quic_client_free . h qc )
+    ( nurl_free # s h )
+}
+
+// ── the request ──────────────────────────────────────────────────
+
+@ __h3c_eq_ci s a s b → b {
+    : i n ( nurl_str_len a )
+    ? != n ( nurl_str_len b ) { ^ F } {}
+    : ~ i k 0
+    ~ < k n {
+        : ~ i x ( nurl_str_get a k )
+        : ~ i y ( nurl_str_get b k )
+        ? & >= x 65 <= x 90 { = x + x 32 } {}
+        ? & >= y 65 <= y 90 { = y + y 32 } {}
+        ? != x y { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+// The request's field section: pseudo-headers first (§4.3.1), then the
+// caller's fields lower-cased, hop-by-hop ones left out (§4.2).
+@ __h3c_request_block s method s scheme s authority s path ( Vec Header ) headers → ( Vec u ) {
+    : ( Vec Header ) all ( vec_new [Header] )
+    ( vec_push [Header] all ( header_new `:method` method ) )
+    ( vec_push [Header] all ( header_new `:scheme` scheme ) )
+    ( vec_push [Header] all ( header_new `:authority` authority ) )
+    ( vec_push [Header] all ( header_new `:path` path ) )
+    : i nh ( vec_len [Header] headers )
+    : *Header hp ( vec_data [Header] headers )
+    : ~ i k 0
+    ~ < k nh {
+        : Header hh . hp k
+        : s nm ( string_data . hh name )
+        : b hop | | | | | ( __h3c_eq_ci nm `connection` ) ( __h3c_eq_ci nm `transfer-encoding` ) ( __h3c_eq_ci nm `keep-alive` ) ( __h3c_eq_ci nm `proxy-connection` ) ( __h3c_eq_ci nm `upgrade` ) ( __h3c_eq_ci nm `host` )
+        ? hop {} {
+            : i ln ( nurl_str_len nm )
+            : String lower ( string_with_cap ln )
+            : ~ i j 0
+            ~ < j ln {
+                : i ch ( nurl_str_get nm j )
+                ( string_push_char lower ? & >= ch 65 <= ch 90 + ch 32 ch )
+                = j + j 1
+            }
+            ( vec_push [Header] all ( header_new ( string_data lower ) ( string_data . hh value ) ) )
+            ( string_free lower )
+        }
+        = k + k 1
+    }
+    : ( Vec u ) block ( qpack_encode_section all )
+    ( vec_free_with [Header] all \ Header hh → v { ( header_free hh ) } )
+    ^ block
+}
+
+// Leading decimal digits of `s`, -1 when there are none.
+@ __h3c_int s v → i {
+    : i n ( nurl_str_len v )
+    : ~ i out 0
+    : ~ i k 0
+    : ~ i any 0
+    ~ < k n {
+        : i ch ( nurl_str_get v k )
+        ? & >= ch 48 <= ch 57 { = out + * out 10 - ch 48 = any 1 } { = k n }
+        = k + k 1
+    }
+    ^ ? == any 1 out -1
+}
+
+// One frame of the response stream; F when the loop must stop.
+@ __h3c_response_frame * H3Client h * H3CStream s b fin * H3FrameHead fh → b {
+    : i ft . fh ftype
+    : i flen . fh length
+    : i hl . fh head_len
+    ( h3_frame_head_free fh )
+    ? | | | == ft ( h3_ft_settings ) == ft ( h3_ft_goaway ) == ft ( h3_ft_max_push_id ) == ft ( h3_ft_cancel_push ) { ( __h3c_fail h ( h3_err_frame_unexpected ) ) = . s err 3 ^ F } {}
+    // PUSH_PROMISE with push never enabled (§7.2.5)
+    ? == ft ( h3_ft_push_promise ) { ( __h3c_fail h ( h3_err_id_error ) ) = . s err 3 ^ F } {}
+    ? & == ft ( h3_ft_data ) == . s state 0 { ( __h3c_fail h ( h3_err_frame_unexpected ) ) = . s err 3 ^ F } {}
+    ? > flen + ( h3c_default_max_field_section ) . h body_max { ( __h3c_fail h ( h3_err_excessive_load ) ) = . s err 4 ^ F } {}
+    : i have - ( vec_len [u] . s buf ) hl
+    ? < have flen {
+        ? fin { ( __h3c_fail h ( h3_err_frame_error ) ) = . s err 3 } {}
+        ^ F
+    } {}
+    : ( Vec u ) payload ( bytes_slice . s buf hl + hl flen )
+    : ( Vec u ) rest ( bytes_slice . s buf + hl flen ( vec_len [u] . s buf ) )
+    ( vec_free [u] . s buf )
+    = . s buf rest
+    ? == ft ( h3_ft_headers ) {
+        ? == . s state 2 { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_frame_unexpected ) ) = . s err 3 ^ F } {}
+        ? > flen . h max_field_section { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_excessive_load ) ) = . s err 4 ^ F } {}
+        ?? ( qpack_decode_section payload ) {
+            T hs → {
+                ? == . s state 0 {
+                    // :status first (§4.3.2); the rest are the response's fields
+                    : ~ i st -1
+                    : ~ i bad 0
+                    : i nh ( vec_len [Header] hs )
+                    : *Header hp ( vec_data [Header] hs )
+                    : ~ i k 0
+                    ~ < k nh {
+                        : Header hh . hp k
+                        : s nm ( string_data . hh name )
+                        ? & > ( nurl_str_len nm ) 0 == ( nurl_str_get nm 0 ) 58 {
+                            ? != 0 ( nurl_str_eq nm `:status` ) {
+                                ? | >= st 0 != k 0 { = bad 1 } { = st ( __h3c_int ( string_data . hh value ) ) }
+                            } { = bad 1 }
+                        } {
+                            ( vec_push [Header] . s headers ( header_new nm ( string_data . hh value ) ) )
+                        }
+                        = k + k 1
+                    }
+                    ( vec_free_with [Header] hs \ Header hh → v { ( header_free hh ) } )
+                    ? | != bad 0 | < st 100 > st 999 { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_message_error ) ) = . s err 3 ^ F } {}
+                    // 1xx interim responses: another HEADERS follows (§4.1)
+                    ? < st 200 {
+                        ( vec_free_with [Header] . s headers \ Header hh → v { ( header_free hh ) } )
+                        = . s headers ( vec_new [Header] )
+                    } {
+                        = . s status st
+                        = . s state 1
+                    }
+                } {
+                    // trailers: accepted, not surfaced
+                    ( vec_free_with [Header] hs \ Header hh → v { ( header_free hh ) } )
+                    = . s state 2
+                }
+            }
+            F code → { ( vec_free [u] payload ) ( __h3c_fail h code ) = . s err 3 ^ F }
+        }
+    } {
+        ? == ft ( h3_ft_data ) {
+            ? == . s state 2 { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_frame_unexpected ) ) = . s err 3 ^ F } {}
+            ? > + ( vec_len [u] . s body ) flen . h body_max {
+                ( vec_free [u] payload )
+                = . s err 4
+                ( quic_conn_stream_stop_sending . h c . s id ( h3_err_excessive_load ) )
+                = . s done 1
+                ^ F
+            } {}
+            ( bytes_extend_bytes . s body payload )
+        } {}
+        // reserved / unknown types: skipped (§7.2.8, §9)
+    }
+    ( vec_free [u] payload )
+    ^ T
+}
+
+@ __h3c_response_stream * H3Client h * H3CStream s b fin → v {
+    : ~ b more T
+    ~ & & more == . s done 0 == . h failed 0 {
+        : *H3FrameHead fh ( h3_frame_peek . s buf 0 )
+        ? == # i fh 0 {
+            ? & fin > ( vec_len [u] . s buf ) 0 { ( __h3c_fail h ( h3_err_frame_error ) ) = . s err 3 } {}
+            = more F
+        } {
+            ? ! ( __h3c_response_frame h s fin fh ) { = more F } {}
+        }
+    }
+    ? & & fin == . s done 0 == . h failed 0 {
+        ? == ( vec_len [u] . s buf ) 0 {
+            ? >= . s state 1 { = . s done 1 } { = . s err 3 = . s done 1 }
+        } {}
+    } {}
+}
+
+// ── the server's unidirectional streams ─────────────────────────
+
+@ __h3c_control_stream * H3Client h * H3CStream s b fin → v {
+    ~ & == . h failed 0 T {
+        : *H3FrameHead fh ( h3_frame_peek . s buf 0 )
+        ? == # i fh 0 { ? fin { ( __h3c_fail h ( h3_err_closed_critical_stream ) ) } {} ^ } {}
+        : i ft . fh ftype
+        : i flen . fh length
+        : i hl . fh head_len
+        ( h3_frame_head_free fh )
+        ? & == . h peer_settings 0 != ft ( h3_ft_settings ) { ? ( h3_type_is_reserved ft ) {} { ( __h3c_fail h ( h3_err_missing_settings ) ) ^ } } {}
+        ? & != . h peer_settings 0 == ft ( h3_ft_settings ) { ( __h3c_fail h ( h3_err_frame_unexpected ) ) ^ } {}
+        ? | | | == ft ( h3_ft_data ) == ft ( h3_ft_headers ) == ft ( h3_ft_push_promise ) == ft ( h3_ft_max_push_id ) { ( __h3c_fail h ( h3_err_frame_unexpected ) ) ^ } {}
+        ? > flen 65536 { ( __h3c_fail h ( h3_err_excessive_load ) ) ^ } {}
+        : i have - ( vec_len [u] . s buf ) hl
+        ? < have flen { ? fin { ( __h3c_fail h ( h3_err_closed_critical_stream ) ) } {} ^ } {}
+        : ( Vec u ) payload ( bytes_slice . s buf hl + hl flen )
+        : ( Vec u ) rest ( bytes_slice . s buf + hl flen ( vec_len [u] . s buf ) )
+        ( vec_free [u] . s buf )
+        = . s buf rest
+        ? == ft ( h3_ft_settings ) {
+            : i bad ( h3_settings_parse payload )
+            ? != bad 0 { ( vec_free [u] payload ) ( __h3c_fail h bad ) ^ } {}
+            = . h peer_settings 1
+            : i mfs ( h3_settings_get payload ( h3_setting_max_field_section_size ) )
+            ? > mfs 0 { ? < mfs . h max_field_section { = . h max_field_section mfs } {} } {}
+        } {}
+        ? == ft ( h3_ft_goaway ) {
+            // the server is going away: the id names the first request
+            // stream it did not process (§5.2); it may only go down
+            : i gid ( quic_varint_read payload 0 )
+            ? | < gid 0 != & gid 3 0 { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_id_error ) ) ^ } {}
+            ? & >= . h goaway_id 0 > gid . h goaway_id { ( vec_free [u] payload ) ( __h3c_fail h ( h3_err_id_error ) ) ^ } {}
+            = . h goaway_id gid
+        } {}
+        // CANCEL_PUSH, reserved, unknown: nothing to do
+        ( vec_free [u] payload )
+    }
+}
+
+@ __h3c_qpack_stream * H3Client h * H3CStream s b fin b encoder → v {
+    ~ & == . h failed 0 > ( vec_len [u] . s buf ) 0 {
+        : i r ? encoder ( qpack_encoder_instruction . s buf 0 ) ( qpack_decoder_instruction . s buf 0 )
+        ? == r -1 { ? fin { ( __h3c_fail h ( h3_err_closed_critical_stream ) ) } {} ^ } {}
+        ? == r -2 { ( __h3c_fail h ? encoder ( qpack_err_encoder_stream ) ( qpack_err_decoder_stream ) ) ^ } {}
+        : ( Vec u ) rest ( bytes_slice . s buf r ( vec_len [u] . s buf ) )
+        ( vec_free [u] . s buf )
+        = . s buf rest
+    }
+    ? & fin == . h failed 0 { ( __h3c_fail h ( h3_err_closed_critical_stream ) ) } {}
+}
+
+// Classify a server unidirectional stream by its first varint (§6.2).
+@ __h3c_classify * H3Client h * H3CStream s → v {
+    : i t ( quic_varint_read . s buf 0 )
+    ? < t 0 { ^ } {}
+    : i tl ( quic_varint_len_at . s buf 0 )
+    : ( Vec u ) rest ( bytes_slice . s buf tl ( vec_len [u] . s buf ) )
+    ( vec_free [u] . s buf )
+    = . s buf rest
+    ? == t ( h3_st_control ) {
+        ? >= . h peer_control 0 { ( __h3c_fail h ( h3_err_stream_creation ) ) ^ } {}
+        = . h peer_control . s id
+        = . s kind 1
+        ^
+    } {}
+    ? == t ( h3_st_qpack_encoder ) {
+        ? >= . h peer_qenc 0 { ( __h3c_fail h ( h3_err_stream_creation ) ) ^ } {}
+        = . h peer_qenc . s id
+        = . s kind 3
+        ^
+    } {}
+    ? == t ( h3_st_qpack_decoder ) {
+        ? >= . h peer_qdec 0 { ( __h3c_fail h ( h3_err_stream_creation ) ) ^ } {}
+        = . h peer_qdec . s id
+        = . s kind 4
+        ^
+    } {}
+    // a push stream with push never enabled (§6.2.2)
+    ? == t ( h3_st_push ) { ( __h3c_fail h ( h3_err_id_error ) ) ^ } {}
+    = . s kind 5
+    ( vec_clear [u] . s buf )
+    ( quic_conn_stream_stop_sending . h c . s id ( h3_err_stream_creation ) )
+}
+
+// Everything that arrived on stream `id`.
+@ __h3c_on_stream * H3Client h i id → v {
+    : *QuicConn c . h c
+    : ~ * H3CStream s ( __h3c_stream_get h id )
+    : b uni != & id 2 0
+    ? == # i s 0 {
+        // a server-initiated bidirectional stream cannot exist (§6.1) —
+        // the transport limit is 0, so the connection has failed already
+        ? ! uni { ^ } {}
+        = s ( __h3c_stream_new id -1 )
+        ( vec_push [i] . h streams # i s )
+    } {}
+    ? != . s done 0 { ^ } {}
+    ? >= ( quic_conn_stream_reset_err c id ) 0 {
+        ? | == . s kind 1 | == . s kind 3 == . s kind 4 { ( __h3c_fail h ( h3_err_closed_critical_stream ) ) ^ } {}
+        ? == . s kind 0 { = . h last_refusal ( quic_conn_stream_reset_err c id ) = . s err 5 = . s done 1 ^ } {}
+        ( __h3c_stream_drop h id )
+        ^
+    } {}
+    ? & == . s kind 0 >= ( quic_conn_stream_stop_err c id ) 0 { = . h last_refusal ( quic_conn_stream_stop_err c id ) = . s err 5 = . s done 1 ^ } {}
+    : ~ b more T
+    ~ more {
+        : ( Vec u ) d ( quic_conn_stream_recv c id 65536 )
+        ? == ( vec_len [u] d ) 0 { = more F } {
+            ? == . s kind 5 {} { ( bytes_extend_bytes . s buf d ) }
+        }
+        ( vec_free [u] d )
+    }
+    : b fin ( quic_conn_stream_fin c id )
+    ? == . s kind -1 { ( __h3c_classify h s ) } {}
+    ? == . h failed 0 {
+        ? == . s kind 0 { ( __h3c_response_stream h s fin ) } {}
+        ? == . s kind 1 { ( __h3c_control_stream h s fin ) } {}
+        ? == . s kind 3 { ( __h3c_qpack_stream h s fin T ) } {}
+        ? == . s kind 4 { ( __h3c_qpack_stream h s fin F ) } {}
+    } {}
+    ? & == . s kind 5 fin { ( __h3c_stream_drop h id ) } {}
+}
+
+@ __h3c_now → i { ^ / ( monotonic_ns ) 1000000 }
+
+@ h3_client_request * H3Client h s method s scheme s authority s path ( Vec Header ) headers ( Vec u ) body i timeout_ms → !HttpResponse i {
+    ? ! ( h3_client_alive h ) { ^ @ !HttpResponse i { F 1 } } {}
+    : *QuicConn c . h c
+    : i sid ( quic_conn_open_bidi c )
+    ? < sid 0 { ^ @ !HttpResponse i { F 1 } } {}
+    : *H3CStream s ( __h3c_stream_new sid 0 )
+    ( vec_push [i] . h streams # i s )
+    : ( Vec u ) block ( __h3c_request_block method scheme authority path headers )
+    : ( Vec u ) wire ( vec_new [u] )
+    ( h3_push_frame wire ( h3_ft_headers ) block )
+    ( vec_free [u] block )
+    ? > ( vec_len [u] body ) 0 { ( h3_push_frame wire ( h3_ft_data ) body ) } {}
+    : i _n ( quic_conn_stream_send c sid wire T )
+    ( vec_free [u] wire )
+    ( quic_client_pump . h qc )
+    // drive the connection until the response is complete
+    : i deadline + ( __h3c_now ) timeout_ms
+    : ~ i err 0
+    ~ & & == . s done 0 == err 0 == . h failed 0 {
+        : i now ( __h3c_now )
+        ? >= now deadline { = err 2 } {
+            ? ( quic_client_wait_readable . h qc - deadline now ) {
+                : ( Vec i ) ids ( quic_conn_take_readable c )
+                : ~ i k 0
+                ~ & < k ( vec_len [i] ids ) == . h failed 0 {
+                    ( __h3c_on_stream h ( __h3c_ri ids k ) )
+                    = k + k 1
+                }
+                ( vec_free [i] ids )
+                ( quic_client_pump . h qc )
+            } {
+                ? >= ( quic_conn_state c ) 2 { = err 1 } {}
+            }
+        }
+    }
+    ? & == err 0 != . h failed 0 { = err 3 } {}
+    ? & == err 0 != . s err 0 { = err . s err } {}
+    // a GOAWAY that names this stream or an earlier one: not processed
+    ? & == err 0 & >= . h goaway_id 0 >= sid . h goaway_id { ? == . s state 0 { = err 5 } {} } {}
+    ? != err 0 {
+        ? == ( quic_conn_state c ) 1 { ( quic_conn_stream_reset c sid ( h3_err_request_cancelled ) ) ( quic_conn_stream_stop_sending c sid ( h3_err_request_cancelled ) ) ( quic_client_pump . h qc ) } {}
+        ( quic_conn_stream_done c sid )
+        ( __h3c_stream_drop h sid )
+        ^ @ !HttpResponse i { F err }
+    } {}
+    : HttpResponse r ( response_new . s status )
+    ( vec_free [Header] . r headers )
+    = . r headers . s headers
+    = . s headers ( vec_new [Header] )
+    ( vec_free [u] . r body )
+    = . r body . s body
+    = . s body ( vec_new [u] )
+    ( quic_conn_stream_done c sid )
+    ( __h3c_stream_drop h sid )
+    ^ @ !HttpResponse i { T r }
+}

--- a/stdlib/ext/http3_qpack.nu
+++ b/stdlib/ext/http3_qpack.nu
@@ -346,7 +346,8 @@ $ `stdlib/std/quic_varint.nu`
     ~ < k ( qpack_static_table_size ) {
         ? ( nurl_str_eq ( qpack_static_name k ) name ) {
             ? ( nurl_str_eq ( qpack_static_value k ) value ) { ^ k } {}
-            ? < best 0 { = best - 0 - k 2 } {}
+            // -(k+2), so that k = 0 (:authority) is told apart from "no hit"
+            ? < best 0 { = best - - 0 k 2 } {}
         } {}
         = k + k 1
     }

--- a/stdlib/std/quic_client.nu
+++ b/stdlib/std/quic_client.nu
@@ -1,0 +1,179 @@
+// stdlib/std/quic_client.nu — a QUIC client: one UDP socket, one
+// connection (`std/quic_conn.nu`, client role), and the loop that
+// feeds it — the client-side twin of `std/quic_server.nu`. Synchronous
+// by design: every call drives the connection until what it waits for
+// has happened or its deadline has passed; on a fiber the socket parks
+// on the reactor, on a thread it blocks with a timeout. HTTP/3
+// (`ext/http3_client.nu`) sits on top and talks to streams.
+//
+//   ( quic_client_connect host port server_name alpn tp verify timeout_ms )
+//                                          → *QuicClient   0 when the name does not resolve or the socket
+//                                                          cannot be bound; otherwise the handshake has been
+//                                                          driven until it completed, failed, or `timeout_ms`
+//                                                          passed — `quic_client_connected` says which, and
+//                                                          the connection's close code says why not.
+//                                                          `alpn` = "h3" (a preference list); verify = 1
+//                                                          checks the certificate against the system roots
+//                                                          + `server_name`
+//   ( quic_client_connected cl )           → b             the handshake completed (streams may open)
+//   ( quic_client_free cl )                → v             closes the socket; the connection with it
+//   ( quic_client_conn cl )                → *QuicConn     BORROWED — streams, ALPN, PQ evidence, close code
+//   ( quic_client_step cl wait_ms )        → v             one loop turn: receive (at most `wait_ms`), timers, send
+//   ( quic_client_pump cl )                → v             send whatever the connection has ready
+//   ( quic_client_wait_readable cl timeout_ms ) → b        drive until a stream has data / FIN / RESET, or the
+//                                                          connection is gone (F) or the time is up (F)
+//   ( quic_client_close cl app code reason timeout_ms ) → v  close and drive until the peer has seen it
+//
+// Retry, Version Negotiation, NEW_TOKEN and HANDSHAKE_DONE are the
+// connection's business; the socket layer here has nothing to know.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/udp.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/quic_tp.nu`
+$ `stdlib/std/quic_conn.nu`
+
+: QuicClient {
+    UdpSocket sock
+    * QuicConn conn
+    ( Vec u ) peer
+    ( Vec u ) buf
+    ( Vec u ) from
+    i has_sock
+}
+
+@ __qcl_now → i { ^ / ( monotonic_ns ) 1000000 }
+
+// The limits this client advertises: 30 s idle, 1 MiB connection
+// window, 256 KiB per stream, 100 bidirectional streams the server may
+// open (an HTTP/3 server opens none), 3 unidirectional (control + 2
+// QPACK).
+@ quic_client_default_tp → *QuicTp {
+    : *QuicTp tp ( quic_tp_new )
+    = . tp max_idle_timeout 30000
+    = . tp max_udp_payload_size 1350
+    = . tp initial_max_data 1048576
+    = . tp initial_max_stream_data_bidi_local 262144
+    = . tp initial_max_stream_data_bidi_remote 262144
+    = . tp initial_max_stream_data_uni 262144
+    = . tp initial_max_streams_bidi 100
+    = . tp initial_max_streams_uni 3
+    ^ tp
+}
+
+@ quic_client_connect s host i port s server_name s alpn * QuicTp tp i verify i timeout_ms → *QuicClient {
+    : !( Vec u ) NetErr ar ( udp_addr_resolve host port )
+    : ( Vec u ) peer ?? ar { T a → a F _ → ( vec_new [u] ) }
+    ? == ( vec_len [u] peer ) 0 { ( vec_free [u] peer ) ^ # *QuicClient 0 } {}
+    // a socket of the peer's family: bind the wildcard of that family
+    : !UdpSocket NetErr sr ( udp_bind ? == ( udp_addr_family peer ) 6 `::` `0.0.0.0` 0 )
+    : ~ i ok 0
+    : ~ UdpSocket sock @ UdpSocket { `` }
+    ?? sr { T s → { = sock s = ok 1 } F _ → {} }
+    ? == ok 0 { ( vec_free [u] peer ) ^ # *QuicClient 0 } {}
+    : *QuicClient cl # *QuicClient ( nurl_alloc Z QuicClient )
+    = . cl sock sock
+    = . cl has_sock 1
+    = . cl peer peer
+    = . cl buf ( vec_with_cap [u] 65536 )
+    = . cl from ( udp_addr_new )
+    = . cl conn ( quic_conn_new_client peer server_name alpn tp verify ( __qcl_now ) )
+    ( quic_client_pump cl )
+    : i deadline + ( __qcl_now ) timeout_ms
+    ~ & < ( quic_conn_state . cl conn ) 1 < ( __qcl_now ) deadline {
+        ( quic_client_step cl - deadline ( __qcl_now ) )
+    }
+    ^ cl
+}
+
+@ quic_client_connected * QuicClient cl → b { ^ == ( quic_conn_state . cl conn ) 1 }
+
+@ quic_client_free * QuicClient cl → v {
+    ? == # i cl 0 { ^ } {}
+    ( quic_conn_free . cl conn )
+    ? != . cl has_sock 0 { ( udp_close . cl sock ) } {}
+    ( vec_free [u] . cl peer )
+    ( vec_free [u] . cl buf )
+    ( vec_free [u] . cl from )
+    ( nurl_free # s cl )
+}
+
+@ quic_client_conn * QuicClient cl → *QuicConn { ^ . cl conn }
+
+// Send everything the connection has ready.
+@ quic_client_pump * QuicClient cl → v {
+    : ~ i guard 0
+    ~ < guard 64 {
+        : ( Vec u ) d ( quic_conn_send . cl conn ( __qcl_now ) )
+        ? == ( vec_len [u] d ) 0 { ( vec_free [u] d ) = guard 64 } {
+            : !i NetErr w ( udp_send_addr . cl sock d . cl peer )
+            ?? w { T _ → {} F _ → {} }
+            ( vec_free [u] d )
+            = guard + guard 1
+        }
+    }
+}
+
+// One turn of the loop: wait for a datagram at most `wait_ms` (or until
+// the connection's next deadline, whichever is first), feed it, drain
+// what else is ready, run the timers, send.
+@ quic_client_step * QuicClient cl i wait_ms → v {
+    : *QuicConn c . cl conn
+    : i now0 ( __qcl_now )
+    : ~ i wait ? < wait_ms 0 0 wait_ms
+    : i t ( quic_conn_next_timeout c )
+    ? > t 0 {
+        : i d - t now0
+        ? < d wait { = wait ? < d 0 0 d } {}
+    } {}
+    : !i NetErr r ( udp_recv_into_deadline . cl sock . cl buf . cl from wait )
+    ?? r {
+        T n → { ( quic_conn_recv c . cl buf . cl from ( __qcl_now ) ) }
+        F e → {}
+    }
+    : ~ i more 1
+    ~ != more 0 {
+        : !i NetErr r2 ( udp_recv_into_deadline . cl sock . cl buf . cl from 0 )
+        ?? r2 {
+            T n → { ( quic_conn_recv c . cl buf . cl from ( __qcl_now ) ) }
+            F e → { = more 0 }
+        }
+    }
+    : i now2 ( __qcl_now )
+    : i t2 ( quic_conn_next_timeout c )
+    ? & > t2 0 <= t2 now2 { ( quic_conn_on_timeout c now2 ) } {}
+    ( quic_client_pump cl )
+}
+
+// Drive until a stream is readable (T), or the connection is closing /
+// closed or the time is up (F). The ids are left in the connection for
+// `quic_conn_take_readable`.
+@ quic_client_wait_readable * QuicClient cl i timeout_ms → b {
+    : *QuicConn c . cl conn
+    : i deadline + ( __qcl_now ) timeout_ms
+    ~ T {
+        ? >= ( quic_conn_state c ) 2 { ^ F } {}
+        : ( Vec i ) r ( quic_conn_take_readable c )
+        : i n ( vec_len [i] r )
+        ( _qc_requeue_readable c r )
+        ( vec_free [i] r )
+        ? > n 0 { ^ T } {}
+        : i now ( __qcl_now )
+        ? >= now deadline { ^ F } {}
+        ( quic_client_step cl - deadline now )
+    }
+    ^ F
+}
+
+// Close (application error when `app` = 1) and keep the loop going
+// until the connection has gone through closing, or `timeout_ms`.
+@ quic_client_close * QuicClient cl i app i code ( Vec u ) reason i timeout_ms → v {
+    : *QuicConn c . cl conn
+    ( quic_conn_close c app code reason )
+    ( quic_client_pump cl )
+    : i deadline + ( __qcl_now ) timeout_ms
+    ~ & < ( quic_conn_state c ) 4 < ( __qcl_now ) deadline {
+        ( quic_client_step cl - deadline ( __qcl_now ) )
+    }
+}

--- a/stdlib/std/quic_conn.nu
+++ b/stdlib/std/quic_conn.nu
@@ -1,10 +1,15 @@
-// stdlib/std/quic_conn.nu — one QUIC v1 connection, server role
+// stdlib/std/quic_conn.nu — one QUIC v1 connection, either role
 // (RFC 9000 / 9001 / 9002). Sans-IO: datagrams in with a clock,
 // datagrams out, timers as absolute deadlines; the listener
-// (`std/quic_server.nu`) owns the socket, the loop and the clock, and the
-// application (HTTP/3 in `ext/http3_conn.nu`) talks to streams.
+// (`std/quic_server.nu`) or the client pump (`std/quic_client.nu`) owns
+// the socket, the loop and the clock, and the application (HTTP/3 in
+// `ext/http3_conn.nu` / `ext/http3_client.nu`) talks to streams.
 //
 //   ( quic_conn_new_server scid odcid peer creds alpn_prefs tp now ) → *QuicConn
+//   ( quic_conn_new_client peer server_name alpn tp verify now )     → *QuicConn  the ClientHello is queued;
+//                                                                                  `alpn` = "h3" (preference list);
+//                                                                                  verify = 1 checks the certificate chain
+//                                                                                  + hostname (std/tls_verify.nu)
 //   ( quic_conn_free c )                                 → v
 //   ( quic_conn_recv c dgram from now )                  → v        one UDP datagram (coalesced packets)
 //   ( quic_conn_send c now )                             → ( Vec u ) OWNED next datagram, empty when nothing to send
@@ -20,17 +25,23 @@
 //   ( quic_conn_stream_recv c id max )                   → ( Vec u ) OWNED bytes (empty when none)
 //   ( quic_conn_stream_fin c id )                        → b        FIN reached and all data read
 //   ( quic_conn_stream_reset_err c id )                  → i        RESET_STREAM error code, -1 none
-//   ( quic_conn_open_uni c )                             → i        a new server-initiated unidirectional stream, -1 at the peer's limit
+//   ( quic_conn_open_uni c )                             → i        a new locally-initiated unidirectional stream, -1 at the peer's limit
+//   ( quic_conn_open_bidi c )                            → i        a new locally-initiated bidirectional stream, -1 at the peer's limit
+//   ( quic_conn_is_client c ) · ( quic_conn_is_pq c ) · ( quic_conn_confirmed c )
+//   ( quic_conn_close_code c ) · ( quic_conn_close_is_app c ) · ( quic_conn_closed_by_peer c ) · ( quic_conn_close_reason c )
+//   ( quic_conn_new_token c )                            → ( Vec u ) BORROWED: the server's NEW_TOKEN for a later connection (client)
 //   ( quic_conn_stream_send c id data fin )              → i        bytes accepted (buffered), -1 no such / closed stream
 //   ( quic_conn_stream_reset c id err ) · ( quic_conn_stream_stop_sending c id err )
 //   ( quic_conn_stream_stop_err c id )                   → i        STOP_SENDING error code from the peer, -1 none
 //   ( quic_conn_stream_done c id )                       → v        the application is finished with the stream
 //
 // Deliberately absent (documented in temp.md / NETWORKING.md): 0-RTT,
-// Retry / address-validation tokens, preferred_address, stateless
-// reset emission, ECN marking, path migration beyond following a
-// validated peer address, and 1-RTT packets that arrive before the
-// client's Finished (dropped; the peer's PTO retransmits them).
+// Retry emission and address-validation tokens on the server (the
+// client honours a Retry and sends NEW_TOKEN tokens back),
+// preferred_address, stateless reset emission, ECN marking, path
+// migration beyond following a validated peer address, and 1-RTT
+// packets that arrive before the peer's Finished (dropped; the peer's
+// PTO retransmits them).
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
@@ -141,11 +152,12 @@ $ `stdlib/std/quic_recovery.nu`
 
 @ _qc_stream_is_server i id → b { ^ == & id 1 1 }
 
-@ __qc_stream_new i id i rx_window i tx_max → *QuicStream {
+// `local`: this endpoint opened the stream.
+@ __qc_stream_new i id i rx_window i tx_max b local → *QuicStream {
     : *QuicStream s # *QuicStream ( nurl_alloc Z QuicStream )
     = . s id id
-    // A server-initiated unidirectional stream has no receive side.
-    : b has_rx ! & ( _qc_stream_is_server id ) ! ( __qc_stream_is_bidi id )
+    // Our own unidirectional stream has no receive side.
+    : b has_rx ! & local ! ( __qc_stream_is_bidi id )
     = . s rx ? has_rx ( quic_rxbuf_new rx_window ) # *QuicRxBuf 0
     = . s rx_window rx_window
     = . s rx_max_data rx_window
@@ -161,8 +173,8 @@ $ `stdlib/std/quic_recovery.nu`
     = . s tx_reset_err -1
     = . s tx_reset_sent 0
     = . s tx_stop_err -1
-    // A client-initiated unidirectional stream has no send side.
-    : b has_tx | ( _qc_stream_is_server id ) ( __qc_stream_is_bidi id )
+    // The peer's unidirectional stream has no send side.
+    : b has_tx | local ( __qc_stream_is_bidi id )
     = . s tx_done ? has_tx 0 1
     = . s app_done 0
     ^ s
@@ -265,6 +277,17 @@ $ `stdlib/std/quic_recovery.nu`
     i max_udp
     i stream_rx_window
     i alpn_ok
+    // ── role ──
+    i is_client
+    * QuicTlsCli tlsc  // the client's TLS machine (`tls` is the server's)
+    ( Vec u ) token  // Retry token to put in our Initials (client)
+    ( Vec u ) new_token  // the server's NEW_TOKEN, for a later connection (client)
+    i retry_seen
+    ( Vec u ) retry_scid  // the Retry's SCID, to be echoed in the server's transport parameters
+    i dcid_learned  // client: the server's SCID has replaced the DCID we chose
+    ( Vec u ) server_name  // client: for certificate verification
+    i verify
+    i peer_closed  // the close code / reason came from the peer's CONNECTION_CLOSE
 }
 
 @ quic_conn_default_idle_ms → i { ^ 30000 }
@@ -277,6 +300,9 @@ $ `stdlib/std/quic_recovery.nu`
 
 @ quic_conn_default_max_streams_uni → i { ^ 3 }
 
+// Did this endpoint open stream `id`? (server: odd ids; client: even)
+@ __qc_is_local * QuicConn c i id → b { ^ == & id 1 ? != . c is_client 0 0 1 }
+
 @ __qc_rand i n → ( Vec u ) {
     : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
     : b _ok ( vec_resize_zeroed [u] v n )
@@ -285,15 +311,15 @@ $ `stdlib/std/quic_recovery.nu`
     ^ v
 }
 
-// The transport parameters this server sends: `tp` is the caller's
-// template (limits); the connection IDs are filled in here.
-@ quic_conn_new_server ( Vec u ) scid ( Vec u ) odcid ( Vec u ) peer * QuicCreds creds ( Vec u ) alpn_prefs * QuicTp tp i now → *QuicConn {
+// Everything both roles share: `tp` is the caller's template (limits);
+// the connection IDs, keys and the TLS machine are the role's to add.
+@ __qc_new_common ( Vec u ) scid ( Vec u ) peer * QuicTp tp i now → *QuicConn {
     : *QuicConn c # *QuicConn ( nurl_alloc Z QuicConn )
     = . c state 0
     = . c now now
     = . c scid ( bytes_slice scid 0 ( vec_len [u] scid ) )
     = . c dcid ( vec_new [u] )
-    = . c odcid ( bytes_slice odcid 0 ( vec_len [u] odcid ) )
+    = . c odcid ( vec_new [u] )
     = . c peer ( bytes_slice peer 0 ( vec_len [u] peer ) )
     = . c cids ( bytes_slice scid 0 ( vec_len [u] scid ) )
     = . c cid_seqs ( vec_new [i] )
@@ -320,22 +346,13 @@ $ `stdlib/std/quic_recovery.nu`
     = . mine max_ack_delay 25
     = . mine disable_active_migration 1
     = . mine active_connection_id_limit 4
-    = . mine has_original_dcid 1
-    ( bytes_extend_bytes . mine original_dcid odcid )
     = . mine has_initial_scid 1
     ( bytes_extend_bytes . mine initial_scid scid )
-    = . mine has_stateless_reset_token 1
-    : ( Vec u ) tok ( __qc_rand 16 )
-    ( bytes_extend_bytes . mine stateless_reset_token tok )
-    ( vec_free [u] tok )
     = . c local_tp mine
-    : ( Vec u ) tpb ( quic_tp_encode mine T )
-    = . c tls ( quic_tls_srv_new . creds cert_chain . creds keytype . creds ec_priv . creds rsa_n . creds rsa_e . creds rsa_d . creds ml_level alpn_prefs tpb )
-    ? > ( vec_len [u] . creds pq_chain ) 0 { ( quic_tls_srv_set_pq . c tls . creds pq_chain . creds pq_level . creds pq_sk ) } {}
-    ( vec_free [u] tpb )
+    = . c tls # *QuicTlsSrv 0
     = . c tls_state 0
-    = . c k_rx0 ( quic_initial_keys odcid T )
-    = . c k_tx0 ( quic_initial_keys odcid F )
+    = . c k_rx0 # *QuicKeys 0
+    = . c k_tx0 # *QuicKeys 0
     = . c k_rx1 # *QuicKeys 0
     = . c k_tx1 # *QuicKeys 0
     = . c k_rx2 # *QuicKeys 0
@@ -403,6 +420,71 @@ $ `stdlib/std/quic_recovery.nu`
     = . c max_udp 1200
     = . c stream_rx_window . tp initial_max_stream_data_bidi_remote
     = . c alpn_ok 0
+    = . c is_client 0
+    = . c tlsc # *QuicTlsCli 0
+    = . c token ( vec_new [u] )
+    = . c new_token ( vec_new [u] )
+    = . c retry_seen 0
+    = . c retry_scid ( vec_new [u] )
+    = . c dcid_learned 1
+    = . c server_name ( vec_new [u] )
+    = . c verify 0
+    = . c peer_closed 0
+    ^ c
+}
+
+// The transport parameters this server sends: `tp` is the caller's
+// template (limits); the connection IDs are filled in here.
+@ quic_conn_new_server ( Vec u ) scid ( Vec u ) odcid ( Vec u ) peer * QuicCreds creds ( Vec u ) alpn_prefs * QuicTp tp i now → *QuicConn {
+    : *QuicConn c ( __qc_new_common scid peer tp now )
+    ( bytes_extend_bytes . c odcid odcid )
+    : *QuicTp mine . c local_tp
+    = . mine has_original_dcid 1
+    ( bytes_extend_bytes . mine original_dcid odcid )
+    = . mine has_stateless_reset_token 1
+    : ( Vec u ) tok ( __qc_rand 16 )
+    ( bytes_extend_bytes . mine stateless_reset_token tok )
+    ( vec_free [u] tok )
+    : ( Vec u ) tpb ( quic_tp_encode mine T )
+    = . c tls ( quic_tls_srv_new . creds cert_chain . creds keytype . creds ec_priv . creds rsa_n . creds rsa_e . creds rsa_d . creds ml_level alpn_prefs tpb )
+    ? > ( vec_len [u] . creds pq_chain ) 0 { ( quic_tls_srv_set_pq . c tls . creds pq_chain . creds pq_level . creds pq_sk ) } {}
+    ( vec_free [u] tpb )
+    = . c k_rx0 ( quic_initial_keys odcid T )
+    = . c k_tx0 ( quic_initial_keys odcid F )
+    ^ c
+}
+
+// A client connection to `peer` (a udp_addr): the ClientHello is built
+// and queued, so the first `quic_conn_send` is the 1200-byte Initial.
+// The DCID we choose (`odcid`, 8 random bytes) keys the Initial packets
+// until the server's first Initial tells us its SCID (§7.2); the server
+// must echo it back as original_destination_connection_id (§7.3).
+@ quic_conn_new_client ( Vec u ) peer s server_name s alpn * QuicTp tp i verify i now → *QuicConn {
+    : ( Vec u ) scid ( __qc_rand 8 )
+    : ( Vec u ) dcid ( __qc_rand 8 )
+    : *QuicConn c ( __qc_new_common scid peer tp now )
+    = . c is_client 1
+    ( bytes_extend_bytes . c dcid dcid )
+    ( bytes_extend_bytes . c odcid dcid )
+    = . c dcid_learned 0
+    : ( Vec u ) sn ( bytes_from_str server_name )
+    ( bytes_extend_bytes . c server_name sn )
+    ( vec_free [u] sn )
+    = . c verify verify
+    // The client's address needs no validating (§8.1) and the client
+    // never sends HANDSHAKE_DONE (§19.20).
+    = . c validated 1
+    = . c handshake_done_sent 1
+    = . c next_local_bidi 0
+    = . c next_local_uni 2
+    : ( Vec u ) tpb ( quic_tp_encode . c local_tp F )
+    = . c tlsc ( quic_tls_cli_new server_name alpn tpb )
+    ( vec_free [u] tpb )
+    = . c k_tx0 ( quic_initial_keys dcid T )
+    = . c k_rx0 ( quic_initial_keys dcid F )
+    ( __qc_tls_pump c )
+    ( vec_free [u] dcid )
+    ( vec_free [u] scid )
     ^ c
 }
 
@@ -412,6 +494,9 @@ $ `stdlib/std/quic_recovery.nu`
     ( vec_free [u] . c peer ) ( vec_free [u] . c cids ) ( vec_free [i] . c cid_seqs )
     ( vec_free [u] . c peer_cids ) ( vec_free [i] . c peer_cid_seqs )
     ( quic_tls_srv_free . c tls )
+    ( quic_tls_cli_free . c tlsc )
+    ( vec_free [u] . c token ) ( vec_free [u] . c new_token )
+    ( vec_free [u] . c retry_scid ) ( vec_free [u] . c server_name )
     ( quic_keys_free . c k_rx0 ) ( quic_keys_free . c k_tx0 )
     ( quic_keys_free . c k_rx1 ) ( quic_keys_free . c k_tx1 )
     ( quic_keys_free . c k_rx2 ) ( quic_keys_free . c k_tx2 )
@@ -434,7 +519,37 @@ $ `stdlib/std/quic_recovery.nu`
 
 @ quic_conn_state * QuicConn c → i { ^ . c state }
 
-@ quic_conn_alpn * QuicConn c → ( Vec u ) { ^ ( quic_tls_srv_alpn . c tls ) }
+@ quic_conn_alpn * QuicConn c → ( Vec u ) {
+    ? != . c is_client 0 { ^ ( quic_tls_cli_alpn . c tlsc ) } {}
+    ^ ( quic_tls_srv_alpn . c tls )
+}
+
+@ quic_conn_is_client * QuicConn c → b { ^ != . c is_client 0 }
+
+// T when the key exchange was X25519MLKEM768.
+@ quic_conn_is_pq * QuicConn c → b {
+    ? != . c is_client 0 { ^ ( quic_tls_cli_is_pq . c tlsc ) } {}
+    ^ == . . . c tls hs kx_group 4588
+}
+
+// Handshake confirmed (§4.1.2): the server on the client's Finished,
+// the client on HANDSHAKE_DONE.
+@ quic_conn_confirmed * QuicConn c → b { ^ != . c confirmed 0 }
+
+// The code the connection is closing / closed with (-1 none); with
+// `quic_conn_close_is_app` telling an application error from a
+// transport one.
+@ quic_conn_close_code * QuicConn c → i { ^ . c close_code }
+
+@ quic_conn_close_is_app * QuicConn c → b { ^ != . c close_app 0 }
+
+// T when the close was the peer's (its CONNECTION_CLOSE), F when ours.
+@ quic_conn_closed_by_peer * QuicConn c → b { ^ != . c peer_closed 0 }
+
+// BORROWED: the reason phrase of the close (ours or the peer's).
+@ quic_conn_close_reason * QuicConn c → ( Vec u ) { ^ . c close_reason }
+
+@ quic_conn_new_token * QuicConn c → ( Vec u ) { ^ . c new_token }
 
 @ quic_conn_peer * QuicConn c → ( Vec u ) { ^ . c peer }
 
@@ -505,7 +620,7 @@ $ `stdlib/std/quic_recovery.nu`
     : ~ i i opened
     ~ <= i idx {
         : i nid | << i 2 & id 3
-        : *QuicStream ns ( __qc_stream_new nid window tx_max )
+        : *QuicStream ns ( __qc_stream_new nid window tx_max F )
         ( vec_push [i] . c streams # i ns )
         = i + i 1
     }
@@ -595,7 +710,20 @@ $ `stdlib/std/quic_recovery.nu`
     : i id . c next_local_uni
     = . c next_local_uni + id 4
     : i tx_max ? != # i . c peer_tp 0 . . c peer_tp initial_max_stream_data_uni 0
-    : *QuicStream s ( __qc_stream_new id 0 tx_max )
+    : *QuicStream s ( __qc_stream_new id 0 tx_max T )
+    ( vec_push [i] . c streams # i s )
+    ^ id
+}
+
+// A bidirectional stream of our own. Needs the peer's transport
+// parameters (the handshake), like the flow-control limit it obeys.
+@ quic_conn_open_bidi * QuicConn c → i {
+    ? == # i . c peer_tp 0 { ^ -1 } {}
+    : i idx >> . c next_local_bidi 2
+    ? >= idx . c max_streams_bidi_peer { ^ -1 } {}
+    : i id . c next_local_bidi
+    = . c next_local_bidi + id 4
+    : *QuicStream s ( __qc_stream_new id . . c local_tp initial_max_stream_data_bidi_local . . c peer_tp initial_max_stream_data_bidi_remote T )
     ( vec_push [i] . c streams # i s )
     ^ id
 }
@@ -652,7 +780,7 @@ $ `stdlib/std/quic_recovery.nu`
         : b tx_finished | != . s tx_done 0 | & != . s tx_fin_sent 0 == ( vec_len [u] . s tx_buf ) 0 != . s tx_reset_sent 0
         : b rx_finished | != . s rx_done 0 >= . s rx_reset_err 0
         ? & & != . s app_done 0 tx_finished rx_finished {
-            ? ! ( _qc_stream_is_server . s id ) {
+            ? ! ( __qc_is_local c . s id ) {
                 ? ( __qc_stream_is_bidi . s id ) {
                     = . c peer_bidi_closed + . c peer_bidi_closed 1
                     : i want + . c peer_bidi_closed . . c local_tp initial_max_streams_bidi
@@ -768,6 +896,12 @@ $ `stdlib/std/quic_recovery.nu`
 
 @ __qc_install_handshake_keys * QuicConn c → v {
     ? != # i . c k_tx1 0 { ^ } {}
+    ? != . c is_client 0 {
+        : i cipher ( quic_tls_cli_cipher . c tlsc )
+        = . c k_tx1 ( quic_keys_derive cipher ( quic_tls_cli_c_hs . c tlsc ) )
+        = . c k_rx1 ( quic_keys_derive cipher ( quic_tls_cli_s_hs . c tlsc ) )
+        ^
+    } {}
     : i cipher ( quic_tls_srv_cipher . c tls )
     = . c k_tx1 ( quic_keys_derive cipher ( quic_tls_srv_s_hs . c tls ) )
     = . c k_rx1 ( quic_keys_derive cipher ( quic_tls_srv_c_hs . c tls ) )
@@ -775,14 +909,33 @@ $ `stdlib/std/quic_recovery.nu`
     = . c k_rx2 ( quic_keys_derive cipher ( quic_tls_srv_c_ap . c tls ) )
 }
 
+// The client's 1-RTT keys, once the server Finished has verified.
+@ __qc_install_app_keys * QuicConn c → v {
+    ? != # i . c k_tx2 0 { ^ } {}
+    : i cipher ( quic_tls_cli_cipher . c tlsc )
+    = . c k_tx2 ( quic_keys_derive cipher ( quic_tls_cli_c_ap . c tlsc ) )
+    = . c k_rx2 ( quic_keys_derive cipher ( quic_tls_cli_s_ap . c tlsc ) )
+}
+
 // The peer's transport parameters, once the TLS layer has them.
 @ __qc_apply_peer_tp * QuicConn c → v {
     ? != # i . c peer_tp 0 { ^ } {}
-    : *QuicTp p ( quic_tp_decode ( quic_tls_srv_client_tp . c tls ) T )
+    : *QuicTp p ? != . c is_client 0 ( quic_tp_decode ( quic_tls_cli_server_tp . c tlsc ) F ) ( quic_tp_decode ( quic_tls_srv_client_tp . c tls ) T )
     ? == # i p 0 { ( __qc_fail c 0 ( quic_err_transport_parameter ) 0 ) ^ } {}
-    // §7.3: initial_source_connection_id must be the SCID of the client's
-    // Initial packet — the DCID we send to.
-    ? ! ( bytes_eq . p initial_scid . c dcid ) {
+    // §7.3: initial_source_connection_id must be the SCID of the peer's
+    // first packet — the DCID we send to.
+    : ~ b ok ( bytes_eq . p initial_scid . c dcid )
+    ? != . c is_client 0 {
+        // ... and a server proves it saw our first Initial: the DCID we
+        // chose comes back as original_destination_connection_id, and
+        // after a Retry that packet's SCID as retry_source_connection_id
+        // (a retry_source_connection_id with no Retry is as wrong).
+        ? | == . p has_original_dcid 0 ! ( bytes_eq . p original_dcid . c odcid ) { = ok F } {}
+        ? != . c retry_seen 0 {
+            ? | == . p has_retry_scid 0 ! ( bytes_eq . p retry_scid . c retry_scid ) { = ok F } {}
+        } { ? != . p has_retry_scid 0 { = ok F } {} }
+    } {}
+    ? ! ok {
         ( quic_tp_free p )
         ( __qc_fail c 0 ( quic_err_transport_parameter ) 0 )
         ^
@@ -802,7 +955,9 @@ $ `stdlib/std/quic_recovery.nu`
     : ~ i k 0
     ~ < k ( vec_len [i] . c streams ) {
         : *QuicStream s # *QuicStream ( __qc_ri . c streams k )
-        ? ( __qc_stream_is_bidi . s id ) { = . s tx_max_data . p initial_max_stream_data_bidi_local } {}
+        ? ( __qc_stream_is_bidi . s id ) {
+            = . s tx_max_data ? ( __qc_is_local c . s id ) . p initial_max_stream_data_bidi_remote . p initial_max_stream_data_bidi_local
+        } {}
         = k + k 1
     }
 }
@@ -810,6 +965,7 @@ $ `stdlib/std/quic_recovery.nu`
 // Drain the TLS layer's outputs into the CRYPTO queues and react to
 // its state changes.
 @ __qc_tls_pump * QuicConn c → v {
+    ? != . c is_client 0 { ( __qc_tls_pump_client c ) ^ } {}
     : ( Vec u ) o0 ( quic_tls_srv_take_out . c tls 0 )
     ( bytes_extend_bytes . c crypto_out0 o0 ) ( vec_free [u] o0 )
     : ( Vec u ) o1 ( quic_tls_srv_take_out . c tls 1 )
@@ -830,6 +986,40 @@ $ `stdlib/std/quic_recovery.nu`
         = . c confirmed 1
         ( quic_rec_set_confirmed . c rec )
         ( __qc_drop_keys c 1 )
+        ( quic_rec_new_max_datagram . c rec . c max_udp )
+        ( __qc_issue_cids c )
+    } {}
+}
+
+// The client: handshake keys after the ServerHello; 1-RTT keys, the
+// server's transport parameters and the certificate check once its
+// Finished verified — the handshake is then complete (streams may
+// open, 1-RTT data flows both ways) but confirmed only on the server's
+// HANDSHAKE_DONE (§4.1.2), which is when the Handshake keys go.
+@ __qc_tls_pump_client * QuicConn c → v {
+    : ( Vec u ) o0 ( quic_tls_cli_take_out . c tlsc 0 )
+    ( bytes_extend_bytes . c crypto_out0 o0 ) ( vec_free [u] o0 )
+    : ( Vec u ) o1 ( quic_tls_cli_take_out . c tlsc 1 )
+    ( bytes_extend_bytes . c crypto_out1 o1 ) ( vec_free [u] o1 )
+    : ( Vec u ) o2 ( quic_tls_cli_take_out . c tlsc 2 )
+    ( bytes_extend_bytes . c crypto_out2 o2 ) ( vec_free [u] o2 )
+    : i st ( quic_tls_cli_state . c tlsc )
+    ? & >= st 1 == . c tls_state 0 {
+        = . c tls_state 1
+        ( __qc_install_handshake_keys c )
+    } {}
+    ? & >= st 2 < . c tls_state 2 {
+        = . c tls_state 2
+        ? != . c verify 0 {
+            : String sn ( string_from_bytes ( vec_data [u] . c server_name ) ( vec_len [u] . c server_name ) )
+            : i vrc ( quic_tls_cli_verify . c tlsc ( string_data sn ) )
+            ( string_free sn )
+            ? != vrc 0 { ( __qc_fail c 0 ( quic_err_crypto vrc ) 0 ) ^ } {}
+        } {}
+        ( __qc_install_app_keys c )
+        ( __qc_apply_peer_tp c )
+        ? >= . c state 2 { ^ } {}
+        = . c state 1
         ( quic_rec_new_max_datagram . c rec . c max_udp )
         ( __qc_issue_cids c )
     } {}
@@ -879,11 +1069,11 @@ $ `stdlib/std/quic_recovery.nu`
 // Returns 0 to continue, 1 when the connection has failed.
 @ __qc_on_stream_frame * QuicConn c * QuicFrame f → i {
     : i id . f a
-    ? ( _qc_stream_is_server id ) {
+    ? ( __qc_is_local c id ) {
         ? ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) . f ftype ) ^ 1 } {}
         ? >= id . c next_local_bidi { ( __qc_fail c 0 ( quic_err_stream_state ) . f ftype ) ^ 1 } {}
     } {}
-    : *QuicStream s ? ( _qc_stream_is_server id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
+    : *QuicStream s ? ( __qc_is_local c id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
     ? == # i s 0 { ^ ? >= . c state 2 1 0 } {}
     ? == # i . s rx 0 { ( __qc_fail c 0 ( quic_err_stream_state ) . f ftype ) ^ 1 } {}
     : i off . f b
@@ -923,18 +1113,26 @@ $ `stdlib/std/quic_recovery.nu`
         ^ 0
     } {}
     ? == ft 6 {
-        : i rc ( quic_tls_srv_crypto . c tls space . f a . f bytes )
+        : i rc ? != . c is_client 0 ( quic_tls_cli_crypto . c tlsc space . f a . f bytes ) ( quic_tls_srv_crypto . c tls space . f a . f bytes )
         ? != rc 0 { ( __qc_fail c 0 rc ft ) ^ 1 } {}
         ( __qc_tls_pump c )
         ^ ? >= . c state 2 1 0
     } {}
-    ? == ft 7 { ( __qc_fail c 0 10 ft ) ^ 1 } {}
+    ? == ft 7 {
+        // NEW_TOKEN: a server may not receive one (§19.7); a client keeps
+        // the newest for a later connection to this server.
+        ? == . c is_client 0 { ( __qc_fail c 0 10 ft ) ^ 1 } {}
+        ? == ( vec_len [u] . f bytes ) 0 { ( __qc_fail c 0 ( quic_err_frame_encoding ) ft ) ^ 1 } {}
+        ( vec_clear [u] . c new_token )
+        ( bytes_extend_bytes . c new_token . f bytes )
+        ^ 0
+    } {}
     ? ( quic_frame_is_stream ft ) { ^ ( __qc_on_stream_frame c f ) } {}
     ? == ft 4 {
         : i id . f a
-        ? & ( _qc_stream_is_server id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        ? & ( _qc_stream_is_server id ) >= id . c next_local_bidi { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        : *QuicStream s ? ( _qc_stream_is_server id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
+        ? & ( __qc_is_local c id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        ? & ( __qc_is_local c id ) >= id . c next_local_bidi { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        : *QuicStream s ? ( __qc_is_local c id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
         ? == # i s 0 { ^ ? >= . c state 2 1 0 } {}
         ? == # i . s rx 0 { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
         : i final . f c
@@ -952,9 +1150,9 @@ $ `stdlib/std/quic_recovery.nu`
     ? == ft 5 {
         : i id . f a
         // receive-only for us: the peer's unidirectional streams
-        ? & ! ( _qc_stream_is_server id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        ? & ( _qc_stream_is_server id ) >= id ? ( __qc_stream_is_bidi id ) . c next_local_bidi . c next_local_uni { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        : *QuicStream s ? ( _qc_stream_is_server id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
+        ? & ! ( __qc_is_local c id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        ? & ( __qc_is_local c id ) >= id ? ( __qc_stream_is_bidi id ) . c next_local_bidi . c next_local_uni { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        : *QuicStream s ? ( __qc_is_local c id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
         ? == # i s 0 { ^ ? >= . c state 2 1 0 } {}
         ? < . s tx_stop_err 0 {
             = . s tx_stop_err . f b
@@ -966,9 +1164,9 @@ $ `stdlib/std/quic_recovery.nu`
     ? == ft 16 { ? > . f a . c max_data_peer { = . c max_data_peer . f a } {} ^ 0 } {}
     ? == ft 17 {
         : i id . f a
-        ? & ! ( _qc_stream_is_server id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        ? & ( _qc_stream_is_server id ) >= id ? ( __qc_stream_is_bidi id ) . c next_local_bidi . c next_local_uni { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
-        : *QuicStream s ? ( _qc_stream_is_server id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
+        ? & ! ( __qc_is_local c id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        ? & ( __qc_is_local c id ) >= id ? ( __qc_stream_is_bidi id ) . c next_local_bidi . c next_local_uni { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        : *QuicStream s ? ( __qc_is_local c id ) ( __qc_stream_get c id ) ( __qc_peer_stream c id )
         ? == # i s 0 { ^ ? >= . c state 2 1 0 } {}
         ? > . f b . s tx_max_data { = . s tx_max_data . f b } {}
         ^ 0
@@ -982,7 +1180,7 @@ $ `stdlib/std/quic_recovery.nu`
     ? == ft 20 { ^ 0 } {}
     ? == ft 21 {
         : i id . f a
-        ? & ! ( _qc_stream_is_server id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
+        ? & ! ( __qc_is_local c id ) ! ( __qc_stream_is_bidi id ) { ( __qc_fail c 0 ( quic_err_stream_state ) ft ) ^ 1 } {}
         ^ 0
     } {}
     ? | == ft 22 == ft 23 {
@@ -1067,14 +1265,31 @@ $ `stdlib/std/quic_recovery.nu`
     ? == ft 26 { ( quic_push_path_response . c ctl2 . f bytes ) ^ 0 } {}
     ? == ft 27 { ^ 0 } {}
     ? | == ft 28 == ft 29 {
-        // the peer is closing: drain (§10.2.2)
+        // the peer is closing: drain (§10.2.2); its code and reason are
+        // kept for the application (quic_conn_close_code / _reason)
         ? < . c state 3 {
             = . c state 3
             = . c close_deadline + . c now * 3 ( quic_rec_pto . c rec )
+            = . c close_code . f a
+            = . c close_app ? == ft 29 1 0
+            = . c close_frame_type ? == ft 28 . f b 0
+            = . c peer_closed 1
+            ( vec_clear [u] . c close_reason )
+            ( bytes_extend_bytes . c close_reason . f bytes )
         } {}
         ^ 1
     } {}
-    ? == ft 30 { ( __qc_fail c 0 10 ft ) ^ 1 } {}
+    ? == ft 30 {
+        // HANDSHAKE_DONE: only a server sends it (§19.20); for the client
+        // it confirms the handshake — Handshake keys go (§4.9.2).
+        ? == . c is_client 0 { ( __qc_fail c 0 10 ft ) ^ 1 } {}
+        ? == . c confirmed 0 {
+            = . c confirmed 1
+            ( quic_rec_set_confirmed . c rec )
+            ( __qc_drop_keys c 1 )
+        } {}
+        ^ 0
+    } {}
     ( __qc_fail c 0 ( quic_err_frame_encoding ) ft )
     ^ 1
 }
@@ -1106,6 +1321,61 @@ $ `stdlib/std/quic_recovery.nu`
     ^ ok
 }
 
+// Version Negotiation (§6.2), client only, and only before any packet
+// of the server's has been processed (a Retry counts): if version 1 is listed the packet is
+// a fake and ignored; otherwise there is no version in common and the
+// attempt is abandoned — the connection closes with no packet sent.
+@ __qc_on_vn * QuicConn c ( Vec u ) dgram * QuicHdr h → v {
+    ? | | | == . c is_client 0 >= . c largest_rx0 0 != . c tls_state 0 != . c retry_seen 0 { ^ } {}
+    : ~ i p . h pn_off
+    : ~ b has1 F
+    ~ < + p 4 + . h end 1 {
+        : i v | | | << ( __qc_bget dgram p ) 24 << ( __qc_bget dgram + p 1 ) 16 << ( __qc_bget dgram + p 2 ) 8 ( __qc_bget dgram + p 3 )
+        ? == v 1 { = has1 T } {}
+        = p + p 4
+    }
+    ? has1 { ^ } {}
+    = . c state 4
+    = . c close_code ( quic_err_no_error )
+}
+
+// Retry (§17.2.5), client only, once, and only before any packet of the
+// server's has been read: check the integrity tag against the DCID we
+// chose, then start the Initial exchange again — the Retry's SCID is the
+// new DCID (new Initial keys), its token rides in every Initial, the
+// ClientHello goes again, and packet numbers continue (§17.2.5.3). A
+// Retry that fails its tag or repeats our own DCID is discarded.
+@ __qc_on_retry * QuicConn c ( Vec u ) dgram i off * QuicHdr h → v {
+    ? | | | == . c is_client 0 != . c retry_seen 0 >= . c largest_rx0 0 != . c tls_state 0 { ^ } {}
+    : i n . h end
+    ? < - n off 16 { ^ } {}
+    : ( Vec u ) body ( bytes_slice dgram off - n 16 )
+    : ( Vec u ) tag ( bytes_slice dgram - n 16 n )
+    : ( Vec u ) want ( quic_retry_tag . c odcid body )
+    : b ok ( bytes_eq tag want )
+    ( vec_free [u] want ) ( vec_free [u] tag ) ( vec_free [u] body )
+    ? ! ok { ^ } {}
+    : ( Vec u ) rscid ( quic_hdr_scid h dgram )
+    ? | == ( vec_len [u] rscid ) 0 ( bytes_eq rscid . c dcid ) { ( vec_free [u] rscid ) ^ } {}
+    = . c retry_seen 1
+    ( vec_clear [u] . c retry_scid ) ( bytes_extend_bytes . c retry_scid rscid )
+    ( vec_clear [u] . c dcid ) ( bytes_extend_bytes . c dcid rscid )
+    : ( Vec u ) tok ( quic_hdr_token h dgram )
+    ( vec_clear [u] . c token ) ( bytes_extend_bytes . c token tok )
+    ( vec_free [u] tok )
+    ( quic_keys_free . c k_tx0 ) ( quic_keys_free . c k_rx0 )
+    = . c k_tx0 ( quic_initial_keys rscid T )
+    = . c k_rx0 ( quic_initial_keys rscid F )
+    ( vec_free [u] rscid )
+    // the Initial we sent is gone as far as the server is concerned
+    ( quic_rec_discard_space . c rec 0 )
+    ( vec_clear [u] . c retx0 )
+    ( vec_clear [u] . c crypto_out0 )
+    ( bytes_extend_bytes . c crypto_out0 ( quic_tls_cli_client_hello . c tlsc ) )
+    = . c crypto_sent0 0
+    = . c ack_needed0 0
+}
+
 // One packet out of a datagram. Returns the offset after it, or -1 to
 // stop processing the datagram.
 @ __qc_recv_packet * QuicConn c ( Vec u ) dgram i off → i {
@@ -1113,10 +1383,12 @@ $ `stdlib/std/quic_recovery.nu`
     ? == # i h 0 { ^ -1 } {}
     : i ptype . h ptype
     : i end . h end
-    ? == ptype 5 { ( quic_hdr_free h ) ^ -1 } {}
+    ? == ptype 5 { ( __qc_on_vn c dgram h ) ( quic_hdr_free h ) ^ -1 } {}
     ? & != ptype 4 != . h version 1 { ( quic_hdr_free h ) ^ -1 } {}
     ? ! ( __qc_is_ours c dgram h ) { ( quic_hdr_free h ) ^ end } {}
-    ? | == ptype 1 == ptype 3 { ( quic_hdr_free h ) ^ end } {}
+    // a Retry is never coalesced with anything else (§17.2.5.1)
+    ? == ptype 3 { ( __qc_on_retry c dgram off h ) ( quic_hdr_free h ) ^ -1 } {}
+    ? == ptype 1 { ( quic_hdr_free h ) ^ end } {}
     : i space ? == ptype 0 0 ? == ptype 2 1 2
     // 1-RTT before the client's Finished: dropped (see the header).
     ? & == space 2 < . c tls_state 2 { ( quic_hdr_free h ) ^ end } {}
@@ -1148,8 +1420,17 @@ $ `stdlib/std/quic_recovery.nu`
     } {
         ?? ( quic_open keys pn hdr body ) { T p → { ( vec_free [u] payload ) = payload p = opened T } F → {} }
     }
+    // the server's SCID from its first authenticated Initial is the DCID
+    // we send to from now on (§7.2)
+    : ( Vec u ) srv_scid ? & & opened == space 0 == . c dcid_learned 0 ( quic_hdr_scid h dgram ) ( vec_new [u] )
     ( vec_free [u] body ) ( vec_free [u] hdr ) ( vec_free [u] pkt ) ( quic_hdr_free h )
-    ? ! opened { ( vec_free [u] payload ) ^ end } {}
+    ? ! opened { ( vec_free [u] payload ) ( vec_free [u] srv_scid ) ^ end } {}
+    ? & == space 0 == . c dcid_learned 0 {
+        = . c dcid_learned 1
+        ( vec_clear [u] . c dcid )
+        ( bytes_extend_bytes . c dcid srv_scid )
+    } {}
+    ( vec_free [u] srv_scid )
     // reserved bits (§17.2 / §17.3.1), only meaningful once authenticated
     ? != & b0 12 0 { ( vec_free [u] payload ) ( __qc_fail c 0 10 0 ) ^ -1 } {}
     ? ( __qc_rx_seen c space pn ) { ( vec_free [u] payload ) ^ end } {}
@@ -1526,16 +1807,17 @@ $ `stdlib/std/quic_recovery.nu`
     : ~ i ae1 0
     : ~ i ae2 0
     : ~ i used 0
-    // per-space header cost: long = 1+4+1+8+1+dcid+len(2)+pn(4 at most) + 16 tag
+    // per-space header cost: long = 1+4+1+8+1+dcid+token(varint+bytes, Initial)+len(2)+pn(4 at most) + 16 tag
+    : i tok_cost + ( quic_varint_size ( vec_len [u] . c token ) ) ( vec_len [u] . c token )
     : i hdr_long + + + + + 1 4 1 8 1 + ( vec_len [u] . c dcid ) + 2 4
     : i hdr_short + + 1 ( vec_len [u] . c dcid ) 4
     : ~ i has0 0
     : ~ i has1 0
     : ~ i has2 0
     ? & ( __qc_space_wants_send c 0 ) == . c keys0_dropped 0 {
-        : i room - - budget used + hdr_long 16
+        : i room - - budget used + + hdr_long tok_cost 16
         ? > room 0 { = ae0 ( __qc_build_payload c 0 room pay0 rt0 ) } {}
-        ? | > ( vec_len [u] pay0 ) 0 == . c close_sent 0 { = has0 1 = used + used + + hdr_long 16 ( vec_len [u] pay0 ) } {}
+        ? | > ( vec_len [u] pay0 ) 0 == . c close_sent 0 { = has0 1 = used + used + + + hdr_long tok_cost 16 ( vec_len [u] pay0 ) } {}
     } {}
     ? & ( __qc_space_wants_send c 1 ) == . c keys1_dropped 0 {
         : i room - - budget used + hdr_long 16
@@ -1555,8 +1837,9 @@ $ `stdlib/std/quic_recovery.nu`
         ( vec_free [u] rt0 ) ( vec_free [u] rt1 ) ( vec_free [u] rt2 )
         ^ dgram
     } {}
-    // A datagram carrying an ack-eliciting Initial is padded to 1200 (§14.1).
-    ? & != has0 0 != ae0 0 {
+    // A datagram carrying an ack-eliciting Initial is padded to 1200
+    // (§14.1) — a client pads every datagram with an Initial in it.
+    ? & != has0 0 | != ae0 0 != . c is_client 0 {
         ? < used 1200 {
             : i pad - 1200 used
             ? != has2 0 { ( quic_push_padding pay2 pad ) } { ? != has1 0 { ( quic_push_padding pay1 pad ) } { ( quic_push_padding pay0 pad ) } }
@@ -1568,7 +1851,7 @@ $ `stdlib/std/quic_recovery.nu`
         : i pn . c next_pn0
         : i pn_len 4
         : i length + + pn_len ( vec_len [u] pay0 ) 16
-        : ( Vec u ) hdr ( quic_long_hdr_build 0 . c dcid . c scid empty length pn pn_len )
+        : ( Vec u ) hdr ( quic_long_hdr_build 0 . c dcid . c scid . c token length pn pn_len )
         : ( Vec u ) pkt ( quic_packet_protect . c k_tx0 hdr pn pn_len pay0 )
         ( bytes_extend_bytes dgram pkt )
         ( quic_rec_on_sent . c rec 0 pn now ( vec_len [u] pkt ) ae0 rt0 )
@@ -1601,6 +1884,8 @@ $ `stdlib/std/quic_recovery.nu`
     ( vec_free [u] rt0 ) ( vec_free [u] rt1 ) ( vec_free [u] rt2 )
     = . c bytes_sent + . c bytes_sent ( vec_len [u] dgram )
     ? > ( vec_len [u] dgram ) 0 { = . c last_activity now } {}
+    // a client discards Initial keys when it first sends a Handshake packet (§4.9.1)
+    ? & != . c is_client 0 != has1 0 { ( __qc_drop_keys c 0 ) } {}
     ^ dgram
 }
 

--- a/stdlib/std/quic_tls.nu
+++ b/stdlib/std/quic_tls.nu
@@ -193,3 +193,178 @@ $ `stdlib/std/quic_rxbuf.nu`
 @ quic_tls_srv_c_ap * QuicTlsSrv s → ( Vec u ) { ^ . . s hs c_ap }
 
 @ quic_tls_srv_s_ap * QuicTlsSrv s → ( Vec u ) { ^ . . s hs s_ap }
+
+// ── client role ──────────────────────────────────────────────────
+//
+// The same shape over `CliHs` (std/tls.nu). Levels: the ClientHello
+// leaves at Initial and the ServerHello arrives there; the server's
+// flight (EncryptedExtensions, Certificate, CertificateVerify,
+// Finished) arrives at Handshake and the client Finished leaves there;
+// NewSessionTicket arrives at 1-RTT. The ClientHello carries our
+// quic_transport_parameters and the EncryptedExtensions must carry the
+// server's (missing_extension otherwise).
+//
+//   ( quic_tls_cli_new server_name alpn tp )  → *QuicTlsCli  `alpn` = "h3" (a space-separated preference
+//                                                            list); `tp` = encoded client transport parameters
+//   ( quic_tls_cli_free s )                   → v
+//   ( quic_tls_cli_crypto s level off data )  → i            0 ok, else a QUIC transport error code (as the server)
+//   ( quic_tls_cli_state s )                  → i            0 awaiting ServerHello · 1 awaiting the server
+//                                                            flight · 2 handshake complete (Finished queued) · 3 failed
+//   ( quic_tls_cli_take_out s level )         → ( Vec u )    OWNED bytes to send as CRYPTO at that level
+//   ( quic_tls_cli_server_tp s )              → ( Vec u )    BORROWED body of the server's transport parameters (state ≥ 2)
+//   ( quic_tls_cli_alpn s ) · ( quic_tls_cli_cipher s ) · ( quic_tls_cli_is_pq s )
+//   ( quic_tls_cli_verify s server_name )     → i            0 = the server's certificate verifies for
+//                                                            `server_name` (std/tls_verify.nu), 42 bad_certificate otherwise
+//   secrets (BORROWED): quic_tls_cli_c_hs / _s_hs (state ≥ 1) · _c_ap / _s_ap (state ≥ 2)
+//
+// Refused: a TLS 1.2 ServerHello (protocol_version — QUIC is TLS 1.3
+// only, RFC 9001 §4.2), a HelloRetryRequest (this client offers every
+// group it has, so there is nothing to retry with), KeyUpdate at any
+// level, anything but the ServerHello at Initial, anything but the
+// flight at Handshake, anything but NewSessionTicket at 1-RTT, and a
+// handshake that ends without an ALPN (§8.1).
+
+: QuicTlsCli {
+    * CliHs hs
+    * QuicRxBuf rx0
+    * QuicRxBuf rx1
+    * QuicRxBuf rx2
+    i state
+    ( Vec u ) out0
+    ( Vec u ) out1
+    ( Vec u ) out2
+}
+
+@ quic_tls_cli_new s server_name s alpn ( Vec u ) tp → *QuicTlsCli {
+    : *QuicTlsCli s # *QuicTlsCli ( nurl_alloc Z QuicTlsCli )
+    : ( Vec u ) nosess ( vec_new [u] )
+    = . s hs ( _cli_hs_new server_name alpn nosess )
+    ( vec_free [u] nosess )
+    // ClientHello carries quic_transport_parameters (0x0039); the
+    // EncryptedExtensions must bring the server's back.
+    : ( Vec u ) ext ( vec_with_cap [u] + 4 ( vec_len [u] tp ) )
+    ( _tls_u16 ext 57 )
+    ( _blk16 ext tp )
+    ( _cli_hs_set_ext . s hs ext 57 )
+    ( vec_free [u] ext )
+    // no TLS compatibility mode in QUIC (RFC 9001 §8.4): an empty
+    // legacy_session_id — Google's and Cloudflare's servers refuse the
+    // 32-byte one with illegal_parameter (UNEXPECTED_COMPATIBILITY_MODE)
+    ( _cli_hs_set_compat . s hs 0 )
+    ( _cli_hs_start . s hs )
+    = . s rx0 ( quic_rxbuf_new ( quic_crypto_rx_cap ) )
+    = . s rx1 ( quic_rxbuf_new ( quic_crypto_rx_cap ) )
+    = . s rx2 ( quic_rxbuf_new ( quic_crypto_rx_cap ) )
+    = . s state 0
+    = . s out0 ( bytes_slice . . s hs out_ch 0 ( vec_len [u] . . s hs out_ch ) )
+    = . s out1 ( vec_new [u] )
+    = . s out2 ( vec_new [u] )
+    ^ s
+}
+
+@ quic_tls_cli_free * QuicTlsCli s → v {
+    ? == # i s 0 { ^ } {}
+    ( _cli_hs_free . s hs )
+    ( quic_rxbuf_free . s rx0 )
+    ( quic_rxbuf_free . s rx1 )
+    ( quic_rxbuf_free . s rx2 )
+    ( vec_free [u] . s out0 )
+    ( vec_free [u] . s out1 )
+    ( vec_free [u] . s out2 )
+    ( nurl_free # s s )
+}
+
+@ quic_tls_cli_state * QuicTlsCli s → i { ^ . s state }
+
+@ __qtc_rx_of * QuicTlsCli s i level → *QuicRxBuf {
+    ? == level 0 { ^ . s rx0 } {}
+    ? == level 1 { ^ . s rx1 } {}
+    ^ . s rx2
+}
+
+// Handle one complete handshake message at `level`.
+@ __qtc_message * QuicTlsCli s i level ( Vec u ) m → i {
+    : i mtype ( __qt_bget m 0 )
+    ? | == mtype 24 == mtype 5 { ^ ( quic_err_crypto 10 ) } {}
+    ? == level 0 {
+        ? | != mtype 2 != . s state 0 { ^ ( quic_err_crypto 10 ) } {}
+        : i rc ( _cli_hs_server_hello . s hs m )
+        ? != rc 0 { = . s state 3 ^ ( quic_err_crypto rc ) } {}
+        // TLS 1.2 has no place in QUIC (RFC 9001 §4.2)
+        ? == . . s hs version 12 { = . s state 3 ^ ( quic_err_crypto 70 ) } {}
+        = . s state 1
+        ^ 0
+    } {}
+    ? == level 1 {
+        ? != . s state 1 { ^ ( quic_err_crypto 10 ) } {}
+        : i rc ( _cli_hs_message . s hs m )
+        ? != rc 0 { = . s state 3 ^ ( quic_err_crypto rc ) } {}
+        ? == . . s hs state 3 {
+            // QUIC has no other way to agree on an application protocol
+            // (RFC 9001 §8.1): no ALPN at all is no_application_protocol.
+            ? == ( vec_len [u] . . s hs alpn_sel ) 0 { = . s state 3 ^ ( quic_err_crypto 120 ) } {}
+            ( bytes_extend_bytes . s out1 . . s hs out_fin )
+            = . s state 2
+        } {}
+        ^ 0
+    } {}
+    // 1-RTT: NewSessionTicket is the one post-handshake message a server
+    // sends here (KeyUpdate was refused above). It is accepted and not
+    // kept — this client does not offer QUIC session resumption yet.
+    ? | != mtype 4 != . s state 2 { ^ ( quic_err_crypto 10 ) } {}
+    ^ 0
+}
+
+// Feed CRYPTO frame bytes. Returns 0, or the transport error code the
+// connection must close with.
+@ quic_tls_cli_crypto * QuicTlsCli s i level i off ( Vec u ) data → i {
+    ? == . s state 3 { ^ ( quic_err_protocol_violation ) } {}
+    ? | < level 0 > level 2 { ^ ( quic_err_protocol_violation ) } {}
+    : *QuicRxBuf r ( __qtc_rx_of s level )
+    ? ! ( quic_rxbuf_add r off data ) { ^ ( quic_err_crypto_buffer_exceeded ) } {}
+    ~ T {
+        : ( Vec u ) m ( __qt_rx_take r )
+        ? == ( vec_len [u] m ) 0 { ( vec_free [u] m ) ^ 0 } {}
+        : i rc ( __qtc_message s level m )
+        ( vec_free [u] m )
+        ? != rc 0 { = . s state 3 ^ rc } {}
+    }
+    ^ 0
+}
+
+// OWNED: the bytes queued for CRYPTO frames at `level`, cleared here.
+@ quic_tls_cli_take_out * QuicTlsCli s i level → ( Vec u ) {
+    : ( Vec u ) src ? == level 0 . s out0 ? == level 1 . s out1 . s out2
+    : ( Vec u ) out ( bytes_slice src 0 ( vec_len [u] src ) )
+    ( vec_clear [u] src )
+    ^ out
+}
+
+// The ClientHello once more, for a fresh Initial after a Retry.
+@ quic_tls_cli_client_hello * QuicTlsCli s → ( Vec u ) { ^ . . s hs out_ch }
+
+@ quic_tls_cli_server_tp * QuicTlsCli s → ( Vec u ) { ^ . . s hs ext_in }
+
+@ quic_tls_cli_alpn * QuicTlsCli s → ( Vec u ) { ^ . . s hs alpn_sel }
+
+@ quic_tls_cli_cipher * QuicTlsCli s → i { ^ ? == . . s hs cipher 1 1 2 }
+
+// T when the key exchange was X25519MLKEM768.
+@ quic_tls_cli_is_pq * QuicTlsCli s → b { ^ == . . s hs kx_group 4588 }
+
+// The CertificateVerify scheme the server signed with (see tls_cv_scheme).
+@ quic_tls_cli_sig_scheme * QuicTlsCli s → i { ^ . . s hs cv_scheme }
+
+@ quic_tls_cli_verify * QuicTlsCli s s server_name → i {
+    ? != . . s hs resumed 0 { ^ 0 } {}
+    : i rc ( tls_cert_verify . . s hs cert_msg . . s hs cv_scheme . . s hs cv_sig . . s hs th_cert server_name )
+    ^ ? == rc 0 0 42
+}
+
+@ quic_tls_cli_c_hs * QuicTlsCli s → ( Vec u ) { ^ . . s hs c_hs }
+
+@ quic_tls_cli_s_hs * QuicTlsCli s → ( Vec u ) { ^ . . s hs s_hs }
+
+@ quic_tls_cli_c_ap * QuicTlsCli s → ( Vec u ) { ^ . . s hs c_ap }
+
+@ quic_tls_cli_s_ap * QuicTlsCli s → ( Vec u ) { ^ . . s hs s_ap }

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -525,7 +525,7 @@ $ `stdlib/std/async_ffi.nu`
     : ( Vec u ) body ( vec_new [u] )
     ( _tls_u16 body 771 )  // legacy_version 0x0303
     ( _tls_cat body random )  // 32-byte random
-    ( vec_push [u] body # u 32 )  // session id length
+    ( vec_push [u] body # u ( vec_len [u] sessid ) )  // legacy_session_id (empty for QUIC)
     ( _tls_cat body sessid )
     // cipher_suites: TLS_CHACHA20_POLY1305_SHA256 (0x1303) +
     // TLS_AES_128_GCM_SHA256 (0x1301) — both use the SHA-256 key
@@ -1097,6 +1097,8 @@ $ `stdlib/std/async_ffi.nu`
 //                                                    a usable one becomes the pre_shared_key offer
 //   ( _cli_hs_set_ext h ext_out want )    → v        append `ext_out` (wire-framed extension(s)) to the
 //                                                    ClientHello; require EE extension `want` (0 = none)
+//   ( _cli_hs_set_compat h on )           → v        0 = no middlebox compatibility: an empty
+//                                                    legacy_session_id (QUIC, RFC 9001 §8.4); default 1
 //   ( _cli_hs_start h )                   → v        key shares + ClientHello into `out_ch`
 //   ( _cli_hs_server_hello h sh )         → i        0 ok · alert description otherwise. With TLS 1.2
 //                                                    chosen `version` is 12, nothing is derived, `sh`
@@ -1125,6 +1127,8 @@ $ `stdlib/std/async_ffi.nu`
     i ext_want  // EncryptedExtensions extension type required (0 = none)
     ( Vec u ) ext_in  // its body once seen
     i ext_in_present
+    i compat  // 1: TLS-over-TCP middlebox compatibility (a 32-byte legacy_session_id, RFC 8446 D.4);
+    // 0: QUIC, where the session id MUST be empty (RFC 9001 §8.4)
     i state
     i err  // failure kind: 1 TlsHandshake 2 TlsProtocol 3 TlsBadCipher 4 TlsHRR
     * Sha256 trh  // incremental transcript hash (0 once finished)
@@ -1169,6 +1173,7 @@ $ `stdlib/std/async_ffi.nu`
     = . h ext_want 0
     = . h ext_in ( vec_new [u] )
     = . h ext_in_present 0
+    = . h compat 1
     = . h state 0
     = . h err 0
     // Incremental transcript hash, snapshotted at the checkpoints —
@@ -1224,9 +1229,11 @@ $ `stdlib/std/async_ffi.nu`
     = . h ext_want want
 }
 
+@ _cli_hs_set_compat * CliHs h i on → v { = . h compat on }
+
 @ _cli_hs_free * CliHs h → v {
     ? == # i h 0 { ^ } {}
-    ? != # i . h trh 0 { ( __trh_abort . h trh ) } {}
+    ? != # i . h trh 0 { ( _trh_abort . h trh ) } {}
     ( vec_free [u] . h sni )
     ( vec_free [u] . h alpn )
     ( vec_free [u] . h ext_out )
@@ -1257,7 +1264,7 @@ $ `stdlib/std/async_ffi.nu`
 }
 
 // Discard a live transcript hasher (error paths).
-@ __trh_abort * Sha256 h → v {
+@ _trh_abort * Sha256 h → v {
     : ( Vec u ) d ( sha256_final h )
     ( vec_free [u] d )
 }
@@ -1325,7 +1332,7 @@ $ `stdlib/std/async_ffi.nu`
     ( vec_free [u] . h random )
     = . h random ( _rand_bytes 32 )
     ( vec_free [u] . h sessid )
-    = . h sessid ( _rand_bytes 32 )
+    = . h sessid ( _rand_bytes ? != . h compat 0 32 0 )
     : ~ i obf_age 0
     ? == . h offer 1 {
         : i age - ( now_ms ) . h tk_received_ms

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -246,7 +246,7 @@ $ `stdlib/std/async_ffi.nu`
 // random, so the pair looks fine and the classical half is silently
 // worthless. Returning an empty vector here makes the caller's
 // `_all_zero` test fail closed.
-@ __hybrid_shared * TlsConn c ( Vec u ) priv ( Vec u ) spub → ( Vec u ) {
+@ __hybrid_shared ( Vec u ) dk ( Vec u ) priv ( Vec u ) spub → ( Vec u ) {
     : ( Vec u ) ct ( bytes_slice spub 0 1088 )
     : ( Vec u ) xpub ( bytes_slice spub 1088 1120 )
     : ( Vec u ) xs ( x25519 priv xpub )
@@ -254,7 +254,7 @@ $ `stdlib/std/async_ffi.nu`
         ( vec_free [u] xs ) ( vec_free [u] xpub ) ( vec_free [u] ct )
         ^ ( vec_new [u] )
     } {}
-    : ( Vec u ) out ( mlkem_decaps 768 . c kx_mlkem ct )
+    : ( Vec u ) out ( mlkem_decaps 768 dk ct )
     ( bytes_extend_bytes out xs )
     ( vec_free [u] xs )
     ( vec_free [u] xpub )
@@ -521,7 +521,7 @@ $ `stdlib/std/async_ffi.nu`
 }
 
 // ── ClientHello ───────────────────────────────────────────────────
-@ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) pqpub ( Vec u ) random ( Vec u ) sessid s alpn ( Vec u ) psk_id i obf_age → ( Vec u ) {
+@ __build_client_hello ( Vec u ) host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) pqpub ( Vec u ) random ( Vec u ) sessid ( Vec u ) alp_list ( Vec u ) ext_extra ( Vec u ) psk_id i obf_age → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
     ( _tls_u16 body 771 )  // legacy_version 0x0303
     ( _tls_cat body random )  // 32-byte random
@@ -556,12 +556,12 @@ $ `stdlib/std/async_ffi.nu`
 
     // server_name (0x0000)
     : ( Vec u ) sni ( vec_new [u] )
-    : i hl ( nurl_str_len host )
+    : i hl ( vec_len [u] host )
     ( _tls_u16 sni + hl 3 )  // ServerNameList length
     ( vec_push [u] sni # u 0 )  // name_type host_name
     ( _tls_u16 sni hl )
     : ~ i k 0
-    ~ < k hl { ( vec_push [u] sni # u ( nurl_str_get host k ) ) = k + k 1 }
+    ~ < k hl { ( vec_push [u] sni # u ( _t_bget host k ) ) = k + k 1 }
     ( _tls_u16 ext 0 )
     ( _blk16 ext sni )
     ( vec_free [u] sni )
@@ -660,11 +660,11 @@ $ `stdlib/std/async_ffi.nu`
     ( vec_free [u] ks )
 
     // application_layer_protocol_negotiation (0x0010), RFC 7301: the
-    // protocols we speak, most preferred first ("h2 http/1.1" — the same
-    // space-separated form the server's listener takes). Only emitted
-    // when at least one protocol was requested; otherwise the extension
-    // is omitted and the connect behaves exactly as before.
-    : ( Vec u ) alp_list ( tls_alpn_pack alpn )
+    // protocols we speak, most preferred first — `alp_list` is the wire
+    // form tls_alpn_pack makes of "h2 http/1.1", the same list the
+    // server's listener takes. Only emitted when at least one protocol
+    // was requested; otherwise the extension is omitted and the connect
+    // behaves exactly as before.
     ? > ( vec_len [u] alp_list ) 0 {
         : ( Vec u ) alp ( vec_new [u] )
         ( _tls_u16 alp ( vec_len [u] alp_list ) )  // ProtocolNameList length
@@ -673,7 +673,6 @@ $ `stdlib/std/async_ffi.nu`
         ( _blk16 ext alp )
         ( vec_free [u] alp )
     } {}
-    ( vec_free [u] alp_list )
 
     // ── resumption (RFC 8446 §4.2.9 + §4.2.11) ──
     // psk_key_exchange_modes goes in EVERY hello, offer or not: it is
@@ -690,6 +689,9 @@ $ `stdlib/std/async_ffi.nu`
     ( _tls_u16 ext 45 )
     ( _blk16 ext modes )
     ( vec_free [u] modes )
+    // Whatever the driver asked for (QUIC: quic_transport_parameters),
+    // already wire-framed.
+    ( _tls_cat ext ext_extra )
     // pre_shared_key MUST be the last extension: its binder is an HMAC
     // over the ClientHello up to (not including) the binders list, so
     // everything else has to be in place first. The binder bytes here
@@ -880,34 +882,6 @@ $ `stdlib/std/async_ffi.nu`
     ^ == . c resumed 1
 }
 
-// Load an exported session onto a fresh conn as the offer for its
-// handshake. F (and nothing loaded) for an empty, malformed or expired
-// blob — the caller then simply does a full handshake.
-@ __sess_load * TlsConn c ( Vec u ) sess → b {
-    : i n ( vec_len [u] sess )
-    ? | < n 21 != ( _t_bget sess 0 ) 1 { ^ F } {}
-    : i age_add ( _rdint sess 1 4 )
-    : i lifetime ( _rdint sess 5 4 )
-    : i received ( _rdint sess 9 8 )
-    : i plen ( _rdint sess 17 2 )
-    : i tp + 19 plen
-    ? > + tp 2 n { ^ F } {}
-    : i tlen ( _rdint sess tp 2 )
-    ? | == tlen 0 != + + tp 2 tlen n { ^ F } {}
-    // RFC 8446 §4.6.1: a ticket is usable for ticket_lifetime seconds
-    // (never more than 7 days); past that the server will decline it, so
-    // do not offer it.
-    : i age_ms - ( now_ms ) received
-    ? | < age_ms 0 > age_ms * lifetime 1000 { ^ F } {}
-    ( vec_free [u] . c tk_psk ) ( vec_free [u] . c tk_ticket )
-    = . c tk_psk ( bytes_slice sess 19 tp )
-    = . c tk_ticket ( bytes_slice sess + tp 2 n )
-    = . c tk_age_add age_add
-    = . c tk_lifetime lifetime
-    = . c tk_received_ms received
-    ^ T
-}
-
 // Post-handshake messages that arrive inside the application-data
 // stream. NewSessionTicket (4) is kept — its PSK is derived from this
 // connection's resumption_master_secret — so tls_session_export can hand
@@ -1036,6 +1010,13 @@ $ `stdlib/std/async_ffi.nu`
 // space-separated offer `list`.
 @ _alpn_offered s list ( Vec u ) sel → b {
     : ( Vec u ) packed ( tls_alpn_pack list )
+    : b r ( _alpn_offered_packed packed sel )
+    ( vec_free [u] packed )
+    ^ r
+}
+
+// The same over an offer already in wire form.
+@ _alpn_offered_packed ( Vec u ) packed ( Vec u ) sel → b {
     : i n ( vec_len [u] packed )
     : i sl ( vec_len [u] sel )
     : ~ i p 0
@@ -1053,7 +1034,6 @@ $ `stdlib/std/async_ffi.nu`
         } {}
         = p + + p 1 tl
     }
-    ( vec_free [u] packed )
     ^ found
 }
 
@@ -1096,11 +1076,488 @@ $ `stdlib/std/async_ffi.nu`
     ^ out
 }
 
-// Core client handshake. `alpn` is the space-separated list of ALPN
-// protocols to offer, most preferred first (e.g. "h2 http/1.1"); empty
-// means no ALPN extension is sent. The negotiated protocol (from the
-// server's EncryptedExtensions, checked to be one we offered) is stored
-// in `c.alpn_sel`.
+// ── the client handshake machine ──────────────────────────────────
+//
+// `CliHs` is the TLS 1.3 client handshake with no socket in it — the
+// same split `std/tls_server.nu` gives the server in `SrvHs`: whole
+// handshake messages go in, the messages to send come out, and the
+// traffic secrets are read straight off the machine. Two drivers:
+//
+//   * `__tls_handshake` below (TCP): sends `out_ch` as a plaintext
+//     record, feeds the ServerHello and then the encrypted server
+//     flight message by message, installs the secrets as record keys,
+//     sends `out_fin` under the handshake keys.
+//   * `std/quic_tls.nu` (QUIC, RFC 9001, client role): CRYPTO frame
+//     bytes per encryption level, packet keys from the same secrets,
+//     the quic_transport_parameters extension carried through
+//     `ext_out` / `ext_want` / `ext_in`.
+//
+//   ( _cli_hs_new server_name alpn sess ) → *CliHs   `alpn` = "h2 http/1.1" (empty: no ALPN);
+//                                                    `sess` = a tls_session_export blob (empty: none) —
+//                                                    a usable one becomes the pre_shared_key offer
+//   ( _cli_hs_set_ext h ext_out want )    → v        append `ext_out` (wire-framed extension(s)) to the
+//                                                    ClientHello; require EE extension `want` (0 = none)
+//   ( _cli_hs_start h )                   → v        key shares + ClientHello into `out_ch`
+//   ( _cli_hs_server_hello h sh )         → i        0 ok · alert description otherwise. With TLS 1.2
+//                                                    chosen `version` is 12, nothing is derived, `sh`
+//                                                    is kept, and the caller decides what to do
+//   ( _cli_hs_message h m )               → i        EncryptedExtensions / Certificate /
+//                                                    CertificateVerify / Finished; 0 ok · alert
+//                                                    description. After the Finished `state` is 3 and
+//                                                    out_fin, c_ap / s_ap, res_master are set
+//   ( _cli_hs_err h )                     → TlsErr   what a failure was, in the record layer's terms
+//   ( _cli_hs_free h )                    → v
+//
+// `state`: 0 new · 1 ClientHello built (awaiting ServerHello) · 2
+// handshake secrets derived (awaiting the server flight) · 3 done ·
+// 4 failed. Every `( Vec u )` field is owned by the machine until
+// `_cli_hs_free`; a caller that wants to keep one copies (or moves) it.
+//
+// The certificate is NOT verified here: `cert_msg`, `cv_scheme`,
+// `cv_sig` and `th_cert` are captured for `tls_cert_verify`, exactly as
+// the record layer has always done (`__verify_conn`). A resumed
+// handshake captures nothing — the PSK authenticates the server.
+
+: CliHs {
+    ( Vec u ) sni  // host bytes for server_name
+    ( Vec u ) alpn  // ALPN offer, wire form (tls_alpn_pack)
+    ( Vec u ) ext_out  // extra ClientHello extension(s), wire-framed
+    i ext_want  // EncryptedExtensions extension type required (0 = none)
+    ( Vec u ) ext_in  // its body once seen
+    i ext_in_present
+    i state
+    i err  // failure kind: 1 TlsHandshake 2 TlsProtocol 3 TlsBadCipher 4 TlsHRR
+    * Sha256 trh  // incremental transcript hash (0 once finished)
+    i cipher  // 0 ChaCha20-Poly1305 · 1 AES-128-GCM
+    i version  // 13 / 12, known from the ServerHello on
+    i kx_group  // 4588 X25519MLKEM768 · 29 x25519 · 23 secp256r1
+    i resumed  // 1 when the server took the offered ticket
+    i offer  // 1 when a ticket was offered
+    ( Vec u ) x_priv  // X25519 ephemeral
+    ( Vec u ) x_pub
+    ( Vec u ) p256_priv  // P-256 ephemeral scalar
+    ( Vec u ) pq_dk  // ML-KEM-768 decapsulation key
+    ( Vec u ) random
+    ( Vec u ) sessid
+    ( Vec u ) tk_ticket  // the offered ticket and its PSK
+    ( Vec u ) tk_psk
+    i tk_age_add
+    i tk_lifetime
+    i tk_received_ms
+    ( Vec u ) res_early  // early_secret(PSK) while offering
+    ( Vec u ) alpn_sel  // what the server selected (checked against `alpn`)
+    ( Vec u ) c_hs
+    ( Vec u ) s_hs
+    ( Vec u ) master
+    ( Vec u ) c_ap
+    ( Vec u ) s_ap
+    ( Vec u ) res_master
+    ( Vec u ) cert_msg  // raw Certificate message, for the verifier
+    ( Vec u ) cv_sig  // CertificateVerify signature
+    ( Vec u ) th_cert  // transcript hash through Certificate
+    i cv_scheme  // CertificateVerify SignatureScheme
+    ( Vec u ) out_ch  // the ClientHello, to send in the clear
+    ( Vec u ) out_fin  // the client Finished, to send under c_hs
+    ( Vec u ) sh  // the ServerHello, kept only for a TLS 1.2 fallback
+}
+
+@ _cli_hs_new s server_name s alpn ( Vec u ) sess → *CliHs {
+    : *CliHs h # *CliHs ( nurl_alloc Z CliHs )
+    = . h sni ( bytes_from_str server_name )
+    = . h alpn ( tls_alpn_pack alpn )
+    = . h ext_out ( vec_new [u] )
+    = . h ext_want 0
+    = . h ext_in ( vec_new [u] )
+    = . h ext_in_present 0
+    = . h state 0
+    = . h err 0
+    // Incremental transcript hash, snapshotted at the checkpoints —
+    // the server's machine hashes the same way.
+    = . h trh ( sha256_init )
+    = . h cipher 0
+    = . h version 13
+    = . h kx_group 0
+    = . h resumed 0
+    = . h offer 0
+    = . h x_priv ( vec_new [u] )
+    = . h x_pub ( vec_new [u] )
+    = . h p256_priv ( vec_new [u] )
+    = . h pq_dk ( vec_new [u] )
+    = . h random ( vec_new [u] )
+    = . h sessid ( vec_new [u] )
+    = . h tk_ticket ( vec_new [u] )
+    = . h tk_psk ( vec_new [u] )
+    = . h tk_age_add 0
+    = . h tk_lifetime 0
+    = . h tk_received_ms 0
+    = . h res_early ( vec_new [u] )
+    = . h alpn_sel ( vec_new [u] )
+    = . h c_hs ( vec_new [u] )
+    = . h s_hs ( vec_new [u] )
+    = . h master ( vec_new [u] )
+    = . h c_ap ( vec_new [u] )
+    = . h s_ap ( vec_new [u] )
+    = . h res_master ( vec_new [u] )
+    = . h cert_msg ( vec_new [u] )
+    = . h cv_sig ( vec_new [u] )
+    = . h th_cert ( vec_new [u] )
+    = . h cv_scheme 0
+    = . h out_ch ( vec_new [u] )
+    = . h out_fin ( vec_new [u] )
+    = . h sh ( vec_new [u] )
+    // A usable exported session becomes the pre_shared_key offer; the
+    // server may still decline it (rotated ticket key, expired, or no
+    // resumption at all), in which case the handshake is simply the
+    // full one — nothing here is trusted until the ServerHello says
+    // the ticket was taken.
+    ? ( __cli_sess_load h sess ) {
+        = . h offer 1
+        ( vec_free [u] . h res_early )
+        = . h res_early ( _psk_early . h tk_psk )
+    } {}
+    ^ h
+}
+
+@ _cli_hs_set_ext * CliHs h ( Vec u ) ext_out i want → v {
+    ( vec_clear [u] . h ext_out )
+    ( bytes_extend_bytes . h ext_out ext_out )
+    = . h ext_want want
+}
+
+@ _cli_hs_free * CliHs h → v {
+    ? == # i h 0 { ^ } {}
+    ? != # i . h trh 0 { ( __trh_abort . h trh ) } {}
+    ( vec_free [u] . h sni )
+    ( vec_free [u] . h alpn )
+    ( vec_free [u] . h ext_out )
+    ( vec_free [u] . h ext_in )
+    ( vec_free [u] . h x_priv )
+    ( vec_free [u] . h x_pub )
+    ( vec_free [u] . h p256_priv )
+    ( vec_free [u] . h pq_dk )
+    ( vec_free [u] . h random )
+    ( vec_free [u] . h sessid )
+    ( vec_free [u] . h tk_ticket )
+    ( vec_free [u] . h tk_psk )
+    ( vec_free [u] . h res_early )
+    ( vec_free [u] . h alpn_sel )
+    ( vec_free [u] . h c_hs )
+    ( vec_free [u] . h s_hs )
+    ( vec_free [u] . h master )
+    ( vec_free [u] . h c_ap )
+    ( vec_free [u] . h s_ap )
+    ( vec_free [u] . h res_master )
+    ( vec_free [u] . h cert_msg )
+    ( vec_free [u] . h cv_sig )
+    ( vec_free [u] . h th_cert )
+    ( vec_free [u] . h out_ch )
+    ( vec_free [u] . h out_fin )
+    ( vec_free [u] . h sh )
+    ( nurl_free # s h )
+}
+
+// Discard a live transcript hasher (error paths).
+@ __trh_abort * Sha256 h → v {
+    : ( Vec u ) d ( sha256_final h )
+    ( vec_free [u] d )
+}
+
+@ __cli_hs_fail * CliHs h i err i alert → i {
+    = . h state 4
+    = . h err err
+    ^ alert
+}
+
+@ _cli_hs_err * CliHs h → TlsErr {
+    ? == . h err 2 { ^ # TlsErr TlsProtocol } {}
+    ? == . h err 3 { ^ # TlsErr TlsBadCipher } {}
+    ? == . h err 4 { ^ # TlsErr TlsHRR } {}
+    ^ # TlsErr TlsHandshake
+}
+
+// Load an exported session onto the machine as the offer for its
+// handshake. F (and nothing loaded) for an empty, malformed or expired
+// blob — the caller then simply does a full handshake.
+@ __cli_sess_load * CliHs h ( Vec u ) sess → b {
+    : i n ( vec_len [u] sess )
+    ? | < n 21 != ( _t_bget sess 0 ) 1 { ^ F } {}
+    : i age_add ( _rdint sess 1 4 )
+    : i lifetime ( _rdint sess 5 4 )
+    : i received ( _rdint sess 9 8 )
+    : i plen ( _rdint sess 17 2 )
+    : i tp + 19 plen
+    ? > + tp 2 n { ^ F } {}
+    : i tlen ( _rdint sess tp 2 )
+    ? | == tlen 0 != + + tp 2 tlen n { ^ F } {}
+    // RFC 8446 §4.6.1: a ticket is usable for ticket_lifetime seconds
+    // (never more than 7 days); past that the server will decline it, so
+    // do not offer it.
+    : i age_ms - ( now_ms ) received
+    ? | < age_ms 0 > age_ms * lifetime 1000 { ^ F } {}
+    ( vec_free [u] . h tk_psk ) ( vec_free [u] . h tk_ticket )
+    = . h tk_psk ( bytes_slice sess 19 tp )
+    = . h tk_ticket ( bytes_slice sess + tp 2 n )
+    = . h tk_age_add age_add
+    = . h tk_lifetime lifetime
+    = . h tk_received_ms received
+    ^ T
+}
+
+// Fresh key shares for every group we offer and the ClientHello that
+// carries them, into `out_ch`.
+@ _cli_hs_start * CliHs h → v {
+    ? != . h state 0 { ^ } {}
+    ( vec_free [u] . h x_priv )
+    = . h x_priv ( _rand_bytes 32 )
+    ( vec_free [u] . h x_pub )
+    = . h x_pub ( x25519_base . h x_priv )
+    ( vec_free [u] . h p256_priv )
+    = . h p256_priv ( _rand_bytes 32 )
+    : ( Vec u ) p256pub ( p256_ecdh_keygen . h p256_priv )
+    // ML-KEM-768 for the hybrid group. The decapsulation key stays on
+    // the machine until the server's share arrives; the encapsulation
+    // key travels in the ClientHello.
+    : *MlkemKeys pqkeys ( mlkem_keygen 768 )
+    : ( Vec u ) pqpub ( bytes_slice ( mlkem_ek pqkeys ) 0 ( vec_len [u] ( mlkem_ek pqkeys ) ) )
+    ( vec_free [u] . h pq_dk )
+    = . h pq_dk ( bytes_slice ( mlkem_dk pqkeys ) 0 ( vec_len [u] ( mlkem_dk pqkeys ) ) )
+    ( mlkem_keys_free pqkeys )
+    ( vec_free [u] . h random )
+    = . h random ( _rand_bytes 32 )
+    ( vec_free [u] . h sessid )
+    = . h sessid ( _rand_bytes 32 )
+    : ~ i obf_age 0
+    ? == . h offer 1 {
+        : i age - ( now_ms ) . h tk_received_ms
+        = obf_age & + age . h tk_age_add 4294967295
+    } {}
+    : ( Vec u ) noid ( vec_new [u] )
+    : ( Vec u ) ch ( __build_client_hello . h sni . h x_pub p256pub pqpub . h random . h sessid . h alpn . h ext_out ? == . h offer 1 . h tk_ticket noid obf_age )
+    ( vec_free [u] noid )
+    ( vec_free [u] pqpub )
+    ( vec_free [u] p256pub )
+    ? == . h offer 1 {
+        : ( Vec u ) binder ( _psk_binder_over . h res_early ch - ( vec_len [u] ch ) 35 )
+        ( __ch_patch_binder ch binder )
+        ( vec_free [u] binder )
+    } {}
+    ( sha256_update . h trh ch )
+    ( vec_free [u] . h out_ch )
+    = . h out_ch ch
+    = . h state 1
+}
+
+// The ServerHello: cipher and version, the server's key share, and the
+// whole handshake key schedule. On success `state` is 2 and c_hs / s_hs
+// are the handshake traffic secrets.
+@ _cli_hs_server_hello * CliHs h ( Vec u ) sh → i {
+    ? != . h state 1 { ^ ( __cli_hs_fail h 1 10 ) } {}
+    // handshake type 2, and at least the fixed part of the body
+    ? | < ( vec_len [u] sh ) 42 != ( _t_bget sh 0 ) 2 { ^ ( __cli_hs_fail h 1 50 ) } {}
+    : i suite ( __sh_suite sh )
+    = . h version ( __suite_version suite )
+    = . h cipher ( __suite_cipher suite )
+    ? == . h version 12 {
+        // TLS 1.2: none of the 1.3 schedule applies. The hello is kept
+        // for a caller that speaks 1.2 (the TCP record layer does);
+        // QUIC refuses it.
+        ( vec_free [u] . h sh )
+        = . h sh ( bytes_slice sh 0 ( vec_len [u] sh ) )
+        ^ 0
+    } {}
+    : ~ ( Vec u ) spub ( vec_new [u] )
+    : ~ i bad 0
+    : !( Vec u ) TlsErr spkr ( __parse_server_hello sh )
+    ?? spkr {
+        T k → { ( vec_free [u] spub ) = spub k }
+        F e → { = bad ?? e { TlsHRR → 4 TlsBadCipher → 3 _ → 1 } }
+    }
+    // A HelloRetryRequest is not taken up (every share is in the first
+    // hello, so a server has no reason to send one): handshake_failure.
+    // A suite or key_share we cannot use is illegal_parameter.
+    ? != bad 0 { ( vec_free [u] spub ) ^ ( __cli_hs_fail h bad ? == bad 4 40 47 ) } {}
+    ( sha256_update . h trh sh )
+
+    // The negotiated group is told by the server key-exchange length:
+    // X25519 is 32 bytes, an uncompressed secp256r1 point is 65, and
+    // the X25519MLKEM768 share is 1088 + 32 = 1120.
+    //
+    // For the hybrid group the shared secret handed to the key schedule
+    // is `ML-KEM shared secret ‖ X25519 shared secret` — 64 bytes,
+    // ML-KEM first, matching the order of the shares. Concatenation is
+    // what makes it a hybrid worth having: HKDF-Extract over the pair
+    // is at least as strong as either half, so the handshake survives
+    // ML-KEM being broken *and* survives X25519 being broken.
+    : i sl ( vec_len [u] spub )
+    ? & & != sl 1120 != sl 65 != sl 32 { ( vec_free [u] spub ) ^ ( __cli_hs_fail h 2 47 ) } {}
+    = . h kx_group ? == sl 1120 4588 ? == sl 65 23 29
+    : ( Vec u ) ecdhe ? == sl 1120
+    ( __hybrid_shared . h pq_dk . h x_priv spub )
+    ? == sl 65 ( p256_ecdh_shared . h p256_priv spub ) ( x25519 . h x_priv spub )
+    ( vec_free [u] spub )
+    // RFC 8446 §7.4.2 — abort if the ECDHE output is all-zero (peer sent
+    // a low-order / small-subgroup point forcing a known shared secret).
+    ? ( _all_zero ecdhe ) { ( vec_free [u] ecdhe ) ^ ( __cli_hs_fail h 2 47 ) } {}
+
+    : ( Vec u ) z32 ( vec_with_cap [u] 32 )
+    : ~ i zk 0
+    ~ < zk 32 { ( vec_push [u] z32 # u 0 ) = zk + zk 1 }
+    : ( Vec u ) empty ( vec_new [u] )
+    : ( Vec u ) ehash ( sha256_pure empty )
+    // The server took our ticket iff its ServerHello carries
+    // pre_shared_key; then the early secret is the PSK's and no
+    // Certificate / CertificateVerify will follow — the PSK is the proof
+    // of identity (only the issuer of the ticket knows it).
+    ? & == . h offer 1 ( __sh_has_psk sh ) { = . h resumed 1 } {}
+    : ( Vec u ) early ? == . h resumed 1 ( bytes_slice . h res_early 0 32 ) ( hkdf_extract empty z32 )
+    : ( Vec u ) derived1 ( derive_secret early `derived` ehash )
+    : ( Vec u ) hs_secret ( hkdf_extract derived1 ecdhe )
+    : ( Vec u ) th_sh ( sha256_snapshot . h trh )
+    ( vec_free [u] . h c_hs )
+    = . h c_hs ( derive_secret hs_secret `c hs traffic` th_sh )
+    ( vec_free [u] . h s_hs )
+    = . h s_hs ( derive_secret hs_secret `s hs traffic` th_sh )
+    : ( Vec u ) derived2 ( derive_secret hs_secret `derived` ehash )
+    ( vec_free [u] . h master )
+    = . h master ( hkdf_extract derived2 z32 )
+    ( vec_free [u] ecdhe ) ( vec_free [u] z32 ) ( vec_free [u] empty ) ( vec_free [u] ehash )
+    ( vec_free [u] early ) ( vec_free [u] derived1 ) ( vec_free [u] hs_secret )
+    ( vec_free [u] th_sh ) ( vec_free [u] derived2 )
+    = . h state 2
+    ^ 0
+}
+
+// Offset of the data of extension `want` within msg[es..ee), or -1.
+@ __cli_find_ext ( Vec u ) msg i es i ee i want → i {
+    : ~ i p es
+    : ~ i found -1
+    ~ & < + p 4 + ee 1 == found -1 {
+        : i et ( _rdint msg p 2 )
+        : i el ( _rdint msg + p 2 2 )
+        ? == et want { = found + p 4 } { = p + + p 4 el }
+    }
+    ^ found
+}
+
+// One message of the server's flight, under the handshake keys.
+@ _cli_hs_message * CliHs h ( Vec u ) m → i {
+    ? != . h state 2 { ^ ( __cli_hs_fail h 1 10 ) } {}
+    ? < ( vec_len [u] m ) 4 { ^ ( __cli_hs_fail h 1 50 ) } {}
+    : i t ( _t_bget m 0 )
+    // Nothing but the flight belongs here: a hello, EndOfEarlyData, a
+    // ticket or a KeyUpdate before the Finished is unexpected_message.
+    ? | | | | == t 1 == t 2 == t 4 == t 5 == t 24 { ^ ( __cli_hs_fail h 1 10 ) } {}
+
+    ? == t 20 {
+        // Finished: the MAC is over the transcript BEFORE this message.
+        : ( Vec u ) th_cv ( sha256_snapshot . h trh )
+        : ( Vec u ) expect ( _finished_mac . h s_hs th_cv )
+        : b okfin ( _cmp_finished m expect )
+        ( vec_free [u] th_cv )
+        ( vec_free [u] expect )
+        ? okfin {} { ^ ( __cli_hs_fail h 1 51 ) }
+        ( sha256_update . h trh m )
+        // application traffic secrets: transcript through the server
+        // Finished — also what our own Finished is computed over
+        : ( Vec u ) th_sf ( sha256_snapshot . h trh )
+        ( vec_free [u] . h c_ap )
+        = . h c_ap ( derive_secret . h master `c ap traffic` th_sf )
+        ( vec_free [u] . h s_ap )
+        = . h s_ap ( derive_secret . h master `s ap traffic` th_sf )
+        : ( Vec u ) cfin ( _finished_mac . h c_hs th_sf )
+        : ( Vec u ) finmsg ( vec_with_cap [u] 36 )
+        ( vec_push [u] finmsg # u 20 )
+        ( _u24 finmsg 32 )
+        ( _tls_cat finmsg cfin )
+        // resumption_master_secret: transcript through our own Finished.
+        // Every NewSessionTicket the server sends from here on derives
+        // its PSK from this (see __client_take_ticket).
+        ( sha256_update . h trh finmsg )
+        : ( Vec u ) th_cf ( sha256_final . h trh )
+        = . h trh # *Sha256 0
+        ( vec_free [u] . h res_master )
+        = . h res_master ( derive_secret . h master `res master` th_cf )
+        ( vec_free [u] . h out_fin )
+        = . h out_fin finmsg
+        ( vec_free [u] th_sf ) ( vec_free [u] cfin ) ( vec_free [u] th_cf )
+        = . h state 3
+        ^ 0
+    } {}
+
+    ? == t 8 {
+        // EncryptedExtensions — the negotiated ALPN. The server must
+        // pick from OUR list (RFC 7301 §3.2); anything else is a
+        // protocol violation answered with no_application_protocol.
+        : ( Vec u ) sel ( __ee_alpn m )
+        ? > ( vec_len [u] sel ) 0 {
+            ? ( _alpn_offered_packed . h alpn sel ) {
+                ( vec_free [u] . h alpn_sel )
+                = . h alpn_sel sel
+            } {
+                ( vec_free [u] sel )
+                ^ ( __cli_hs_fail h 1 120 )
+            }
+        } { ( vec_free [u] sel ) }
+        // The extension a driver requires (QUIC: transport parameters).
+        ? != . h ext_want 0 {
+            : i n ( vec_len [u] m )
+            : i extlen ( _rdint m 4 2 )
+            : i ee ? > + 6 extlen n n + 6 extlen
+            : i xo ( __cli_find_ext m 6 ee . h ext_want )
+            ? < xo 0 { ^ ( __cli_hs_fail h 1 109 ) } {}
+            : i xl ( _rdint m - xo 2 2 )
+            ? > + xo xl ee { ^ ( __cli_hs_fail h 1 50 ) } {}
+            = . h ext_in_present 1
+            ( vec_clear [u] . h ext_in )
+            : ( Vec u ) xb ( bytes_slice m xo + xo xl )
+            ( bytes_extend_bytes . h ext_in xb )
+            ( vec_free [u] xb )
+        } {}
+    } {}
+    ? == t 11 {
+        ( vec_free [u] . h cert_msg )
+        = . h cert_msg ( bytes_slice m 0 ( vec_len [u] m ) )
+    } {}
+    ? == t 15 {
+        // CertificateVerify: the transcript through Certificate (before
+        // this message), the scheme and the signature — for the verifier.
+        ? < ( vec_len [u] m ) 8 { ^ ( __cli_hs_fail h 1 50 ) } {}
+        ( vec_free [u] . h th_cert )
+        = . h th_cert ( sha256_snapshot . h trh )
+        = . h cv_scheme ( _rdint m 4 2 )
+        : i siglen ( _rdint m 6 2 )
+        ? > + 8 siglen ( vec_len [u] m ) { ^ ( __cli_hs_fail h 1 50 ) } {}
+        ( vec_free [u] . h cv_sig )
+        = . h cv_sig ( bytes_slice m 8 + 8 siglen )
+    } {}
+    ( sha256_update . h trh m )
+    ^ 0
+}
+
+// Send an alert record (RFC 8446 §6) the way the peer can read it right
+// now: under the current write keys once there are any, in the clear
+// before that. Best effort — the connection is being torn down.
+@ __cli_say_alert * TlsConn c i desc → v {
+    ? > ( vec_len [u] . c c_key ) 0 { ( __send_alert c desc ) ^ } {}
+    : ( Vec u ) alert ( vec_with_cap [u] 2 )
+    ( vec_push [u] alert # u 2 )
+    ( vec_push [u] alert # u desc )
+    : !v TlsErr _w ( _send_plain c 21 alert )
+    ( vec_free [u] alert )
+}
+
+@ __cli_abort * TlsConn c * CliHs hs TlsErr e → !*TlsConn TlsErr {
+    ( _cli_hs_free hs )
+    ( tls_close c )
+    ^ @ !*TlsConn TlsErr { F e }
+}
+
+// Core client handshake over a socket: the record layer around `CliHs`.
+// `alpn` is the space-separated list of ALPN protocols to offer, most
+// preferred first (e.g. "h2 http/1.1"); empty means no ALPN extension
+// is sent. The negotiated protocol (from the server's
+// EncryptedExtensions, checked to be one we offered) is stored in
+// `c.alpn_sel`.
 @ __tls_handshake i raw s server_name s alpn ( Vec u ) sess → !*TlsConn TlsErr {
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
@@ -1143,223 +1600,110 @@ $ `stdlib/std/async_ffi.nu`
     = . c tk_lifetime 0
     = . c tk_received_ms 0
 
-    // ── resumption offer ──
-    // A usable exported session becomes the pre_shared_key offer; the
-    // server may still decline it (rotated ticket key, expired, or no
-    // resumption at all), in which case the handshake below is simply
-    // the full one — nothing here is trusted until the ServerHello says
-    // the ticket was taken.
-    : ~ i offer 0
-    : ~ i obf_age 0
-    ? ( __sess_load c sess ) {
-        = offer 1
-        ( vec_free [u] . c res_early )
-        = . c res_early ( _psk_early . c tk_psk )
-        : i age - ( now_ms ) . c tk_received_ms
-        = obf_age & + age . c tk_age_add 4294967295
-    } {}
-
-    // ── key share ──
-    : ( Vec u ) priv ( _rand_bytes 32 )
-    : ( Vec u ) cpub ( x25519_base priv )
-    : ( Vec u ) p256priv ( _rand_bytes 32 )
-    : ( Vec u ) p256pub ( p256_ecdh_keygen p256priv )
-    ( vec_free [u] . c kx_p256 )
-    = . c kx_p256 p256priv
-    // ML-KEM-768 for the hybrid group. The decapsulation key lives on the
-    // connection until the server's share arrives; the encapsulation key
-    // travels in the ClientHello.
-    : *MlkemKeys pqkeys ( mlkem_keygen 768 )
-    : ( Vec u ) pqpub ( bytes_slice ( mlkem_ek pqkeys ) 0 ( vec_len [u] ( mlkem_ek pqkeys ) ) )
-    ( vec_free [u] . c kx_mlkem )
-    = . c kx_mlkem ( bytes_slice ( mlkem_dk pqkeys ) 0 ( vec_len [u] ( mlkem_dk pqkeys ) ) )
-    ( mlkem_keys_free pqkeys )
-    : ( Vec u ) random ( _rand_bytes 32 )
-    : ( Vec u ) sessid ( _rand_bytes 32 )
-
-    // ── transcript ──
-    : ~ ( Vec u ) tr ( vec_new [u] )
-
     // ── ClientHello ──
-    : ( Vec u ) noid ( vec_new [u] )
-    : ( Vec u ) ch ( __build_client_hello server_name cpub p256pub pqpub random sessid alpn ? == offer 1 . c tk_ticket noid obf_age )
-    ( vec_free [u] noid )
-    ( vec_free [u] pqpub )
-    ( vec_free [u] p256pub )
-    ? == offer 1 {
-        : ( Vec u ) binder ( _psk_binder_over . c res_early ch - ( vec_len [u] ch ) 35 )
-        ( __ch_patch_binder ch binder )
-        ( vec_free [u] binder )
+    : *CliHs hs ( _cli_hs_new server_name alpn sess )
+    ( _cli_hs_start hs )
+    // The offered ticket stays on the connection: a resumed handshake
+    // brings no certificate and need not bring a new ticket, and
+    // tls_session_export still has to hand this one on.
+    ? == . hs offer 1 {
+        ( vec_free [u] . c tk_ticket ) ( vec_free [u] . c tk_psk )
+        = . c tk_ticket ( bytes_slice . hs tk_ticket 0 ( vec_len [u] . hs tk_ticket ) )
+        = . c tk_psk ( bytes_slice . hs tk_psk 0 ( vec_len [u] . hs tk_psk ) )
+        = . c tk_age_add . hs tk_age_add
+        = . c tk_lifetime . hs tk_lifetime
+        = . c tk_received_ms . hs tk_received_ms
     } {}
-    ( _tls_cat tr ch )
-    : !v TlsErr sw ( _send_plain c 22 ch )
-    ?? sw { T _ → {} F e → { ^ ( __fail c priv cpub random sessid ch tr e ) } }
+    : !v TlsErr sw ( _send_plain c 22 . hs out_ch )
+    ?? sw { T _ → {} F e → { ^ ( __cli_abort c hs e ) } }
 
     // ── ServerHello ──
     : !( Vec u ) TlsErr shr ( __next_hs c )
-    : ( Vec u ) sh ?? shr { T m → m F e → { ^ ( __fail c priv cpub random sessid ch tr e ) } }
-    ( _tls_cat tr sh )
-    : i suite ( __sh_suite sh )
-    = . c version ( __suite_version suite )
-    = . c cipher ( __suite_cipher suite )
+    : ( Vec u ) sh ?? shr { T m → m F e → { ^ ( __cli_abort c hs e ) } }
+    : i shrc ( _cli_hs_server_hello hs sh )
+    ? != shrc 0 {
+        ( vec_free [u] sh )
+        ( __cli_say_alert c shrc )
+        ^ ( __cli_abort c hs ( _cli_hs_err hs ) )
+    } {}
+    = . c version . hs version
+    = . c cipher . hs cipher
 
     // ── TLS 1.2 fallback ──
+    // The 1.2 path owns what it is handed, so it gets copies of the
+    // machine's ephemerals and the hellos, and the machine goes.
     ? == . c version 12 {
+        : ( Vec u ) priv ( bytes_slice . hs x_priv 0 ( vec_len [u] . hs x_priv ) )
+        : ( Vec u ) cpub ( bytes_slice . hs x_pub 0 ( vec_len [u] . hs x_pub ) )
+        : ( Vec u ) random ( bytes_slice . hs random 0 ( vec_len [u] . hs random ) )
+        : ( Vec u ) sessid ( bytes_slice . hs sessid 0 ( vec_len [u] . hs sessid ) )
+        : ( Vec u ) ch ( bytes_slice . hs out_ch 0 ( vec_len [u] . hs out_ch ) )
+        : ( Vec u ) tr ( bytes_slice . hs out_ch 0 ( vec_len [u] . hs out_ch ) )
+        ( _tls_cat tr sh )
+        ( vec_free [u] . c kx_p256 )
+        = . c kx_p256 ( bytes_slice . hs p256_priv 0 ( vec_len [u] . hs p256_priv ) )
+        ( _cli_hs_free hs )
         ^ ( __tls12_handshake c sh priv cpub random sessid ch tr )
     } {}
+    ( vec_free [u] sh )
+    = . c kx_group . hs kx_group
+    = . c resumed . hs resumed
 
-    : !( Vec u ) TlsErr spkr ( __parse_server_hello sh )
-    : ( Vec u ) spub ?? spkr { T k → k F e → { ( vec_free [u] sh ) ^ ( __fail c priv cpub random sessid ch tr e ) } }
-
-    // ── key schedule (handshake) ──
-    // Distinguish the negotiated group by the server key-exchange length:
-    // X25519 is 32 bytes, an uncompressed secp256r1 point is 65, and the
-    // X25519MLKEM768 share is 1088 + 32 = 1120.
-    //
-    // For the hybrid group the shared secret handed to the key schedule
-    // is `ML-KEM shared secret ‖ X25519 shared secret` — 64 bytes, ML-KEM
-    // first, matching the order of the shares. Concatenation is what
-    // makes it a hybrid worth having: HKDF-Extract over the pair is at
-    // least as strong as either half, so the handshake survives ML-KEM
-    // being broken *and* survives X25519 being broken.
-    = . c kx_group ? == ( vec_len [u] spub ) 1120 4588 ? == ( vec_len [u] spub ) 65 23 29
-    : ( Vec u ) ecdhe ? == ( vec_len [u] spub ) 1120
-    ( __hybrid_shared c priv spub )
-    ? == ( vec_len [u] spub ) 65 ( p256_ecdh_shared . c kx_p256 spub ) ( x25519 priv spub )
-    // H3: RFC 8446 §7.4.2 — abort if the ECDHE output is all-zero (peer sent a
-    // low-order / small-subgroup point forcing a known shared secret).
-    ? ( _all_zero ecdhe ) {
-        ( vec_free [u] sh ) ( vec_free [u] spub ) ( vec_free [u] ecdhe )
-        ^ ( __fail c priv cpub random sessid ch tr # TlsErr TlsProtocol )
-    } {}
-    : ( Vec u ) zeros ( _rand_bytes 0 )
-    : ( Vec u ) z32 ( vec_with_cap [u] 32 )
-    : ~ i zk 0
-    ~ < zk 32 { ( vec_push [u] z32 # u 0 ) = zk + zk 1 }
-    : ( Vec u ) empty ( vec_new [u] )
-    : ( Vec u ) ehash ( sha256_pure empty )
-    // The server took our ticket iff its ServerHello carries
-    // pre_shared_key; then the early secret is the PSK's and no
-    // Certificate / CertificateVerify will follow — the PSK is the proof
-    // of identity (only the issuer of the ticket knows it).
-    ? & == offer 1 ( __sh_has_psk sh ) { = . c resumed 1 } {}
-    : ( Vec u ) early ? == . c resumed 1 ( bytes_slice . c res_early 0 32 ) ( hkdf_extract empty z32 )
-    : ( Vec u ) derived1 ( derive_secret early `derived` ehash )
-    : ( Vec u ) hs_secret ( hkdf_extract derived1 ecdhe )
-
-    : ( Vec u ) th_sh ( sha256_pure tr )
-    : ( Vec u ) c_hs ( derive_secret hs_secret `c hs traffic` th_sh )
-    : ( Vec u ) s_hs ( derive_secret hs_secret `s hs traffic` th_sh )
-    ( _set_keys c 0 s_hs )
-    ( _set_keys c 1 c_hs )
+    // handshake keys: the client writes under c_hs, reads the server
+    // under s_hs
+    ( _set_keys c 0 . hs s_hs )
+    ( _set_keys c 1 . hs c_hs )
     = . c enc_read 1
 
-    : ( Vec u ) derived2 ( derive_secret hs_secret `derived` ehash )
-    : ( Vec u ) master ( hkdf_extract derived2 z32 )
-
     // ── server flight: EE, Certificate, CertVerify, Finished ──
-    : ~ i done 0
-    : ~ i flighterr 0
-    ~ & == done 0 == flighterr 0 {
+    : ~ i rc 0
+    ~ & == rc 0 != . hs state 3 {
         : !( Vec u ) TlsErr mr ( __next_hs c )
         ?? mr {
-            F _ → { = flighterr 1 }
+            F e → { ^ ( __cli_abort c hs e ) }
             T msg → {
-                : i t ( _t_bget msg 0 )
-                ? == t 20 {
-                    : ( Vec u ) th_cv ( sha256_pure tr )
-                    : ( Vec u ) expect ( _finished_mac s_hs th_cv )
-                    : b okfin ( _cmp_finished msg expect )
-                    ( vec_free [u] th_cv )
-                    ( vec_free [u] expect )
-                    ( _tls_cat tr msg )
-                    ? okfin {} { = flighterr 1 }
-                    = done 1
-                } {
-                    ? == t 11 {
-                        ( vec_free [u] . c cert_msg )
-                        = . c cert_msg ( bytes_slice msg 0 ( vec_len [u] msg ) )
-                    } {}
-                    ? == t 15 {
-                        // CertificateVerify: capture transcript-through-Certificate
-                        // (before appending this message) and the scheme + signature.
-                        : ( Vec u ) thc ( sha256_pure tr )
-                        ( vec_free [u] . c th_cert )
-                        = . c th_cert thc
-                        = . c cv_scheme ( _rdint msg 4 2 )
-                        : i siglen ( _rdint msg 6 2 )
-                        ( vec_free [u] . c cv_sig )
-                        = . c cv_sig ( bytes_slice msg 8 + 8 siglen )
-                    } {}
-                    ? == t 8 {
-                        // EncryptedExtensions — pick up the negotiated ALPN.
-                        // The server must pick from OUR list (RFC 7301
-                        // §3.2); anything else is a protocol violation
-                        // answered with no_application_protocol (120).
-                        : ( Vec u ) sel ( __ee_alpn msg )
-                        ? > ( vec_len [u] sel ) 0 {
-                            ? ( _alpn_offered alpn sel ) {
-                                ( vec_free [u] . c alpn_sel )
-                                = . c alpn_sel sel
-                            } {
-                                ( vec_free [u] sel )
-                                ( __send_alert c 120 )
-                                = flighterr 1
-                            }
-                        } { ( vec_free [u] sel ) }
-                    } {}
-                    ( _tls_cat tr msg )
-                }
+                = rc ( _cli_hs_message hs msg )
                 ( vec_free [u] msg )
             }
         }
     }
-    ? == flighterr 1 {
-        ^ ( __fail2 c priv cpub random sessid ch tr spub ecdhe z32 empty ehash early derived1 hs_secret th_sh c_hs s_hs derived2 master sh )
+    ? != rc 0 {
+        ( __cli_say_alert c rc )
+        ^ ( __cli_abort c hs ( _cli_hs_err hs ) )
     } {}
-
-    // ── application keys ──
-    : ( Vec u ) th_sf ( sha256_pure tr )
-    : ( Vec u ) c_ap ( derive_secret master `c ap traffic` th_sf )
-    : ( Vec u ) s_ap ( derive_secret master `s ap traffic` th_sf )
+    // what the verifier and the callers read off the connection
+    ( vec_free [u] . c cert_msg )
+    = . c cert_msg . hs cert_msg
+    = . hs cert_msg ( vec_new [u] )
+    ( vec_free [u] . c cv_sig )
+    = . c cv_sig . hs cv_sig
+    = . hs cv_sig ( vec_new [u] )
+    ( vec_free [u] . c th_cert )
+    = . c th_cert . hs th_cert
+    = . hs th_cert ( vec_new [u] )
+    = . c cv_scheme . hs cv_scheme
+    ( vec_free [u] . c alpn_sel )
+    = . c alpn_sel . hs alpn_sel
+    = . hs alpn_sel ( vec_new [u] )
 
     // ── client Finished (under handshake keys) ──
-    : ( Vec u ) cfin ( _finished_mac c_hs th_sf )
-    : ( Vec u ) finmsg ( vec_with_cap [u] 36 )
-    ( vec_push [u] finmsg # u 20 )
-    ( _u24 finmsg 32 )
-    ( _tls_cat finmsg cfin )
     // change_cipher_spec for middlebox compatibility
     : ( Vec u ) ccs ( vec_with_cap [u] 1 )
     ( vec_push [u] ccs # u 1 )
     : !v TlsErr cw ( _send_plain c 20 ccs )
     ?? cw { T _ → {} F _ → {} }
     ( vec_free [u] ccs )
-    : !v TlsErr fw ( __send_encrypted c 22 finmsg )
+    : !v TlsErr fw ( __send_encrypted c 22 . hs out_fin )
     ?? fw { T _ → {} F _ → {} }
 
     // switch to application traffic keys
-    ( _set_keys c 0 s_ap )
-    ( _set_keys c 1 c_ap )
+    ( _set_keys c 0 . hs s_ap )
+    ( _set_keys c 1 . hs c_ap )
     = . c established 1
-
-    // resumption_master_secret: transcript through our own Finished.
-    // Every NewSessionTicket the server sends from here on derives its
-    // PSK from this (see __client_take_ticket).
-    ( _tls_cat tr finmsg )
-    : ( Vec u ) th_cf ( sha256_pure tr )
     ( vec_free [u] . c res_master )
-    = . c res_master ( derive_secret master `res master` th_cf )
-    ( vec_free [u] th_cf )
-
-    // free handshake secrets / scratch
-    ( vec_free [u] priv ) ( vec_free [u] cpub ) ( vec_free [u] random ) ( vec_free [u] sessid )
-    ( vec_free [u] ch ) ( vec_free [u] tr ) ( vec_free [u] sh ) ( vec_free [u] spub )
-    ( vec_free [u] ecdhe ) ( vec_free [u] zeros ) ( vec_free [u] z32 ) ( vec_free [u] empty )
-    ( vec_free [u] ehash ) ( vec_free [u] early ) ( vec_free [u] derived1 ) ( vec_free [u] hs_secret )
-    ( vec_free [u] th_sh ) ( vec_free [u] c_hs ) ( vec_free [u] s_hs ) ( vec_free [u] derived2 )
-    ( vec_free [u] master ) ( vec_free [u] th_sf ) ( vec_free [u] c_ap ) ( vec_free [u] s_ap )
-    ( vec_free [u] cfin ) ( vec_free [u] finmsg )
+    = . c res_master . hs res_master
+    = . hs res_master ( vec_new [u] )
+    ( _cli_hs_free hs )
     ^ @ !*TlsConn TlsErr { T c }
 }
 
@@ -1558,16 +1902,6 @@ $ `stdlib/std/async_ffi.nu`
     ( vec_free [u] ch ) ( vec_free [u] tr )
     ( tls_close c )
     ^ @ !*TlsConn TlsErr { F e }
-}
-
-@ __fail2 * TlsConn c ( Vec u ) priv ( Vec u ) cpub ( Vec u ) random ( Vec u ) sessid ( Vec u ) ch ( Vec u ) tr ( Vec u ) spub ( Vec u ) ecdhe ( Vec u ) z32 ( Vec u ) empty ( Vec u ) ehash ( Vec u ) early ( Vec u ) derived1 ( Vec u ) hs_secret ( Vec u ) th_sh ( Vec u ) c_hs ( Vec u ) s_hs ( Vec u ) derived2 ( Vec u ) master ( Vec u ) sh → !*TlsConn TlsErr {
-    ( vec_free [u] priv ) ( vec_free [u] cpub ) ( vec_free [u] random ) ( vec_free [u] sessid )
-    ( vec_free [u] ch ) ( vec_free [u] tr ) ( vec_free [u] spub ) ( vec_free [u] ecdhe )
-    ( vec_free [u] z32 ) ( vec_free [u] empty ) ( vec_free [u] ehash ) ( vec_free [u] early )
-    ( vec_free [u] derived1 ) ( vec_free [u] hs_secret ) ( vec_free [u] th_sh ) ( vec_free [u] c_hs )
-    ( vec_free [u] s_hs ) ( vec_free [u] derived2 ) ( vec_free [u] master ) ( vec_free [u] sh )
-    ( tls_close c )
-    ^ @ !*TlsConn TlsErr { F # TlsErr TlsHandshake }
 }
 
 // ── application data ──────────────────────────────────────────────

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -749,7 +749,7 @@ $ `stdlib/std/aes_gcm.nu`
 
 @ _srv_hs_free * SrvHs h → v {
     ? == # i h 0 { ^ } {}
-    ? != # i . h trh 0 { ( __trh_abort . h trh ) } {}
+    ? != # i . h trh 0 { ( _trh_abort . h trh ) } {}
     ( vec_free [u] . h cert_chain )
     ( vec_free [u] . h ec_priv )
     ( vec_free [u] . h rsa_n )

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -1391,12 +1391,6 @@ $ `stdlib/std/aes_gcm.nu`
     ^ ( __tls_accept_impl raw cert_chain keytype ec_priv rsa_n rsa_e rsa_d 0 pq_chain pq_level pq_sk alpn_prefs )
 }
 
-// Discard a live transcript hasher (error paths).
-@ __trh_abort * Sha256 h → v {
-    : ( Vec u ) d ( sha256_final h )
-    ( vec_free [u] d )
-}
-
 @ __srv_rand i n → ( Vec u ) {
     : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
     : ~ i k 0


### PR DESCRIPTION
Phases 4–6 of the http-client plan, each a commit:

1. **`CliHs`** — the TLS 1.3 client handshake as a message-level machine in `std/tls.nu`, the twin of the server's `SrvHs`; `__tls_handshake` is now the record layer around it. Same bytes on the wire (corpus, h2spec 146/146, h3spec 49/49, `packages/http-client` suite, example.org over HTTP/2 + X25519MLKEM768; TLS 1.2 fallback probed against `openssl s_server -tls1_2`). Client-detected failures now carry their alert; a hello / ticket / EndOfEarlyData / KeyUpdate inside the server flight is refused.
2. **QUIC client role** — `std/quic_conn.nu` plays either side (`quic_conn_new_client`, `quic_conn_open_bidi`), `QuicTlsCli` in `std/quic_tls.nu`, `std/quic_client.nu` as the socket + loop. Retry (tag checked, new DCID + keys, token in every Initial, CH re-sent with the packet number continuing), Version Negotiation, NEW_TOKEN, HANDSHAKE_DONE, every Initial datagram padded, Initial keys dropped on the first Handshake send, certificate verified through `std/tls_verify.nu`. **Found on the way:** RFC 9001 §8.4 — the QUIC ClientHello must carry an empty `legacy_session_id`; Google answered `UNEXPECTED_COMPATIBILITY_MODE` (alert 47) and Cloudflare closed silently until it did. `compiler/tests/quic_client_server.nu` is the first QUIC handshake in the repo that completes with NURL on both ends (PQ asserted on both, echo + FIN, HANDSHAKE_DONE, clean close, self-signed refused with `CRYPTO_ERROR(bad_certificate)` when verifying); `quic_client_retry.nu` pins Retry/VN sans-IO. With verification on and the system roots, cloudflare-quic.com, www.google.com, quic.nginx.org and www.facebook.com all complete post-quantum and confirm.
3. **HTTP/3 client** — `ext/http3_client.nu`; the facade parses and caches `Alt-Svc: h3` per origin and moves the next request onto QUIC, `http_client_set_h3` (0 after Alt-Svc / 1 QUIC first / 2 never), TCP fall-back when a QUIC attempt fails, `last_proto` 3, package 0.2.0, `fetch --h3`. **Root fix:** `__qpack_static_find` encoded a name-only static hit as `2 − k` instead of `−(k + 2)` — `:authority` reached the server as `age`, `accept` as `:status`, the server's `date` left as `age`; the codec test's "name-only" case was an exact hit and never took the path. `compiler/tests/http3_client_server.nu` (NURL↔NURL), the package suite at 25/25 (Alt-Svc switch, QUIC-first, cookies / gzip / redirects / POST over h3, fall-back), and `fetch --h3` gets `HTTP/3 (post-quantum) — status 200` from Cloudflare, Google and nginx.

Gates: `./build.sh` green, h2spec 146/146 (+strict 147/147), h3spec 49/49, check_stdlib_symbols / package_imports / version_strings / builtins_doc / strict_arity OK, ASan+LSan (leak detection on) clean for every new test. The pre-existing leaks in tls_cert_select / tls_ssl_cert_file / http2_client / http_keepalive are server- and test-side (no frame in the new code); `tls_cert_select` is the known port race and passes alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw
