### PR TITLE
packages/oauth 0.1.0 — identify the user, read the claims

### DIFF
--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -1,0 +1,188 @@
+# oauth — OAuth 2.0 and OpenID Connect for NURL
+
+Identify the user, and read the claims.
+
+This package is an OpenID Connect relying party and a resource-server
+guard, in pure NURL. Nothing in the chain is C: the TLS is
+`std/tls.nu`, the JSON is `ext/json.nu`, and the RSA, ECDSA, Ed25519 and
+SHA-2 that decide whether a token is real are `std/rsa.nu`,
+`std/ecdsa_p256.nu`, `std/ed25519.nu` and `std/hash_sha*.nu`.
+
+```nurl
+$ `deps/oauth/src/oauth.nu`
+```
+
+## The two halves
+
+**Get a token** — the authorization-code flow with PKCE:
+
+```nurl
+?? ( oidc_provider_discover `https://accounts.example.com` ) {
+    T p → {
+        : *OauthConfig cfg ( oauth_config_new `my-client` `http://127.0.0.1:8765/callback` `openid profile email` )
+        : Pkce pk ( pkce_new )
+        : String state ( oauth_state_new )
+        : String nonce ( oauth_nonce_new )
+
+        : String url ( oauth_authorize_url p cfg ( string_data state ) ( string_data nonce ) pk )
+        //  … open `url` in a browser, catch the redirect …
+
+        ?? ( oauth_callback_code query ( string_data state ) ) {
+            T code → {
+                ?? ( oauth_exchange_code p cfg ( string_data code ) ( string_data . pk verifier ) ) {
+                    T ts → { /* ( token_set_id_token ts ) */ }
+                    F e → { /* ( oauth_err_name e ), ( oidc_provider_last_error p ) */ }
+                }
+            }
+            F e → {}
+        }
+    }
+    F e → {}
+}
+```
+
+**Believe a token** — and turn it into a person:
+
+```nurl
+: *OidcPolicy pol ( oidc_policy_new `https://accounts.example.com` `my-client` )
+( oidc_policy_set_nonce pol ( string_data nonce ) )
+
+?? ( oidc_verify_id_token p pol ( token_set_id_token ts ) ) {
+    T id → {
+        ( nurl_println ( string_data . id subject ) )   // "248289761001"
+        ( nurl_println ( string_data . id email ) )     // "jane@example.com"
+        : String groups ( oidc_identity_claim id `tenant` )   // anything else
+        ( oidc_identity_free id )
+    }
+    F e → { /* ( oauth_err_name e ) + ( oidc_provider_last_error p ) says why */ }
+}
+```
+
+**Guard an API** with the tokens it hands out:
+
+```nurl
+: HttpServer srv ( server_new listener
+    ( with_oidc_scope p pol `read:things`
+        \ HttpRequest req OidcIdentity id → HttpResponse {
+            ^ ( response_text 200 ( string_data ( oidc_identity_key id ) ) )
+        } ) )
+```
+
+A handler wrapped this way is entered only for a caller the package could
+name. Everything else — no token, an expired one, one from another
+issuer, one minted for another audience, one signed with a key the
+provider never published, one that says `alg: none` — is a 401 with an
+RFC 6750 challenge that names the reason. A caller who is who they say
+but lacks the scope gets 403 `insufficient_scope`, because that is a
+different answer. What the challenge quotes back is sanitized before it
+becomes a header value — part of that text is copied from the token, and
+a `kid` carrying a CR LF is response splitting, not a diagnostic.
+
+## What it checks, and why
+
+| Check | What it stops |
+| --- | --- |
+| `iss` matches the discovery document's own `issuer` | metadata substitution — a redirect that repoints the token endpoint |
+| `aud` contains our client id | the confused deputy: a token minted for another relying party |
+| `azp` is us when it is present | the same, when the token has several audiences |
+| `exp` / `nbf` / `iat`, with leeway | replay of a dead token; a token from the future |
+| `nonce` equals the one we sent | replay of a valid ID token into a session we started |
+| `sub` is present | a "user" with no identity |
+| `max_age` against `auth_time` | a session older than this relying party accepts |
+| header `kid` → a published key | a token signed by anything but the provider |
+| `alg` against the key type | key confusion (verifying an RSA token on the HMAC path) |
+| `alg: none` refused | the oldest JWT break there is |
+| unknown `crit` refused | an extension we do not implement, silently ignored |
+| HS\* refused against a JWKS unless opted in | a public key used as a shared secret |
+| PKCE `S256`, never `plain` | a stolen authorization code |
+| `state` on the callback | login CSRF |
+
+Key **rotation** is handled: a `kid` the cache has never seen triggers a
+JWKS re-fetch, rate-limited (`oidc_provider_set_min_refetch`, 300 s by
+default) so a flood of forged `kid`s cannot be turned into a load
+generator aimed at the provider.
+
+## Modules
+
+| File | What is in it |
+| --- | --- |
+| `src/errors.nu` | `OauthErr`, `oauth_err_name`, the RFC 6750 error code for each |
+| `src/jwk.nu` | `JwkKey`, `jwks_parse` / `jwks_from_json`, `jwks_select`, `jwk_ec_point`, `jwk_thumbprint` (RFC 7638) |
+| `src/jws.nu` | `jws_verify_with_key`, `jws_header_json` / `jws_header_str`, `jws_payload_unverified`, `jws_alg_supported` |
+| `src/claims.nu` | `OidcPolicy` + setters, `claims_check`, `claim_err_desc`, the claim accessors, `OidcIdentity` |
+| `src/pkce.nu` | `pkce_new`, `pkce_challenge_for`, `oauth_state_new`, `oauth_nonce_new`, `oauth_random_token` |
+| `src/provider.nu` | `oidc_provider_discover` / `oidc_discover`, `oidc_fetch_jwks`, `oidc_verify_id_token` / `_access_token` / `_token_at` |
+| `src/flow.nu` | `OauthConfig`, `oauth_authorize_url`, `oauth_callback_code`, `oauth_exchange_code`, `oauth_refresh`, `oauth_client_credentials`, `oauth_userinfo`, `TokenSet` |
+| `src/guard.nu` | `with_oidc_bearer`, `with_oidc_scope`, `oidc_request_identity` |
+| `src/oauth.nu` | the facade — include this one |
+
+### Algorithms
+
+`RS256` `RS384` `RS512` (PKCS#1 v1.5) · `PS256` (PSS) · `ES256` `ES384`
+(ECDSA over P-256 / P-384) · `EdDSA` (Ed25519) · `HS256` (only against a
+key the caller configured as a shared secret, with
+`oidc_policy_allow_symmetric`).
+
+`oidc_policy_set_algs` narrows that to an explicit allowlist — worth
+doing when you know your provider only ever signs one way.
+
+## Examples
+
+```sh
+# Log in with a browser and print who logged in.
+./login --issuer https://accounts.example.com --client-id <id>
+
+# Is this token real, and who does it name? (exit 0 = valid)
+./verify --issuer https://accounts.example.com --audience <id> --token "$JWT"
+
+# An HTTP API that only answers callers it can name.
+./protected-api --issuer https://accounts.example.com \
+                --audience my-api --scope read:things --port 8080
+```
+
+## Tests
+
+```sh
+./tests/oauth_test.sh
+```
+
+`tests/provider.nu` is a small but real OpenID Connect provider: it
+publishes discovery metadata and a JWKS, mints ES256-signed ID and
+access tokens with a `kid`, and genuinely verifies PKCE on the token
+request (its authorization code carries the challenge and nonce the
+authorization request committed to, which is what a real provider keeps
+in a session store). `tests/client.nu` drives the whole package against
+it, and `/mint/<kind>` hands out the deliberately broken tokens — expired,
+tampered, wrong audience, unpublished `kid`, `alg: none`, HS256 signed
+with the public key — that the verifier must refuse, each asserted to
+fail for the *right* reason.
+
+Offline, RS256 and PS256 are checked against tokens minted by OpenSSL
+with an RSA-2048 key, so the pure-NURL RSA path is proven to agree with
+an independent implementation rather than with itself; EdDSA and HS256
+are round-tripped through the stdlib; and PKCE is checked against RFC
+7636's own S256 vector. The last step of the script runs
+`examples/protected_api.nu` as a live API and drives it with curl: 401
+without a token, 200 with a good one, 403 for a valid token without the
+scope, and the challenge naming `invalid_token` on a bad one — and a token whose
+`kid` carries a CR LF, to prove the challenge cannot be turned into a
+header of the attacker's choosing.
+
+The suite (95 in-process assertions + 10 over curl) is clean under
+AddressSanitizer + UndefinedBehaviorSanitizer with LeakSanitizer on.
+
+## Threading
+
+An `*OidcProvider` owns an HTTP client and a mutable key cache and takes
+no lock: one per thread, or one thread that owns it. An `*OidcPolicy` is
+read-only once built and is safe to share, as is a verified
+`OidcIdentity` — it is a value with no back-reference to the provider.
+
+## Not in this version
+
+Device authorization grant (RFC 8628), dynamic client registration
+(RFC 7591), token introspection and revocation calls (the endpoints are
+discovered and exposed, but not driven), JWE-encrypted tokens, ES512 /
+P-521 (the stdlib has no P-521), and back-channel logout. The
+`end_session_endpoint` is discovered so a caller can build an RP-initiated
+logout URL itself.

--- a/packages/oauth/examples/login.nu
+++ b/packages/oauth/examples/login.nu
@@ -1,0 +1,224 @@
+// examples/login.nu — log in with a browser, and print who logged in.
+//
+// The complete OpenID Connect authorization-code flow with PKCE, as a
+// command-line program:
+//
+//   1. discover the provider,
+//   2. mint a PKCE verifier, a state and a nonce,
+//   3. print the authorization URL (open it in a browser),
+//   4. listen on 127.0.0.1:<port> for the redirect back,
+//   5. exchange the code for tokens,
+//   6. VERIFY the ID token against the provider's published keys, and
+//   7. print the identity and the full claim set.
+//
+//   login --issuer https://accounts.example.com \
+//         --client-id <id> [--client-secret <secret>] \
+//         [--scope "openid profile email"] [--port 8765]
+//
+// The redirect URI is http://127.0.0.1:<port>/callback — register that
+// with the provider. A loopback redirect plus PKCE is the OAuth 2.1
+// shape for a native/CLI client: no secret is required, and a code that
+// leaks is useless without the verifier that never left this process.
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+$ `../src/oauth.nu`
+
+// The request target of the first line: "GET <target> HTTP/1.1".
+@ request_target ( Vec u ) buf → String {
+    : String head ( bytes_to_str buf )
+    : i n ( string_len head )
+    : ~ i start 0
+    ~ & < start n != ( string_get head start ) 32 { = start + start 1 }
+    = start + start 1
+    : ~ i end start
+    ~ & < end n != ( string_get head end ) 32 { = end + end 1 }
+    : String out ( string_substr head start - end start )
+    ( string_free head )
+    ^ out
+}
+
+// The query part of "/callback?code=…", or "".
+@ target_query String target → String {
+    ?? ( string_index_of target `?` ) {
+        T q → { ^ ( string_substr target + q 1 - ( string_len target ) + q 1 ) }
+        F _ → { ^ ( string_new ) }
+    }
+}
+
+// Accept one browser request, answer it, and hand back its query string.
+// Requests for anything but the callback path (a browser's favicon
+// probe, say) are answered 404 and waited past.
+@ await_redirect TcpListener l → String {
+    : ~ ( Vec u ) head ( vec_new [u] )
+    : ~ String out ( string_new )
+    : ~ b waiting T
+    ~ waiting {
+        ?? ( tcp_accept l ) {
+            F _ → { = waiting F }
+            T c → {
+                ( vec_free [u] head )
+                = head ( vec_new [u] )
+                : ~ b reading T
+                ~ reading {
+                    ?? ( tcp_read_chunk c 4096 ) {
+                        T chunk → {
+                            ? == 0 ( vec_len [u] chunk ) { = reading F } {}
+                            ( bytes_extend_bytes head chunk )
+                            ( vec_free [u] chunk )
+                            : ( Vec u ) mark ( bytes_from_str `\r\n\r\n` )
+                            ?? ( bytes_index_of head mark ) {
+                                T _ → { = reading F }
+                                F _ → {}
+                            }
+                            ( vec_free [u] mark )
+                            ? > ( vec_len [u] head ) 65536 { = reading F } {}
+                        }
+                        F _ → { = reading F }
+                    }
+                }
+                : String target ( request_target head )
+                : String q ( target_query target )
+                ? > ( string_len q ) 0 {
+                    : !v NetErr _w ( tcp_write_str c `HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\nContent-Length: 62\r\n\r\n<html><body><h3>Signed in. You can close this tab.</h3></body>` )
+                    ( string_free out )
+                    = out q
+                    = waiting F
+                } {
+                    : !v NetErr _w ( tcp_write_str c `HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n` )
+                    ( string_free q )
+                }
+                ( string_free target )
+                ( tcp_close_conn c )
+            }
+        }
+    }
+    ( vec_free [u] head )
+    ^ out
+}
+
+@ say s label String value → v {
+    : String m ( string_from label )
+    ( string_push_str m ( string_data value ) )
+    ( nurl_println ( string_data m ) )
+    ( string_free m )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `login` `OpenID Connect login, on the command line` )
+    ( args_opt ap `issuer` 105 `URL` `the provider's issuer URL` )
+    ( args_opt ap `client-id` 99 `ID` `the OAuth client id` )
+    ( args_opt ap `client-secret` 115 `SECRET` `client secret (omit for a public client)` )
+    ( args_opt ap `scope` 111 `SCOPE` `requested scope (default: openid profile email)` )
+    ( args_opt ap `port` 112 `N` `loopback redirect port (default 8765)` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+
+    : String issuer ( args_value_or ap `issuer` `` )
+    : String client_id ( args_value_or ap `client-id` `` )
+    : String secret ( args_value_or ap `client-secret` `` )
+    : String scope ( args_value_or ap `scope` `openid profile email` )
+    : String port_s ( args_value_or ap `port` `8765` )
+    ( args_free ap )
+    : ~ i port 8765
+    ?? ( string_to_int port_s ) { T x → { = port x } F _ → {} }
+    ( string_free port_s )
+
+    ? | == 0 ( string_len issuer ) == 0 ( string_len client_id ) {
+        ( nurl_eprintln `login: --issuer and --client-id are required` )
+        ^ 2
+    } {}
+
+    : String redirect ( string_from `http://127.0.0.1:` )
+    ( string_push_int redirect port )
+    ( string_push_str redirect `/callback` )
+
+    // 1. Who is the provider?
+    : ~ i rc 1
+    ?? ( oidc_provider_discover ( string_data issuer ) ) {
+        F e → { ( nurl_eprintln ( oauth_err_name e ) ) }
+        T p → {
+            : *OauthConfig cfg ( oauth_config_new ( string_data client_id ) ( string_data redirect ) ( string_data scope ) )
+            ? > ( string_len secret ) 0 { ( oauth_config_set_secret cfg ( string_data secret ) ) } {}
+
+            // 2. The three one-use secrets.
+            : Pkce pk ( pkce_new )
+            : String state ( oauth_state_new )
+            : String nonce ( oauth_nonce_new )
+
+            // 3. Send the user.
+            : String url ( oauth_authorize_url p cfg ( string_data state ) ( string_data nonce ) pk )
+            ( nurl_println `Open this URL in a browser to sign in:` )
+            ( nurl_println `` )
+            ( nurl_println ( string_data url ) )
+            ( nurl_println `` )
+            ( string_free url )
+
+            // 4. Wait for the redirect back.
+            ?? ( tcp_listen `127.0.0.1` port ) {
+                F _ → { ( nurl_eprintln `login: cannot bind the redirect port` ) }
+                T l → {
+                    ( say `Listening on ` redirect )
+                    : String query ( await_redirect l )
+                    ( tcp_close_listener l )
+
+                    // 5. The code — but only if it answers OUR request.
+                    ?? ( oauth_callback_code ( string_data query ) ( string_data state ) ) {
+                        F e → { ( nurl_eprintln ( oauth_err_name e ) ) }
+                        T code → {
+                            ?? ( oauth_exchange_code p cfg ( string_data code ) ( string_data . pk verifier ) ) {
+                                F e → {
+                                    ( nurl_eprintln ( oauth_err_name e ) )
+                                    ( nurl_eprintln ( oidc_provider_last_error p ) )
+                                }
+                                T ts → {
+                                    // 6. Verify — this is the step that
+                                    // turns bytes into an identity.
+                                    : *OidcPolicy pol ( oidc_policy_new ( string_data issuer ) ( string_data client_id ) )
+                                    ( oidc_policy_set_nonce pol ( string_data nonce ) )
+                                    ?? ( oidc_verify_id_token p pol ( token_set_id_token ts ) ) {
+                                        F e → {
+                                            ( nurl_eprintln ( oauth_err_name e ) )
+                                            ( nurl_eprintln ( oidc_provider_last_error p ) )
+                                        }
+                                        T id → {
+                                            // 7. Who logged in.
+                                            : String desc ( oidc_identity_describe id )
+                                            ( nurl_println `` )
+                                            ( say `Signed in: ` desc )
+                                            ( string_free desc )
+                                            : String key ( oidc_identity_key id )
+                                            ( say `Identity:  ` key )
+                                            ( string_free key )
+                                            ( nurl_println `` )
+                                            ( nurl_println `Claims:` )
+                                            : String pretty ( json_pretty . id claims )
+                                            ( nurl_println ( string_data pretty ) )
+                                            ( string_free pretty )
+                                            ( oidc_identity_free id )
+                                            = rc 0
+                                        }
+                                    }
+                                    ( oidc_policy_free pol )
+                                    ( token_set_free ts )
+                                }
+                            }
+                            ( string_free code )
+                        }
+                    }
+                    ( string_free query )
+                }
+            }
+            ( string_free state )
+            ( string_free nonce )
+            ( pkce_free pk )
+            ( oauth_config_free cfg )
+            ( oidc_provider_free p )
+        }
+    }
+    ( string_free issuer ) ( string_free client_id ) ( string_free secret )
+    ( string_free scope ) ( string_free redirect )
+    ^ rc
+}

--- a/packages/oauth/examples/protected_api.nu
+++ b/packages/oauth/examples/protected_api.nu
@@ -1,0 +1,106 @@
+// examples/protected_api.nu — an HTTP API that knows who is calling.
+//
+// The resource-server side: every request must carry an access token
+// this issuer signed, for this audience, unexpired — and the handler is
+// only ever entered with the caller's verified identity in hand.
+//
+//   protected-api --issuer https://accounts.example.com \
+//                 --audience <api-audience> \
+//                 [--scope read:things] [--port 8080]
+//
+//   GET /me      → the identity as JSON
+//   GET /whoami  → "sub@issuer" as text
+//
+// With --scope the whole surface is wrapped in `with_oidc_scope`, which
+// answers 403 `insufficient_scope` for a caller who authenticates but
+// was not granted it; without it, `with_oidc_bearer` requires only a
+// valid token. Both answer 401 with an RFC 6750 challenge naming the
+// reason when the token is missing, expired, forged or for someone else.
+//
+// Try it against the package's own test provider:
+//
+//   ./tests/provider --port 9000 &
+//   ./protected-api --issuer http://127.0.0.1:9000 --audience test-api \
+//                   --scope read:things --port 8080
+//   curl -H "Authorization: Bearer $(curl -s 127.0.0.1:9000/mint/access)" \
+//        127.0.0.1:8080/me
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/json.nu`
+$ `../src/oauth.nu`
+
+// The whole API, entered only for a caller we can name.
+@ api_handle HttpRequest req OidcIdentity id → HttpResponse {
+    : s path ( string_data . req path )
+    ? == 1 ( nurl_str_eq path `/whoami` ) {
+        : String key ( oidc_identity_key id )
+        : HttpResponse r ( response_text 200 ( string_data key ) )
+        ( string_free key )
+        ^ r
+    } {}
+    ? == 1 ( nurl_str_eq path `/me` ) {
+        : Json out ( json_obj_new )
+        ( json_obj_set out `subject` ( json_str_lit ( string_data . id subject ) ) )
+        ( json_obj_set out `issuer` ( json_str_lit ( string_data . id issuer ) ) )
+        ( json_obj_set out `email` ( json_str_lit ( string_data . id email ) ) )
+        ( json_obj_set out `name` ( json_str_lit ( string_data . id name ) ) )
+        ( json_obj_set out `expires_at` ( json_int . id expires_at ) )
+        : HttpResponse r ( response_json 200 out )
+        ( json_free out )
+        ^ r
+    } {}
+    ^ ( response_text 404 `not found\n` )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `protected-api` `an HTTP API behind OpenID Connect` )
+    ( args_opt ap `issuer` 105 `URL` `the issuer whose tokens this API accepts` )
+    ( args_opt ap `audience` 97 `AUD` `this API's audience, required in aud` )
+    ( args_opt ap `scope` 111 `SCOPE` `require this scope on every request` )
+    ( args_opt ap `port` 112 `N` `bind port on 127.0.0.1 (default 8080)` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+    : String issuer ( args_value_or ap `issuer` `` )
+    : String audience ( args_value_or ap `audience` `` )
+    : String scope ( args_value_or ap `scope` `` )
+    : String port_s ( args_value_or ap `port` `8080` )
+    ( args_free ap )
+    : ~ i port 8080
+    ?? ( string_to_int port_s ) { T x → { = port x } F _ → {} }
+    ( string_free port_s )
+
+    ? == 0 ( string_len issuer ) {
+        ( nurl_eprintln `protected-api: --issuer is required` )
+        ^ 2
+    } {}
+
+    : ~ i rc 1
+    // Discovery happens once, at startup: a resource server that cannot
+    // reach its issuer's metadata cannot authenticate anyone, and should
+    // say so now rather than 500 on the first request.
+    ?? ( oidc_provider_discover ( string_data issuer ) ) {
+        F e → { ( nurl_eprintln ( oauth_err_name e ) ) }
+        T p → {
+            : *OidcPolicy pol ( oidc_policy_new ( string_data issuer ) ( string_data audience ) )
+            ?? ( tcp_listen `127.0.0.1` port ) {
+                F _ → { ( nurl_eprintln `protected-api: cannot bind` ) }
+                T l → {
+                    ? > ( string_len scope ) 0 {
+                        : HttpServer srv ( server_new l ( with_oidc_scope p pol ( string_data scope )
+                        \ HttpRequest req OidcIdentity id → HttpResponse { ^ ( api_handle req id ) } ) )
+                        ?? ( server_run srv ) { T _ → { = rc 0 } F _ → {} }
+                    } {
+                        : HttpServer srv ( server_new l ( with_oidc_bearer p pol
+                        \ HttpRequest req OidcIdentity id → HttpResponse { ^ ( api_handle req id ) } ) )
+                        ?? ( server_run srv ) { T _ → { = rc 0 } F _ → {} }
+                    }
+                }
+            }
+            ( oidc_policy_free pol )
+            ( oidc_provider_free p )
+        }
+    }
+    ( string_free issuer ) ( string_free audience ) ( string_free scope )
+    ^ rc
+}

--- a/packages/oauth/examples/verify.nu
+++ b/packages/oauth/examples/verify.nu
@@ -1,0 +1,105 @@
+// examples/verify.nu — is this token real, and who does it name?
+//
+// The verifying half of the package on its own: give it an issuer and a
+// token, and it fetches that issuer's metadata and keys, checks the
+// signature and every claim, and prints the identity — or says exactly
+// what was wrong.
+//
+//   verify --issuer https://accounts.example.com \
+//          --audience <client-id-or-api> \
+//          --token <jwt>            (or --token-file <path>)
+//          [--scope <required-scope>] [--algs "RS256 ES256"]
+//
+// This is what a resource server does on every request; the same call is
+// wrapped for HTTP routes by `with_oidc_bearer` (see protected_api.nu).
+// Exit status is 0 for a token that verifies, 1 for one that does not —
+// so it composes into a shell pipeline as a check.
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/json.nu`
+$ `../src/oauth.nu`
+
+@ main → i {
+    : ArgParser ap ( args_new `verify` `verify an OIDC token and print its claims` )
+    ( args_opt ap `issuer` 105 `URL` `the issuer that minted the token` )
+    ( args_opt ap `audience` 97 `AUD` `the audience the token must name (this client / API)` )
+    ( args_opt ap `token` 116 `JWT` `the token itself` )
+    ( args_opt ap `token-file` 102 `PATH` `read the token from a file instead` )
+    ( args_opt ap `scope` 111 `SCOPE` `also require this scope` )
+    ( args_opt ap `algs` 108 `LIST` `restrict the accepted algorithms` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+
+    : String issuer ( args_value_or ap `issuer` `` )
+    : String audience ( args_value_or ap `audience` `` )
+    : ~ String token ( args_value_or ap `token` `` )
+    : String token_file ( args_value_or ap `token-file` `` )
+    : String want_scope ( args_value_or ap `scope` `` )
+    : String algs ( args_value_or ap `algs` `` )
+    ( args_free ap )
+
+    ? > ( string_len token_file ) 0 {
+        ?? ( read_file ( string_data token_file ) ) {
+            T contents → {
+                ( string_free token )
+                = token ( string_trim contents )
+                ( string_free contents )
+            }
+            F _ → { ( nurl_eprintln `verify: cannot read the token file` ) }
+        }
+    } {}
+
+    ? | == 0 ( string_len issuer ) == 0 ( string_len token ) {
+        ( nurl_eprintln `verify: --issuer and --token (or --token-file) are required` )
+        ^ 2
+    } {}
+
+    : ~ i rc 1
+    ?? ( oidc_provider_discover ( string_data issuer ) ) {
+        F e → {
+            ( nurl_eprintln ( oauth_err_name e ) )
+        }
+        T p → {
+            : *OidcPolicy pol ( oidc_policy_new ( string_data issuer ) ( string_data audience ) )
+            ? > ( string_len algs ) 0 { ( oidc_policy_set_algs pol ( string_data algs ) ) } {}
+            ?? ( oidc_verify_token p pol ( string_data token ) ) {
+                F e → {
+                    : String m ( string_from `INVALID (` )
+                    ( string_push_str m ( oauth_err_name e ) )
+                    ( string_push_str m `): ` )
+                    ( string_push_str m ( oidc_provider_last_error p ) )
+                    ( nurl_println ( string_data m ) )
+                    ( string_free m )
+                }
+                T id → {
+                    : ~ b allowed T
+                    ? > ( string_len want_scope ) 0 {
+                        = allowed ( oidc_identity_has_scope id ( string_data want_scope ) )
+                    } {}
+                    ? allowed {
+                        : String desc ( oidc_identity_describe id )
+                        : String m ( string_from `VALID — ` )
+                        ( string_push_str m ( string_data desc ) )
+                        ( nurl_println ( string_data m ) )
+                        ( string_free m ) ( string_free desc )
+                        : String pretty ( json_pretty . id claims )
+                        ( nurl_println ( string_data pretty ) )
+                        ( string_free pretty )
+                        = rc 0
+                    } {
+                        : String m ( string_from `VALID, but without the scope ` )
+                        ( string_push_str m ( string_data want_scope ) )
+                        ( nurl_println ( string_data m ) )
+                        ( string_free m )
+                    }
+                    ( oidc_identity_free id )
+                }
+            }
+            ( oidc_policy_free pol )
+            ( oidc_provider_free p )
+        }
+    }
+    ( string_free issuer ) ( string_free audience ) ( string_free token )
+    ( string_free token_file ) ( string_free want_scope ) ( string_free algs )
+    ^ rc
+}

--- a/packages/oauth/nurl.toml
+++ b/packages/oauth/nurl.toml
@@ -1,0 +1,9 @@
+[package]
+name = "oauth"
+version = "0.1.0"
+description = "OAuth 2.0 and OpenID Connect for NURL — identify the user and read the claims, with no C anywhere in the chain. The client half runs the authorization-code flow with PKCE (S256 only), OIDC discovery over RFC 8414 metadata with the issuer cross-checked, the token endpoint (authorization_code, refresh_token, client_credentials; client_secret_post or client_secret_basic), and UserInfo. The verifying half is the part that decides who someone is: it fetches the provider's JWKS, picks the key the token's kid/alg names, re-fetches on an unseen kid so a key rotation needs no restart (rate-limited, so a flood of forged kids cannot be aimed at the provider), and checks the signature in pure NURL — RS256/RS384/RS512, PS256, ES256/ES384, EdDSA, and HS256 only for a deliberately configured shared secret. Then the claims: iss, aud with azp, exp/nbf/iat with leeway, nonce, sub and max_age, each named when it fails. `alg: none` and an unrecognised `crit` are refused, not ignored. The result is an OidcIdentity — subject, issuer, email, name, picture and the full claim set — and, on the server side, with_oidc_bearer / with_oidc_scope wrap an HttpApp route so a handler only ever runs for a caller it can name, with 401 challenges and 403 insufficient_scope written per RFC 6750."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/nurl-lang/nurl-lang/tree/main/packages/oauth"
+
+[dependencies]
+http-client = { path = "../http-client", version = "^0" }

--- a/packages/oauth/src/claims.nu
+++ b/packages/oauth/src/claims.nu
@@ -1,0 +1,410 @@
+// oauth/claims.nu — read the claims, and decide whether to believe them.
+//
+// A verified signature only says the token was issued by the holder of a
+// key. Everything that makes it an ANSWER to "who is this, and is this
+// token for me, right now" lives in the claims, and the checks are
+// exactly the ones an attacker attacks when they are skipped:
+//
+//   iss    the token came from the issuer we trust, not another one
+//   aud    it was minted for THIS client, not for a different relying
+//          party that would happily hand it to us (the confused deputy)
+//   azp    with several audiences, the authorized party is still us
+//   exp    it has not expired · nbf it has begun · iat it is not future
+//   nonce  it answers the authorization request WE started (replay)
+//   sub    there is a subject at all — the user this token identifies
+//
+// `OidcPolicy` is the heap-owned statement of what this relying party
+// will accept; `claims_check` applies it and names the first failure.
+//
+//   : *OidcPolicy pol ( oidc_policy_new issuer client_id )
+//   ( oidc_policy_set_leeway pol 60 )
+//   ?? ( claims_check claims pol ( now_seconds ) ) {
+//       T e → ( nurl_eprintln ( claim_err_desc e ) )
+//       F _ → { /* believe it */ }
+//   }
+//
+// `OidcIdentity` is the answer itself: the subject and the profile
+// claims lifted out for direct use, with the full claim set still
+// attached for anything else the provider sent (groups, roles, tenant).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+
+// ── What can be wrong with a claim set ─────────────────────────────
+
+: | ClaimErr {
+    ClNotObject  // the payload was not a JSON object
+    ClExpired  // now ≥ exp (+ leeway)
+    ClNotYetValid  // now < nbf (− leeway)
+    ClIssuedInFuture  // iat is ahead of our clock by more than the leeway
+    ClNoExpiry  // policy demands exp; the token has none
+    ClIssuer  // iss ≠ the issuer we trust
+    ClAudience  // our client id is not in aud
+    ClAuthorizedParty  // azp names a different client
+    ClNonce  // nonce ≠ the one we sent
+    ClNoSubject  // no sub — the token identifies nobody
+    ClMaxAge  // the authentication is older than max_age
+}
+
+@ claim_err_desc ClaimErr e → s {
+    ^ ?? e {
+        ClNotObject → `claims are not a JSON object`
+        ClExpired → `token expired`
+        ClNotYetValid → `token not yet valid`
+        ClIssuedInFuture → `token issued in the future`
+        ClNoExpiry → `token has no exp claim`
+        ClIssuer → `wrong issuer`
+        ClAudience → `wrong audience`
+        ClAuthorizedParty → `wrong authorized party (azp)`
+        ClNonce → `nonce mismatch`
+        ClNoSubject → `token has no sub claim`
+        ClMaxAge → `authentication too old for max_age`
+    }
+}
+
+// ── Accessors ──────────────────────────────────────────────────────
+
+// A string claim as an owned String; empty when absent or not a string.
+@ claims_str Json c s key → String {
+    : ~ s raw ``
+    ?? ( json_obj_get c key ) {
+        T v → { ? ( json_is_str v ) { = raw ( json_str_data v ) } {} }
+        F _ → {}
+    }
+    ^ ( string_from raw )
+}
+
+// A numeric claim (NumericDate and friends); `missing` when absent.
+@ claims_int_or Json c s key i missing → i {
+    : ~ i out missing
+    ?? ( json_obj_get c key ) {
+        T v → {
+            ? ( json_is_num v ) {
+                ?? ( json_num_as_i v ) { T n → { = out n } F _ → {} }
+            } {}
+        }
+        F _ → {}
+    }
+    ^ out
+}
+
+@ claims_int Json c s key → i { ^ ( claims_int_or c key -1 ) }
+
+@ claims_bool Json c s key → b {
+    : ~ b out F
+    ?? ( json_obj_get c key ) {
+        T v → { ? ( json_is_bool v ) { = out ( json_bool_val v ) } {} }
+        F _ → {}
+    }
+    ^ out
+}
+
+@ claims_has Json c s key → b { ^ ( json_obj_has c key ) }
+
+// A claim that is either a string or an array of strings — `aud`, and
+// the shape most providers use for groups and roles. Always an owned
+// vector of owned Strings (free with claims_strings_free).
+@ claims_string_list Json c s key → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    ?? ( json_obj_get c key ) {
+        T v → {
+            ? ( json_is_str v ) {
+                ( vec_push [String] out ( string_from ( json_str_data v ) ) )
+            } {
+                ? ( json_is_arr v ) {
+                    : i n ( json_arr_len v )
+                    : ~ i k 0
+                    ~ < k n {
+                        ?? ( json_arr_get v k ) {
+                            T item → {
+                                ? ( json_is_str item ) {
+                                    ( vec_push [String] out ( string_from ( json_str_data item ) ) )
+                                } {}
+                            }
+                            F _ → {}
+                        }
+                        = k + k 1
+                    }
+                } {}
+            }
+        }
+        F _ → {}
+    }
+    ^ out
+}
+
+@ claims_strings_free ( Vec String ) v → v {
+    ( vec_free_with [String] v \ String s → v { ( string_free s ) } )
+}
+
+@ __cl_list_has ( Vec String ) list s want → b {
+    : i n ( vec_len [String] list )
+    : *String data ( vec_data [String] list )
+    : ~ i k 0
+    ~ < k n {
+        : String item . data k
+        ? == 1 ( nurl_str_eq ( string_data item ) want ) { ^ T } {}
+        = k + k 1
+    }
+    ^ F
+}
+
+@ claims_has_audience Json c s aud → b {
+    : ( Vec String ) list ( claims_string_list c `aud` )
+    : b found ( __cl_list_has list aud )
+    ( claims_strings_free list )
+    ^ found
+}
+
+// The `scope` claim (RFC 8693 §4.2: one space-delimited string).
+@ claims_scopes Json c → ( Vec String ) {
+    : String sc ( claims_str c `scope` )
+    : ( Vec String ) out ( string_split sc ` ` )
+    ( string_free sc )
+    ^ out
+}
+
+@ claims_has_scope Json c s scope → b {
+    : ( Vec String ) list ( claims_scopes c )
+    : b found ( __cl_list_has list scope )
+    ( claims_strings_free list )
+    ^ found
+}
+
+// ── Policy ─────────────────────────────────────────────────────────
+
+: OidcPolicy {
+    String issuer  // expected `iss`; empty = do not check (never for OIDC)
+    String audience  // our client id, expected in `aud`; empty = skip
+    String nonce  // the nonce we sent with the authorization request
+    String algs  // space-separated `alg` allowlist; empty = every supported
+    i leeway  // clock-skew tolerance in seconds
+    i max_age  // reject an authentication older than this; 0 = no limit
+    b require_sub
+    b require_exp
+    b allow_symmetric  // permit HS* (only with a configured shared secret)
+}
+
+@ oidc_policy_new s issuer s audience → *OidcPolicy {
+    : *OidcPolicy p # *OidcPolicy ( nurl_malloc Z OidcPolicy )
+    = . p issuer ( string_from issuer )
+    = . p audience ( string_from audience )
+    = . p nonce ( string_new )
+    = . p algs ( string_new )
+    = . p leeway 60
+    = . p max_age 0
+    = . p require_sub T
+    = . p require_exp T
+    = . p allow_symmetric F
+    ^ p
+}
+
+@ oidc_policy_free * OidcPolicy p → v {
+    ( string_free . p issuer )
+    ( string_free . p audience )
+    ( string_free . p nonce )
+    ( string_free . p algs )
+    ( nurl_free # s p )
+}
+
+@ oidc_policy_set_issuer * OidcPolicy p s issuer → v {
+    ( string_free . p issuer )
+    = . p issuer ( string_from issuer )
+}
+
+@ oidc_policy_set_audience * OidcPolicy p s audience → v {
+    ( string_free . p audience )
+    = . p audience ( string_from audience )
+}
+
+@ oidc_policy_set_nonce * OidcPolicy p s nonce → v {
+    ( string_free . p nonce )
+    = . p nonce ( string_from nonce )
+}
+
+@ oidc_policy_set_algs * OidcPolicy p s algs → v {
+    ( string_free . p algs )
+    = . p algs ( string_from algs )
+}
+
+@ oidc_policy_set_leeway * OidcPolicy p i secs → v { = . p leeway secs }
+
+@ oidc_policy_set_max_age * OidcPolicy p i secs → v { = . p max_age secs }
+
+@ oidc_policy_require_sub * OidcPolicy p b on → v { = . p require_sub on }
+
+@ oidc_policy_require_exp * OidcPolicy p b on → v { = . p require_exp on }
+
+@ oidc_policy_allow_symmetric * OidcPolicy p b on → v { = . p allow_symmetric on }
+
+// Is `alg` inside the policy's allowlist? An empty allowlist means "any
+// algorithm the verifier supports", which still excludes HS* unless the
+// caller deliberately allowed symmetric keys.
+@ oidc_policy_alg_allowed * OidcPolicy p s alg → b {
+    ? == 0 ( string_len . p algs ) { ^ T } {}
+    : ( Vec String ) list ( string_split . p algs ` ` )
+    : b found ( __cl_list_has list alg )
+    ( claims_strings_free list )
+    ^ found
+}
+
+// ── The check ──────────────────────────────────────────────────────
+
+// None = every check passed. `now` is epoch seconds — passed in, not
+// read here, so a test (or a caller with its own time source) is
+// deterministic.
+@ claims_check Json c * OidcPolicy pol i now → ?ClaimErr {
+    ? ( json_is_obj c ) {} { ^ @ ?ClaimErr { T ClNotObject } }
+    : i leeway . pol leeway
+
+    // exp / nbf / iat
+    : i exp ( claims_int c `exp` )
+    ? >= exp 0 {
+        ? >= now + exp leeway { ^ @ ?ClaimErr { T ClExpired } } {}
+    } {
+        ? . pol require_exp { ^ @ ?ClaimErr { T ClNoExpiry } } {}
+    }
+    : i nbf ( claims_int c `nbf` )
+    ? >= nbf 0 {
+        ? < + now leeway nbf { ^ @ ?ClaimErr { T ClNotYetValid } } {}
+    } {}
+    : i iat ( claims_int c `iat` )
+    ? >= iat 0 {
+        ? > iat + now leeway { ^ @ ?ClaimErr { T ClIssuedInFuture } } {}
+    } {}
+
+    // iss
+    ? > ( string_len . pol issuer ) 0 {
+        : String iss ( claims_str c `iss` )
+        : b same ( string_eq iss . pol issuer )
+        ( string_free iss )
+        ? same {} { ^ @ ?ClaimErr { T ClIssuer } }
+    } {}
+
+    // aud + azp
+    ? > ( string_len . pol audience ) 0 {
+        : s want ( string_data . pol audience )
+        ? ( claims_has_audience c want ) {} { ^ @ ?ClaimErr { T ClAudience } }
+        // OIDC core §3.1.3.7: when azp is present it must be our client.
+        : String azp ( claims_str c `azp` )
+        : b azp_bad & > ( string_len azp ) 0 == 0 ( nurl_str_eq ( string_data azp ) want )
+        ( string_free azp )
+        ? azp_bad { ^ @ ?ClaimErr { T ClAuthorizedParty } } {}
+    } {}
+
+    // nonce
+    ? > ( string_len . pol nonce ) 0 {
+        : String nonce ( claims_str c `nonce` )
+        : b same ( string_eq nonce . pol nonce )
+        ( string_free nonce )
+        ? same {} { ^ @ ?ClaimErr { T ClNonce } }
+    } {}
+
+    // sub
+    ? . pol require_sub {
+        : String sub ( claims_str c `sub` )
+        : b empty == 0 ( string_len sub )
+        ( string_free sub )
+        ? empty { ^ @ ?ClaimErr { T ClNoSubject } } {}
+    } {}
+
+    // max_age — measured from auth_time when the provider sent one
+    // (that is the actual authentication event), else from iat.
+    ? > . pol max_age 0 {
+        : i auth_time ( claims_int_or c `auth_time` iat )
+        ? < auth_time 0 { ^ @ ?ClaimErr { T ClMaxAge } } {}
+        ? > - now auth_time + . pol max_age leeway { ^ @ ?ClaimErr { T ClMaxAge } } {}
+    } {}
+
+    ^ @ ?ClaimErr { F }
+}
+
+@ claims_check_now Json c * OidcPolicy pol → ?ClaimErr {
+    ^ ( claims_check c pol ( now_seconds ) )
+}
+
+// ── The identity ───────────────────────────────────────────────────
+
+: OidcIdentity {
+    String subject  // `sub` — stable, unique WITHIN the issuer
+    String issuer  // `iss` — the pair (issuer, subject) is the user
+    String email
+    String name
+    String username  // `preferred_username`
+    String picture
+    b email_verified
+    i issued_at
+    i expires_at
+    Json claims  // everything else the provider said, owned
+}
+
+// Takes OWNERSHIP of `claims`; freed by oidc_identity_free.
+@ oidc_identity_from_claims Json claims → OidcIdentity {
+    ^ @ OidcIdentity {
+        ( claims_str claims `sub` )
+        ( claims_str claims `iss` )
+        ( claims_str claims `email` )
+        ( claims_str claims `name` )
+        ( claims_str claims `preferred_username` )
+        ( claims_str claims `picture` )
+        ( claims_bool claims `email_verified` )
+        ( claims_int claims `iat` )
+        ( claims_int claims `exp` )
+        claims
+    }
+}
+
+@ oidc_identity_free OidcIdentity id → v {
+    ( string_free . id subject )
+    ( string_free . id issuer )
+    ( string_free . id email )
+    ( string_free . id name )
+    ( string_free . id username )
+    ( string_free . id picture )
+    ( json_free . id claims )
+}
+
+// Any other claim, by name — the provider-specific half of the profile.
+@ oidc_identity_claim OidcIdentity id s key → String {
+    ^ ( claims_str . id claims key )
+}
+
+@ oidc_identity_claim_list OidcIdentity id s key → ( Vec String ) {
+    ^ ( claims_string_list . id claims key )
+}
+
+@ oidc_identity_has_scope OidcIdentity id s scope → b {
+    ^ ( claims_has_scope . id claims scope )
+}
+
+// "sub@issuer" — the globally unique name of the user, which is the
+// pair, never the subject alone.
+@ oidc_identity_key OidcIdentity id → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out ( string_data . id subject ) )
+    ( string_push_char out 64 )  // '@'
+    ( string_push_str out ( string_data . id issuer ) )
+    ^ out
+}
+
+// A one-line human rendering, for logs and CLI output.
+@ oidc_identity_describe OidcIdentity id → String {
+    : String out ( string_with_cap 128 )
+    ( string_push_str out ( string_data . id subject ) )
+    ? > ( string_len . id name ) 0 {
+        ( string_push_str out ` (` )
+        ( string_push_str out ( string_data . id name ) )
+        ( string_push_char out 41 )  // ')'
+    } {}
+    ? > ( string_len . id email ) 0 {
+        ( string_push_str out ` <` )
+        ( string_push_str out ( string_data . id email ) )
+        ( string_push_char out 62 )  // '>'
+        ? . id email_verified {} { ( string_push_str out ` [unverified]` ) }
+    } {}
+    ( string_push_str out ` @ ` )
+    ( string_push_str out ( string_data . id issuer ) )
+    ^ out
+}

--- a/packages/oauth/src/errors.nu
+++ b/packages/oauth/src/errors.nu
@@ -1,0 +1,62 @@
+// oauth/errors.nu — one error type for the whole package.
+//
+// Discovery, JWKS fetching, token-endpoint calls, signature checking and
+// claim validation all fold into `OauthErr`, so a caller writes one
+// `?? … { T id → … F e → ( oauth_err_name e ) }` and is done. The
+// human-readable detail that does not fit an enum — the OAuth server's
+// own `error_description`, the claim that failed — is carried on the
+// provider (`oidc_provider_last_error`), set by whichever call failed.
+
+: | OauthErr {
+    OaNetwork  // could not connect / the transport failed
+    OaHttpStatus  // an endpoint answered non-2xx (detail in last_error)
+    OaBadResponse  // the body was not the JSON this endpoint must return
+    OaIssuerMismatch  // discovery doc's `issuer` ≠ the issuer we asked for
+    OaNoJwks  // the provider publishes no usable key set
+    OaNoKey  // no JWK matched the token's kid / alg
+    OaBadToken  // not a well-formed JWS / claims are not an object
+    OaBadSignature  // the signature did not verify under the chosen key
+    OaAlgNotAllowed  // header `alg` is unsupported or outside the policy
+    OaClaims  // a claim check failed (detail in last_error)
+    OaServer  // the endpoint returned an OAuth error response
+    OaState  // the redirect's `state` is not the one we sent
+    OaConfig  // caller misconfiguration — a required endpoint/field is unset
+}
+
+@ oauth_err_name OauthErr e → s {
+    ^ ?? e {
+        OaNetwork → `OaNetwork`
+        OaHttpStatus → `OaHttpStatus`
+        OaBadResponse → `OaBadResponse`
+        OaIssuerMismatch → `OaIssuerMismatch`
+        OaNoJwks → `OaNoJwks`
+        OaNoKey → `OaNoKey`
+        OaBadToken → `OaBadToken`
+        OaBadSignature → `OaBadSignature`
+        OaAlgNotAllowed → `OaAlgNotAllowed`
+        OaClaims → `OaClaims`
+        OaServer → `OaServer`
+        OaState → `OaState`
+        OaConfig → `OaConfig`
+    }
+}
+
+// The RFC 6750 §3.1 `error=` token a resource server puts in its
+// WWW-Authenticate challenge for this failure.
+@ oauth_err_bearer_code OauthErr e → s {
+    ^ ?? e {
+        OaNetwork → `temporarily_unavailable`
+        OaHttpStatus → `temporarily_unavailable`
+        OaBadResponse → `temporarily_unavailable`
+        OaIssuerMismatch → `invalid_token`
+        OaNoJwks → `temporarily_unavailable`
+        OaNoKey → `invalid_token`
+        OaBadToken → `invalid_token`
+        OaBadSignature → `invalid_token`
+        OaAlgNotAllowed → `invalid_token`
+        OaClaims → `invalid_token`
+        OaServer → `invalid_token`
+        OaState → `invalid_request`
+        OaConfig → `temporarily_unavailable`
+    }
+}

--- a/packages/oauth/src/flow.nu
+++ b/packages/oauth/src/flow.nu
@@ -1,0 +1,471 @@
+// oauth/flow.nu — the authorization-code flow, end to end.
+//
+// Three requests and one redirect:
+//
+//   1. ( oauth_authorize_url p cfg state nonce pk )
+//        → send the user's browser here. The URL carries the PKCE
+//          challenge, the state and the nonce; the secrets behind them
+//          stay on this side.
+//   2. the provider redirects back to the client's redirect_uri with
+//      `?code=…&state=…` — ( oauth_callback_code query state ) checks
+//      the state and hands back the code (or names the provider's own
+//      error, which arrives the same way).
+//   3. ( oauth_exchange_code p cfg code verifier )
+//        → POST to the token endpoint: the code plus the PKCE verifier,
+//          answered with the access token and — this is the point — the
+//          ID TOKEN, a signed JWT stating who just logged in.
+//
+// Then ( oidc_verify_id_token p pol ( token_set_id_token ts ) ) turns
+// that into an OidcIdentity. `oauth_userinfo` fetches the same profile
+// from the UserInfo endpoint when the ID token is deliberately thin.
+//
+// Also here: `oauth_refresh` (a new access token without the user) and
+// `oauth_client_credentials` (a machine identity — no user at all).
+//
+// Client authentication is `client_secret_post` by default and
+// `client_secret_basic` on request (RFC 6749 §2.3.1); a public client
+// simply sets no secret and relies on PKCE, which is the OAuth 2.1
+// shape for anything running on the user's machine.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/url.nu`
+$ `stdlib/ext/json.nu`
+$ `deps/http-client/src/http_client.nu`
+$ `errors.nu`
+$ `claims.nu`
+$ `pkce.nu`
+$ `provider.nu`
+
+// ── Client configuration ───────────────────────────────────────────
+
+: OauthConfig {
+    String client_id
+    String client_secret  // empty = a public client (PKCE only)
+    String redirect_uri
+    String scope  // space-separated; "openid" is what makes it OIDC
+    String audience  // a resource indicator, when the provider wants one
+    String prompt  // "none" · "login" · "consent" — empty to omit
+    b basic_auth  // client_secret_basic instead of client_secret_post
+}
+
+@ oauth_config_new s client_id s redirect_uri s scope → *OauthConfig {
+    : *OauthConfig c # *OauthConfig ( nurl_malloc Z OauthConfig )
+    = . c client_id ( string_from client_id )
+    = . c client_secret ( string_new )
+    = . c redirect_uri ( string_from redirect_uri )
+    = . c scope ( string_from scope )
+    = . c audience ( string_new )
+    = . c prompt ( string_new )
+    = . c basic_auth F
+    ^ c
+}
+
+@ oauth_config_free * OauthConfig c → v {
+    ( string_free . c client_id )
+    ( string_free . c client_secret )
+    ( string_free . c redirect_uri )
+    ( string_free . c scope )
+    ( string_free . c audience )
+    ( string_free . c prompt )
+    ( nurl_free # s c )
+}
+
+@ oauth_config_set_secret * OauthConfig c s secret → v {
+    ( string_free . c client_secret )
+    = . c client_secret ( string_from secret )
+}
+
+@ oauth_config_set_audience * OauthConfig c s audience → v {
+    ( string_free . c audience )
+    = . c audience ( string_from audience )
+}
+
+@ oauth_config_set_prompt * OauthConfig c s prompt → v {
+    ( string_free . c prompt )
+    = . c prompt ( string_from prompt )
+}
+
+@ oauth_config_set_basic_auth * OauthConfig c b on → v { = . c basic_auth on }
+
+// ── Form / query encoding ──────────────────────────────────────────
+
+// Append `key=value`, percent-encoded, with a separating '&' when the
+// buffer already holds a pair. An empty value is omitted entirely — an
+// OAuth request must not carry `scope=` with nothing after it.
+@ __oaf_kv String q s key s value → v {
+    ? > ( nurl_str_len value ) 0 {
+        ? > ( string_len q ) 0 { ( string_push_char q 38 ) } {}
+        : String ek ( url_percent_encode key )
+        : String ev ( url_percent_encode value )
+        ( string_push_str q ( string_data ek ) )
+        ( string_push_char q 61 )  // '='
+        ( string_push_str q ( string_data ev ) )
+        ( string_free ek )
+        ( string_free ev )
+    } {}
+}
+
+// ── Authorization request ──────────────────────────────────────────
+
+// The URL to send the user's browser to. `state` and `nonce` are the
+// values the caller minted (pkce.nu) and must remember: state is
+// compared on the way back, nonce is compared inside the ID token.
+@ oauth_authorize_url * OidcProvider p * OauthConfig cfg s state s nonce Pkce pk → String {
+    : String q ( string_with_cap 512 )
+    ( __oaf_kv q `response_type` `code` )
+    ( __oaf_kv q `client_id` ( string_data . cfg client_id ) )
+    ( __oaf_kv q `redirect_uri` ( string_data . cfg redirect_uri ) )
+    ( __oaf_kv q `scope` ( string_data . cfg scope ) )
+    ( __oaf_kv q `state` state )
+    ( __oaf_kv q `nonce` nonce )
+    ( __oaf_kv q `code_challenge` ( string_data . pk challenge ) )
+    ( __oaf_kv q `code_challenge_method` ( string_data . pk method ) )
+    ( __oaf_kv q `audience` ( string_data . cfg audience ) )
+    ( __oaf_kv q `prompt` ( string_data . cfg prompt ) )
+    : String out ( string_from ( string_data . p authorization_endpoint ) )
+    // The endpoint may already carry a query of its own (RFC 6749 §3.1).
+    ? ( string_contains out `?` ) {
+        ( string_push_char out 38 )
+    } {
+        ( string_push_char out 63 )  // '?'
+    }
+    ( string_push_str out ( string_data q ) )
+    ( string_free q )
+    ^ out
+}
+
+// ── The redirect back ──────────────────────────────────────────────
+
+: CallbackParams {
+    String code
+    String state
+    String error
+    String error_description
+}
+
+@ callback_params_free CallbackParams cb → v {
+    ( string_free . cb code )
+    ( string_free . cb state )
+    ( string_free . cb error )
+    ( string_free . cb error_description )
+}
+
+@ __oaf_param ( Vec UrlParam ) ps s key → String {
+    : i n ( vec_len [UrlParam] ps )
+    : *UrlParam data ( vec_data [UrlParam] ps )
+    : ~ i k 0
+    ~ < k n {
+        : UrlParam pp . data k
+        ? == 1 ( nurl_str_eq ( string_data . pp key ) key ) {
+            ^ ( string_from ( string_data . pp val ) )
+        } {}
+        = k + k 1
+    }
+    ^ ( string_new )
+}
+
+// Parse the query string of the redirect the provider sent the browser.
+@ oauth_callback_parse s query → CallbackParams {
+    : ( Vec UrlParam ) ps ( url_query_decode query )
+    : CallbackParams cb @ CallbackParams {
+        ( __oaf_param ps `code` )
+        ( __oaf_param ps `state` )
+        ( __oaf_param ps `error` )
+        ( __oaf_param ps `error_description` )
+    }
+    ( url_params_free ps )
+    ^ cb
+}
+
+// The authorization code, once the callback is proven to be the answer
+// to the request WE started. A `state` that does not match is not a
+// recoverable condition — it is someone else's login being fed to us.
+@ oauth_callback_code s query s expected_state → !String OauthErr {
+    : CallbackParams cb ( oauth_callback_parse query )
+    // The provider said no (`error=access_denied`, …). Read the detail
+    // from `oauth_callback_parse` when you want to show it.
+    ? > ( string_len . cb error ) 0 {
+        ( callback_params_free cb )
+        ^ @ !String OauthErr { F OaServer }
+    } {}
+    ? > ( nurl_str_len expected_state ) 0 {
+        ? == 1 ( nurl_str_eq ( string_data . cb state ) expected_state ) {} {
+            ( callback_params_free cb )
+            ^ @ !String OauthErr { F OaState }
+        }
+    } {}
+    ? == 0 ( string_len . cb code ) {
+        ( callback_params_free cb )
+        ^ @ !String OauthErr { F OaBadResponse }
+    } {}
+    : String code ( string_from ( string_data . cb code ) )
+    ( callback_params_free cb )
+    ^ @ !String OauthErr { T code }
+}
+
+// ── Tokens ─────────────────────────────────────────────────────────
+
+: TokenSet {
+    String access_token
+    String id_token  // the signed statement of WHO — empty for a
+    // non-OIDC grant (client_credentials, plain OAuth)
+    String refresh_token
+    String token_type  // "Bearer"
+    String scope  // what the provider actually granted
+    i expires_in  // seconds, −1 when the provider said nothing
+    i obtained_at  // our clock when the response arrived
+}
+
+@ token_set_free TokenSet t → v {
+    ( string_free . t access_token )
+    ( string_free . t id_token )
+    ( string_free . t refresh_token )
+    ( string_free . t token_type )
+    ( string_free . t scope )
+}
+
+@ token_set_access_token TokenSet t → s { ^ ( string_data . t access_token ) }
+
+@ token_set_id_token TokenSet t → s { ^ ( string_data . t id_token ) }
+
+@ token_set_refresh_token TokenSet t → s { ^ ( string_data . t refresh_token ) }
+
+@ token_set_token_type TokenSet t → s { ^ ( string_data . t token_type ) }
+
+@ token_set_scope TokenSet t → s { ^ ( string_data . t scope ) }
+
+// When the access token stops being usable; −1 when unknown.
+@ token_set_expires_at TokenSet t → i {
+    ? < . t expires_in 0 { ^ -1 } {}
+    ^ + . t obtained_at . t expires_in
+}
+
+// Refresh a minute early — a token that expires in flight is a 401 the
+// caller has to retry, and the clocks are not the same clock.
+@ token_set_stale TokenSet t i now → b {
+    : i at ( token_set_expires_at t )
+    ? < at 0 { ^ F } {}
+    ^ >= + now 60 at
+}
+
+@ __oaf_token_set_from_json Json j → TokenSet {
+    ^ @ TokenSet {
+        ( claims_str j `access_token` )
+        ( claims_str j `id_token` )
+        ( claims_str j `refresh_token` )
+        ( claims_str j `token_type` )
+        ( claims_str j `scope` )
+        ( claims_int_or j `expires_in` -1 )
+        ( now_seconds )
+    }
+}
+
+// ── The token endpoint ─────────────────────────────────────────────
+
+// Add whichever client authentication the config asks for: the secret in
+// the body, or an Authorization header the caller then sends.
+@ __oaf_auth_header * OauthConfig cfg → String {
+    : String out ( string_new )
+    ? & . cfg basic_auth > ( string_len . cfg client_secret ) 0 {
+        : String ek ( url_percent_encode ( string_data . cfg client_id ) )
+        : String es ( url_percent_encode ( string_data . cfg client_secret ) )
+        : String pair ( string_with_cap 128 )
+        ( string_push_str pair ( string_data ek ) )
+        ( string_push_char pair 58 )  // ':'
+        ( string_push_str pair ( string_data es ) )
+        : String enc ( b64_encode ( string_data pair ) )
+        ( string_push_str out `Basic ` )
+        ( string_push_str out ( string_data enc ) )
+        ( string_free ek ) ( string_free es )
+        ( string_free pair ) ( string_free enc )
+    } {}
+    ^ out
+}
+
+// POST a form to the token endpoint and read the token response.
+@ __oaf_token_request * OidcProvider p * OauthConfig cfg String form → !TokenSet OauthErr {
+    ? == 0 ( string_len . p token_endpoint ) {
+        ( _oidc_err p `no token_endpoint — run discovery or set one` )
+        ^ @ !TokenSet OauthErr { F OaConfig }
+    } {}
+    : String auth ( __oaf_auth_header cfg )
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `content-type` `application/x-www-form-urlencoded` ) )
+    ( vec_push [Header] hs ( header_new `accept` `application/json` ) )
+    ? > ( string_len auth ) 0 {
+        ( vec_push [Header] hs ( header_new `authorization` ( string_data auth ) ) )
+    } {}
+    ( string_free auth )
+    : ( Vec u ) body ( bytes_from_str ( string_data form ) )
+    : !HttpResponse HttpClientErr rr ( http_client_request . p http `POST` ( string_data . p token_endpoint ) hs body )
+    ( vec_free [u] body )
+    ?? rr {
+        T r → {
+            : i status ( http_client_status r )
+            : !Json JsonError pj ( json_parse_bytes . r body )
+            ( http_response_free r )
+            ?? pj {
+                T j → {
+                    // An OAuth error response is JSON too (RFC 6749 §5.2),
+                    // and it is the only place the reason is stated.
+                    : String oerr ( claims_str j `error` )
+                    ? > ( string_len oerr ) 0 {
+                        : String desc ( claims_str j `error_description` )
+                        : String msg ( string_with_cap 128 )
+                        ( string_push_str msg `token endpoint: ` )
+                        ( string_push_str msg ( string_data oerr ) )
+                        ? > ( string_len desc ) 0 {
+                            ( string_push_str msg ` — ` )
+                            ( string_push_str msg ( string_data desc ) )
+                        } {}
+                        ( _oidc_err p ( string_data msg ) )
+                        ( string_free msg ) ( string_free desc ) ( string_free oerr )
+                        ( json_free j )
+                        ^ @ !TokenSet OauthErr { F OaServer }
+                    } {}
+                    ( string_free oerr )
+                    ? & >= status 200 < status 300 {} {
+                        ( _oidc_err_status p `token endpoint` status )
+                        ( json_free j )
+                        ^ @ !TokenSet OauthErr { F OaHttpStatus }
+                    }
+                    : TokenSet ts ( __oaf_token_set_from_json j )
+                    ( json_free j )
+                    ? == 0 ( string_len . ts access_token ) {
+                        ( token_set_free ts )
+                        ( _oidc_err p `token response carries no access_token` )
+                        ^ @ !TokenSet OauthErr { F OaBadResponse }
+                    } {}
+                    ^ @ !TokenSet OauthErr { T ts }
+                }
+                F _ → {
+                    ( _oidc_err_status p `token endpoint (non-JSON)` status )
+                    ^ @ !TokenSet OauthErr { F OaBadResponse }
+                }
+            }
+        }
+        F e → {
+            ( _oidc_err2 p `token endpoint: ` ( http_client_err_name e ) )
+            ^ @ !TokenSet OauthErr { F OaNetwork }
+        }
+    }
+}
+
+// Exchange the authorization code for tokens. `verifier` is the PKCE
+// secret whose challenge went out with the authorization request.
+@ oauth_exchange_code * OidcProvider p * OauthConfig cfg s code s verifier → !TokenSet OauthErr {
+    : String form ( string_with_cap 512 )
+    ( __oaf_kv form `grant_type` `authorization_code` )
+    ( __oaf_kv form `code` code )
+    ( __oaf_kv form `redirect_uri` ( string_data . cfg redirect_uri ) )
+    ( __oaf_kv form `client_id` ( string_data . cfg client_id ) )
+    ( __oaf_kv form `code_verifier` verifier )
+    ? . cfg basic_auth {} {
+        ( __oaf_kv form `client_secret` ( string_data . cfg client_secret ) )
+    }
+    : !TokenSet OauthErr r ( __oaf_token_request p cfg form )
+    ( string_free form )
+    ^ r
+}
+
+// A new access token from a refresh token — no user interaction.
+@ oauth_refresh * OidcProvider p * OauthConfig cfg s refresh_token → !TokenSet OauthErr {
+    : String form ( string_with_cap 512 )
+    ( __oaf_kv form `grant_type` `refresh_token` )
+    ( __oaf_kv form `refresh_token` refresh_token )
+    ( __oaf_kv form `client_id` ( string_data . cfg client_id ) )
+    ( __oaf_kv form `scope` ( string_data . cfg scope ) )
+    ? . cfg basic_auth {} {
+        ( __oaf_kv form `client_secret` ( string_data . cfg client_secret ) )
+    }
+    : !TokenSet OauthErr r ( __oaf_token_request p cfg form )
+    ( string_free form )
+    ^ r
+}
+
+// The machine grant: this service authenticating as itself, with no user
+// behind it (RFC 6749 §4.4).
+@ oauth_client_credentials * OidcProvider p * OauthConfig cfg → !TokenSet OauthErr {
+    : String form ( string_with_cap 512 )
+    ( __oaf_kv form `grant_type` `client_credentials` )
+    ( __oaf_kv form `client_id` ( string_data . cfg client_id ) )
+    ( __oaf_kv form `scope` ( string_data . cfg scope ) )
+    ( __oaf_kv form `audience` ( string_data . cfg audience ) )
+    ? . cfg basic_auth {} {
+        ( __oaf_kv form `client_secret` ( string_data . cfg client_secret ) )
+    }
+    : !TokenSet OauthErr r ( __oaf_token_request p cfg form )
+    ( string_free form )
+    ^ r
+}
+
+// ── UserInfo ───────────────────────────────────────────────────────
+
+// The profile as the provider will state it right now, fetched with the
+// access token (OIDC core §5.3). Returns the owned claims object.
+@ oauth_userinfo * OidcProvider p s access_token → !Json OauthErr {
+    ? == 0 ( string_len . p userinfo_endpoint ) {
+        ( _oidc_err p `no userinfo_endpoint — run discovery or set one` )
+        ^ @ !Json OauthErr { F OaConfig }
+    } {}
+    : String auth ( string_with_cap 64 )
+    ( string_push_str auth `Bearer ` )
+    ( string_push_str auth access_token )
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `authorization` ( string_data auth ) ) )
+    ( vec_push [Header] hs ( header_new `accept` `application/json` ) )
+    ( string_free auth )
+    : ( Vec u ) body ( vec_new [u] )
+    : !HttpResponse HttpClientErr rr ( http_client_request . p http `GET` ( string_data . p userinfo_endpoint ) hs body )
+    ( vec_free [u] body )
+    ?? rr {
+        T r → {
+            : i status ( http_client_status r )
+            ? & >= status 200 < status 300 {} {
+                ( _oidc_err_status p `userinfo` status )
+                ( http_response_free r )
+                ^ @ !Json OauthErr { F OaHttpStatus }
+            }
+            : !Json JsonError pj ( json_parse_bytes . r body )
+            ( http_response_free r )
+            ?? pj {
+                T j → { ^ @ !Json OauthErr { T j } }
+                F _ → {
+                    ( _oidc_err p `userinfo did not return JSON` )
+                    ^ @ !Json OauthErr { F OaBadResponse }
+                }
+            }
+        }
+        F e → {
+            ( _oidc_err2 p `userinfo: ` ( http_client_err_name e ) )
+            ^ @ !Json OauthErr { F OaNetwork }
+        }
+    }
+}
+
+// The identity behind an access token, taken from UserInfo rather than
+// from a signed token — for a provider whose access tokens are opaque.
+// The `sub` MUST match the ID token's when both are in play (OIDC core
+// §5.3.2); with no ID token in hand, pass "" to skip that.
+@ oauth_userinfo_identity * OidcProvider p s access_token s expect_sub → !OidcIdentity OauthErr {
+    ?? ( oauth_userinfo p access_token ) {
+        T j → {
+            ? > ( nurl_str_len expect_sub ) 0 {
+                : String sub ( claims_str j `sub` )
+                : b same == 1 ( nurl_str_eq ( string_data sub ) expect_sub )
+                ( string_free sub )
+                ? same {} {
+                    ( _oidc_err p `userinfo sub does not match the ID token` )
+                    ( json_free j )
+                    ^ @ !OidcIdentity OauthErr { F OaClaims }
+                }
+            } {}
+            ^ @ !OidcIdentity OauthErr { T ( oidc_identity_from_claims j ) }
+        }
+        F e → { ^ @ !OidcIdentity OauthErr { F # OauthErr e } }
+    }
+}

--- a/packages/oauth/src/guard.nu
+++ b/packages/oauth/src/guard.nu
@@ -1,0 +1,165 @@
+// oauth/guard.nu — the resource-server side: a route that knows who
+// called it.
+//
+// The client half of this package gets tokens; this half spends them.
+// Wrap a handler and it only ever runs for a request that carried a
+// valid `Authorization: Bearer <JWT>`, with the caller's verified
+// identity handed straight in:
+//
+//   ( http_app_get a `/me`
+//       ( with_oidc_bearer p pol
+//           \ HttpRequest req OidcIdentity id → HttpResponse {
+//               ^ ( response_text 200 ( string_data ( oidc_identity_describe id ) ) )
+//           } ) )
+//
+// Everything a bearer token can be wrong about — no token, a token from
+// another issuer, for another audience, expired, signed with a key the
+// provider never published, signed with `alg: none` — becomes a 401 with
+// the RFC 6750 §3 challenge naming the reason. A token that is valid but
+// does not carry the scope the route needs is a 403 `insufficient_scope`
+// (`with_oidc_scope`), because that is a different answer: re-
+// authenticating will not help, asking for more scope will.
+//
+// `id` is BORROWED by the handler — the middleware frees it (and the
+// claims behind it) once the handler returns.
+//
+// The wrapper closure lives as long as the app that routes to it, the
+// same as with_jwt_* / with_cors_default: build it once at startup.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_auth.nu`
+$ `errors.nu`
+$ `claims.nu`
+$ `provider.nu`
+
+// Append `value` as the inside of an RFC 7235 quoted-string, keeping only
+// bytes that are legal there and capping the length.
+//
+// This is load-bearing, not hygiene: the description we render comes from
+// `oidc_provider_last_error`, and some of what lands there is quoted from
+// the TOKEN — an attacker-supplied `kid`, a provider's error_description.
+// A CR or LF echoed into a response header is response splitting; a `"`
+// ends the parameter early. Neither reaches the wire.
+@ _oidc_safe_param String out s value → v {
+    : i n ( nurl_str_len value )
+    : i cap ? > n 200 200 n
+    : ~ i k 0
+    ~ < k cap {
+        : i c ( nurl_str_get value k )
+        ? | < c 32 == c 127 {
+            ( string_push_char out 32 )
+        } {
+            ? | == c 34 == c 92 {
+                ( string_push_char out 32 )
+            } {
+                ( string_push_char out c )
+            }
+        }
+        = k + k 1
+    }
+    ? > n cap { ( string_push_str out `...` ) } {}
+}
+
+// 401 with a Bearer challenge. `code` is the RFC 6750 error token, empty
+// for a missing credential (§3.1: no error code when none was offered).
+@ _oidc_unauthorized s code s desc → HttpResponse {
+    : HttpResponse r ( response_text 401 `Unauthorized\n` )
+    : String chal ( string_with_cap 96 )
+    ( string_push_str chal `Bearer` )
+    ? > ( nurl_str_len code ) 0 {
+        ( string_push_str chal ` error="` )
+        ( _oidc_safe_param chal code )
+        ( string_push_char chal 34 )
+        ? > ( nurl_str_len desc ) 0 {
+            ( string_push_str chal `, error_description="` )
+            ( _oidc_safe_param chal desc )
+            ( string_push_char chal 34 )
+        } {}
+    } {}
+    ( response_set_header r `WWW-Authenticate` ( string_data chal ) )
+    ( string_free chal )
+    ^ r
+}
+
+// 403: the caller is who they say, and still may not do this.
+@ _oidc_forbidden s scope → HttpResponse {
+    : HttpResponse r ( response_text 403 `Forbidden\n` )
+    : String chal ( string_with_cap 96 )
+    ( string_push_str chal `Bearer error="insufficient_scope"` )
+    ? > ( nurl_str_len scope ) 0 {
+        ( string_push_str chal `, scope="` )
+        ( _oidc_safe_param chal scope )
+        ( string_push_char chal 34 )
+    } {}
+    ( response_set_header r `WWW-Authenticate` ( string_data chal ) )
+    ( string_free chal )
+    ^ r
+}
+
+// Verify the request's bearer token directly — for a handler that wants
+// the identity without being wrapped, or for a protocol other than HTTP
+// routing (a WebSocket upgrade, an MCP session).
+@ oidc_request_identity * OidcProvider p * OidcPolicy pol HttpRequest req → !OidcIdentity OauthErr {
+    ?? ( parse_bearer_auth req ) {
+        T t → {
+            : !OidcIdentity OauthErr r ( oidc_verify_token p pol ( string_data t ) )
+            ( string_free t )
+            ^ r
+        }
+        F _ → {
+            ( _oidc_err p `no bearer token` )
+            ^ @ !OidcIdentity OauthErr { F OaBadToken }
+        }
+    }
+}
+
+// Only run `inner` for an authenticated caller.
+@ with_oidc_bearer * OidcProvider p * OidcPolicy pol ( @ HttpResponse HttpRequest OidcIdentity ) inner → ( @ HttpResponse HttpRequest ) {
+    : ( @ HttpResponse HttpRequest ) wrapped \ HttpRequest req → HttpResponse {
+        ?? ( parse_bearer_auth req ) {
+            T t → {
+                : !OidcIdentity OauthErr vr ( oidc_verify_token p pol ( string_data t ) )
+                ( string_free t )
+                ^ ?? vr {
+                    T id → {
+                        : HttpResponse resp ( inner req id )
+                        ( oidc_identity_free id )
+                        ^ resp
+                    }
+                    F e → ( _oidc_unauthorized ( oauth_err_bearer_code # OauthErr e ) ( oidc_provider_last_error p ) )
+                }
+            }
+            F _ → { ^ ( _oidc_unauthorized `` `` ) }
+        }
+    }
+    ^ wrapped
+}
+
+// Authenticated AND carrying `scope`.
+@ with_oidc_scope * OidcProvider p * OidcPolicy pol s scope ( @ HttpResponse HttpRequest OidcIdentity ) inner → ( @ HttpResponse HttpRequest ) {
+    : ( @ HttpResponse HttpRequest ) wrapped \ HttpRequest req → HttpResponse {
+        ?? ( parse_bearer_auth req ) {
+            T t → {
+                : !OidcIdentity OauthErr vr ( oidc_verify_token p pol ( string_data t ) )
+                ( string_free t )
+                ^ ?? vr {
+                    T id → {
+                        ? ( oidc_identity_has_scope id scope ) {
+                            : HttpResponse resp ( inner req id )
+                            ( oidc_identity_free id )
+                            ^ resp
+                        } {
+                            ( oidc_identity_free id )
+                            ^ ( _oidc_forbidden scope )
+                        }
+                    }
+                    F e → ( _oidc_unauthorized ( oauth_err_bearer_code # OauthErr e ) ( oidc_provider_last_error p ) )
+                }
+            }
+            F _ → { ^ ( _oidc_unauthorized `` `` ) }
+        }
+    }
+    ^ wrapped
+}

--- a/packages/oauth/src/jwk.nu
+++ b/packages/oauth/src/jwk.nu
@@ -1,0 +1,319 @@
+// oauth/jwk.nu — JSON Web Key and JWK Set (RFC 7517 / RFC 7518 §6).
+//
+// A provider publishes its verification keys as a JWKS document:
+//
+//     { "keys": [ { "kty":"RSA", "kid":"a1", "alg":"RS256",
+//                   "n":"<base64url>", "e":"AQAB" }, … ] }
+//
+// This module turns that into `( Vec JwkKey )` — the parameters already
+// base64url-decoded into byte vectors, ready to hand to the verifier —
+// and picks the key a token's `kid`/`alg` names.
+//
+//   ( jwks_parse text )              → ( Vec JwkKey )   (empty on garbage)
+//   ( jwks_from_json doc )           → ( Vec JwkKey )
+//   ( jwks_free ks )                 → v
+//   ( jwks_select ks kid alg )       → i   index, or -1
+//   ( jwk_ec_point jk )              → ( Vec u )  0x04‖X‖Y
+//   ( jwk_thumbprint jk )            → String     RFC 7638, base64url
+//
+// A `JwkKey` is a plain value struct: the strings and vectors are owned
+// by the vector that holds it, so `vec_data` + `. data k` hands out a
+// BORROW that must not be freed — only `jwks_free` frees.
+//
+// Key selection follows RFC 7515 §4.1.4 and the OIDC core rules: a `kid`
+// in the token header must match a `kid` in the set; a key that declares
+// `alg` must agree with the header's; a key that declares `use` must say
+// `sig`; and the key type must be the one the algorithm family needs
+// (RS*/PS* → RSA, ES* → EC with the right curve, EdDSA → OKP/Ed25519,
+// HS* → oct). A set with exactly one usable key is accepted even when
+// the token carries no `kid` — the common single-key provider.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/ext/json.nu`
+
+: JwkKey {
+    String kty  // "RSA" · "EC" · "OKP" · "oct"
+    String kid
+    String alg  // may be empty — a key that names no algorithm
+    String crv  // "P-256" · "P-384" · "Ed25519"
+    String usage  // the `use` member: "sig" · "enc" · empty
+    ( Vec u ) n  // RSA modulus (big-endian)
+    ( Vec u ) e  // RSA public exponent (big-endian)
+    ( Vec u ) x  // EC x-coordinate · OKP public key
+    ( Vec u ) y  // EC y-coordinate
+    ( Vec u ) oct  // the `k` member: a symmetric secret (HS*)
+}
+
+// ── JSON field readers ─────────────────────────────────────────────
+
+// A string member as an owned String; empty when absent or not a string.
+@ __jwk_str Json j s key → String {
+    : ~ s raw ``
+    ?? ( json_obj_get j key ) {
+        T v → { ? ( json_is_str v ) { = raw ( json_str_data v ) } {} }
+        F _ → {}
+    }
+    ^ ( string_from raw )
+}
+
+// A base64url member decoded to bytes; empty when absent or malformed.
+@ __jwk_b64u Json j s key → ( Vec u ) {
+    : ~ s raw ``
+    ?? ( json_obj_get j key ) {
+        T v → { ? ( json_is_str v ) { = raw ( json_str_data v ) } {} }
+        F _ → {}
+    }
+    ? == 0 ( nurl_str_len raw ) { ^ ( vec_new [u] ) } {}
+    ?? ( b64_url_decode_vec raw ) {
+        T bs → { ^ bs }
+        F _ → { ^ ( vec_new [u] ) }
+    }
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────
+
+@ jwk_free JwkKey jk → v {
+    ( string_free . jk kty )
+    ( string_free . jk kid )
+    ( string_free . jk alg )
+    ( string_free . jk crv )
+    ( string_free . jk usage )
+    ( vec_free [u] . jk n )
+    ( vec_free [u] . jk e )
+    ( vec_free [u] . jk x )
+    ( vec_free [u] . jk y )
+    ( vec_free [u] . jk oct )
+}
+
+@ jwks_free ( Vec JwkKey ) ks → v {
+    ( vec_free_with [JwkKey] ks \ JwkKey jk → v { ( jwk_free jk ) } )
+}
+
+// Append one JWK object to `out`. Returns F (and appends nothing) when
+// the node is not an object with a `kty`.
+@ jwk_push_json ( Vec JwkKey ) out Json j → b {
+    ? ! ( json_is_obj j ) { ^ F } {}
+    : String kty ( __jwk_str j `kty` )
+    ? == 0 ( string_len kty ) { ( string_free kty ) ^ F } {}
+    : JwkKey jk @ JwkKey {
+        kty
+        ( __jwk_str j `kid` )
+        ( __jwk_str j `alg` )
+        ( __jwk_str j `crv` )
+        ( __jwk_str j `use` )
+        ( __jwk_b64u j `n` )
+        ( __jwk_b64u j `e` )
+        ( __jwk_b64u j `x` )
+        ( __jwk_b64u j `y` )
+        ( __jwk_b64u j `k` )
+    }
+    ( vec_push [JwkKey] out jk )
+    ^ T
+}
+
+// The `keys` array of a JWKS document. A document that is itself a bare
+// JWK (some providers hand one out) is accepted as a one-key set.
+@ jwks_from_json Json doc → ( Vec JwkKey ) {
+    : ( Vec JwkKey ) out ( vec_new [JwkKey] )
+    ?? ( json_obj_get doc `keys` ) {
+        T arr → {
+            ? ( json_is_arr arr ) {
+                : i n ( json_arr_len arr )
+                : ~ i k 0
+                ~ < k n {
+                    ?? ( json_arr_get arr k ) {
+                        T item → { : b _ok ( jwk_push_json out item ) }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            } {}
+        }
+        F _ → { : b _ok ( jwk_push_json out doc ) }
+    }
+    ^ out
+}
+
+@ jwks_parse s text → ( Vec JwkKey ) {
+    ?? ( json_parse text ) {
+        T doc → {
+            : ( Vec JwkKey ) ks ( jwks_from_json doc )
+            ( json_free doc )
+            ^ ks
+        }
+        F _ → { ^ ( vec_new [JwkKey] ) }
+    }
+}
+
+// ── Selection ──────────────────────────────────────────────────────
+
+// The key type an algorithm needs, or "" for an unknown algorithm.
+@ jwk_kty_for_alg s alg → s {
+    ? == 1 ( nurl_str_starts alg `RS` ) { ^ `RSA` } {}
+    ? == 1 ( nurl_str_starts alg `PS` ) { ^ `RSA` } {}
+    ? == 1 ( nurl_str_starts alg `ES` ) { ^ `EC` } {}
+    ? == 1 ( nurl_str_eq alg `EdDSA` ) { ^ `OKP` } {}
+    ? == 1 ( nurl_str_starts alg `HS` ) { ^ `oct` } {}
+    ^ ``
+}
+
+// The EC curve an ES* algorithm is defined over ("" when not ES*).
+@ jwk_crv_for_alg s alg → s {
+    ? == 1 ( nurl_str_eq alg `ES256` ) { ^ `P-256` } {}
+    ? == 1 ( nurl_str_eq alg `ES384` ) { ^ `P-384` } {}
+    ^ ``
+}
+
+// Does this key answer to (kid, alg)? `kid` may be empty (the token
+// header carried none) — then only the algebraic constraints apply.
+@ jwk_matches JwkKey jk s kid s alg → b {
+    ? > ( nurl_str_len kid ) 0 {
+        ? == 0 ( nurl_str_eq ( string_data . jk kid ) kid ) { ^ F } {}
+    } {}
+    // A key that declares its own algorithm must agree with the header.
+    ? & > ( string_len . jk alg ) 0 > ( nurl_str_len alg ) 0 {
+        ? == 0 ( nurl_str_eq ( string_data . jk alg ) alg ) { ^ F } {}
+    } {}
+    // `use` is optional; when present it must be for signatures.
+    ? > ( string_len . jk usage ) 0 {
+        ? == 0 ( nurl_str_eq ( string_data . jk usage ) `sig` ) { ^ F } {}
+    } {}
+    : s want_kty ( jwk_kty_for_alg alg )
+    ? > ( nurl_str_len want_kty ) 0 {
+        ? == 0 ( nurl_str_eq ( string_data . jk kty ) want_kty ) { ^ F } {}
+    } {}
+    : s want_crv ( jwk_crv_for_alg alg )
+    ? > ( nurl_str_len want_crv ) 0 {
+        ? == 0 ( nurl_str_eq ( string_data . jk crv ) want_crv ) { ^ F } {}
+    } {}
+    ? == 1 ( nurl_str_eq alg `EdDSA` ) {
+        ? == 0 ( nurl_str_eq ( string_data . jk crv ) `Ed25519` ) { ^ F } {}
+    } {}
+    ^ T
+}
+
+// Index of the first key matching (kid, alg), or -1.
+@ jwks_select ( Vec JwkKey ) ks s kid s alg → i {
+    ^ ( jwks_select_from ks kid alg 0 )
+}
+
+// The same, starting at `from` — so a verifier can walk EVERY candidate
+// key rather than betting on the first. That is the case during a key
+// rotation, when the provider publishes the old and the new key and the
+// tokens in flight carry no `kid` to tell them apart.
+@ jwks_select_from ( Vec JwkKey ) ks s kid s alg i from → i {
+    : i n ( vec_len [JwkKey] ks )
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : ~ i k ? > from 0 from 0
+    ~ < k n {
+        : JwkKey jk . data k
+        ? ( jwk_matches jk kid alg ) { ^ k } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+// Does the set hold a key with this `kid` at all? Used to decide whether
+// an unknown `kid` justifies re-fetching the JWKS.
+@ jwks_has_kid ( Vec JwkKey ) ks s kid → b {
+    : i n ( vec_len [JwkKey] ks )
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : ~ i k 0
+    ~ < k n {
+        : JwkKey jk . data k
+        ? == 1 ( nurl_str_eq ( string_data . jk kid ) kid ) { ^ T } {}
+        = k + k 1
+    }
+    ^ F
+}
+
+// ── Derived material ───────────────────────────────────────────────
+
+// SEC1 uncompressed point 0x04‖X‖Y, left-padded to the curve width.
+// Empty when the key is not an EC key of a curve we know.
+@ jwk_ec_point JwkKey jk → ( Vec u ) {
+    : ~ i width 0
+    ? == 1 ( nurl_str_eq ( string_data . jk crv ) `P-256` ) { = width 32 } {}
+    ? == 1 ( nurl_str_eq ( string_data . jk crv ) `P-384` ) { = width 48 } {}
+    ? == width 0 { ^ ( vec_new [u] ) } {}
+    : i xlen ( vec_len [u] . jk x )
+    : i ylen ( vec_len [u] . jk y )
+    ? | > xlen width > ylen width { ^ ( vec_new [u] ) } {}
+    ? | == xlen 0 == ylen 0 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) pt ( vec_with_cap [u] + 1 * 2 width )
+    ( vec_push [u] pt # u 4 )
+    : ~ i pad - width xlen
+    ~ > pad 0 { ( vec_push [u] pt # u 0 ) = pad - pad 1 }
+    ( vec_extend [u] pt . jk x )
+    = pad - width ylen
+    ~ > pad 0 { ( vec_push [u] pt # u 0 ) = pad - pad 1 }
+    ( vec_extend [u] pt . jk y )
+    ^ pt
+}
+
+// ── RFC 7638 thumbprint ────────────────────────────────────────────
+//
+// SHA-256 over the key's REQUIRED members, in lexicographic order, as
+// the most compact JSON possible. That is the key's stable identity —
+// two providers publishing the same key agree on it — so it doubles as
+// a `kid` for a key that ships without one.
+
+@ __jwk_tp_member String out s name ( Vec u ) raw b first → v {
+    ? first {} { ( string_push_char out 44 ) }  // ','
+    ( string_push_char out 34 )
+    ( string_push_str out name )
+    ( string_push_str out `":` )
+    ( string_push_char out 34 )
+    : String enc ( b64_url_encode_vec raw )
+    ( string_push_str out ( string_data enc ) )
+    ( string_free enc )
+    ( string_push_char out 34 )
+}
+
+@ __jwk_tp_lit String out s name s value b first → v {
+    ? first {} { ( string_push_char out 44 ) }
+    ( string_push_char out 34 )
+    ( string_push_str out name )
+    ( string_push_str out `":"` )
+    ( string_push_str out value )
+    ( string_push_char out 34 )
+}
+
+@ jwk_thumbprint JwkKey jk → String {
+    : String canon ( string_with_cap 256 )
+    ( string_push_char canon 123 )  // '{'
+    : s kty ( string_data . jk kty )
+    ? == 1 ( nurl_str_eq kty `RSA` ) {
+        ( __jwk_tp_member canon `e` . jk e T )
+        ( __jwk_tp_lit canon `kty` `RSA` F )
+        ( __jwk_tp_member canon `n` . jk n F )
+    } {
+        ? == 1 ( nurl_str_eq kty `EC` ) {
+            ( __jwk_tp_lit canon `crv` ( string_data . jk crv ) T )
+            ( __jwk_tp_lit canon `kty` `EC` F )
+            ( __jwk_tp_member canon `x` . jk x F )
+            ( __jwk_tp_member canon `y` . jk y F )
+        } {
+            ? == 1 ( nurl_str_eq kty `OKP` ) {
+                ( __jwk_tp_lit canon `crv` ( string_data . jk crv ) T )
+                ( __jwk_tp_lit canon `kty` `OKP` F )
+                ( __jwk_tp_member canon `x` . jk x F )
+            } {
+                ( __jwk_tp_member canon `k` . jk oct T )
+                ( __jwk_tp_lit canon `kty` `oct` F )
+            }
+        }
+    }
+    ( string_push_char canon 125 )  // '}'
+    : ( Vec u ) msg ( bytes_from_str ( string_data canon ) )
+    ( string_free canon )
+    : ( Vec u ) h ( sha256_pure msg )
+    ( vec_free [u] msg )
+    : String out ( b64_url_encode_vec h )
+    ( vec_free [u] h )
+    ^ out
+}

--- a/packages/oauth/src/jws.nu
+++ b/packages/oauth/src/jws.nu
@@ -1,0 +1,317 @@
+// oauth/jws.nu — verify a compact JWS (a JWT) against a JWK.
+//
+// The stdlib's ext/jwt.nu signs and verifies with a key you already
+// hold, for the three algorithms it chose to support. An OpenID Connect
+// relying party has the opposite problem: the token arrives first and
+// names its own key (`kid`) and algorithm (`alg`) in the header, and the
+// key comes from the provider's JWKS. This module is that direction —
+// header-driven verification over the whole algorithm set providers
+// actually publish:
+//
+//   RS256 · RS384 · RS512   RSASSA-PKCS1-v1_5 (std/rsa.nu)
+//   PS256                   RSASSA-PSS
+//   ES256 · ES384           ECDSA over P-256 / P-384 (std/ecdsa_p256.nu)
+//   EdDSA                   Ed25519 (std/ed25519.nu)
+//   HS256                   HMAC-SHA-256, for a shared-secret `oct` key
+//
+//   ( jws_verify_with_key jk token )   → !Json OauthErr   owned claims
+//   ( jws_header_json token )          → !Json OauthErr   owned header
+//   ( jws_header_str token key )       → String           "" when absent
+//   ( jws_payload_unverified token )   → !Json OauthErr
+//
+// `alg: none` is refused — it is not an algorithm, it is the absence of
+// one, and every historical JWT break starts there. So is an `alg` the
+// key cannot possibly carry: the key type is checked against the family
+// before the signature is touched (jwk_matches), which is what stops the
+// classic "verify an RSA-signed token with the HMAC path" confusion.
+//
+// The claims come back as an owned `Json` object; time and issuer/
+// audience checks are NOT done here (claims.nu owns that), so a caller
+// can inspect an expired token deliberately.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/subtle.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
+$ `stdlib/std/rsa.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/ext/json.nu`
+$ `errors.nu`
+$ `jwk.nu`
+
+// ── Segments ───────────────────────────────────────────────────────
+
+// Byte index of the n-th (0-based) '.' in `s`, or -1.
+@ __jws_dot_at s str i n → i {
+    : i len ( nurl_str_len str )
+    : ~ i seen 0
+    : ~ i k 0
+    ~ < k len {
+        ? == ( nurl_str_get str k ) 46 {
+            ? == seen n { ^ k } {}
+            = seen + seen 1
+        } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+@ __jws_slice s str i a i b → String {
+    : String out ( string_with_cap + 1 - b a )
+    : ~ i k a
+    ~ < k b {
+        ( string_push_char out ( nurl_str_get str k ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// A compact JWS is exactly three base64url segments. Reports the two dot
+// positions through `slots` (index 0 and 1); F when the shape is wrong.
+@ __jws_dots s token ( Vec i ) slots → b {
+    : i d0 ( __jws_dot_at token 0 )
+    : i d1 ( __jws_dot_at token 1 )
+    : i d2 ( __jws_dot_at token 2 )
+    : i tlen ( nurl_str_len token )
+    ? < d0 1 { ^ F } {}
+    ? <= d1 + d0 1 { ^ F } {}
+    ? >= d2 0 { ^ F } {}
+    // The signature segment MAY be empty: that is the "unsecured JWS"
+    // of RFC 7515 §6, structurally valid and refused on its `alg`, which
+    // is a more useful answer than calling it malformed.
+    ? > + d1 1 tlen { ^ F } {}
+    ( vec_push [i] slots d0 )
+    ( vec_push [i] slots d1 )
+    ^ T
+}
+
+// base64url segment [a,b) → an owned JSON object.
+@ __jws_json_seg s token i a i b → !Json OauthErr {
+    : String seg ( __jws_slice token a b )
+    : !( Vec u ) ParseErr dec ( b64_url_decode_vec ( string_data seg ) )
+    ( string_free seg )
+    ?? dec {
+        T raw → {
+            : !Json JsonError pj ( json_parse_bytes raw )
+            ( vec_free [u] raw )
+            ?? pj {
+                T j → {
+                    ? ( json_is_obj j ) {} {
+                        ( json_free j )
+                        ^ @ !Json OauthErr { F OaBadToken }
+                    }
+                    ^ @ !Json OauthErr { T j }
+                }
+                F _ → { ^ @ !Json OauthErr { F OaBadToken } }
+            }
+        }
+        F _ → { ^ @ !Json OauthErr { F OaBadToken } }
+    }
+}
+
+@ jws_header_json s token → !Json OauthErr {
+    : ( Vec i ) slots ( vec_new [i] )
+    ? ( __jws_dots token slots ) {} {
+        ( vec_free [i] slots )
+        ^ @ !Json OauthErr { F OaBadToken }
+    }
+    : i d0 ?? ( vec_get [i] slots 0 ) { T v → v F _ → 0 }
+    ( vec_free [i] slots )
+    ^ ( __jws_json_seg token 0 d0 )
+}
+
+@ jws_payload_unverified s token → !Json OauthErr {
+    : ( Vec i ) slots ( vec_new [i] )
+    ? ( __jws_dots token slots ) {} {
+        ( vec_free [i] slots )
+        ^ @ !Json OauthErr { F OaBadToken }
+    }
+    : i d0 ?? ( vec_get [i] slots 0 ) { T v → v F _ → 0 }
+    : i d1 ?? ( vec_get [i] slots 1 ) { T v → v F _ → 0 }
+    ( vec_free [i] slots )
+    ^ ( __jws_json_seg token + d0 1 d1 )
+}
+
+// A string member of an already-parsed JOSE header / claims object.
+@ _jws_json_str Json j s key → String {
+    : ~ s raw ``
+    ?? ( json_obj_get j key ) {
+        T v → { ? ( json_is_str v ) { = raw ( json_str_data v ) } {} }
+        F _ → {}
+    }
+    ^ ( string_from raw )
+}
+
+// A string member of the JOSE header — `alg`, `kid`, `typ`. Empty when
+// the token is malformed or the member is absent. Reading the header is
+// how a verifier learns which key to fetch; it is never trusted beyond
+// that, because the signature has not been checked yet.
+@ jws_header_str s token s key → String {
+    ?? ( jws_header_json token ) {
+        T h → {
+            : String out ( _jws_json_str h key )
+            ( json_free h )
+            ^ out
+        }
+        F _ → { ^ ( string_new ) }
+    }
+}
+
+// ── Algorithms ─────────────────────────────────────────────────────
+
+@ jws_alg_supported s alg → b {
+    ? == 1 ( nurl_str_eq alg `RS256` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `RS384` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `RS512` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `PS256` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `ES256` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `ES384` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `EdDSA` ) { ^ T } {}
+    ? == 1 ( nurl_str_eq alg `HS256` ) { ^ T } {}
+    ^ F
+}
+
+// Is `alg` a symmetric (shared-secret) algorithm? A relying party that
+// verifies with a PUBLISHED key set must refuse these unless it really
+// did configure a shared secret — accepting HS* against a JWKS is the
+// key-confusion attack.
+@ jws_alg_symmetric s alg → b {
+    ^ == 1 ( nurl_str_starts alg `HS` )
+}
+
+// The digest the algorithm signs over.
+@ __jws_digest s alg ( Vec u ) msg → ( Vec u ) {
+    ? == 1 ( nurl_str_ends alg `384` ) { ^ ( sha384_pure msg ) } {}
+    ? == 1 ( nurl_str_ends alg `512` ) { ^ ( sha512_pure msg ) } {}
+    ^ ( sha256_pure msg )
+}
+
+@ __jws_rsa_di s alg → ( Vec u ) {
+    ? == 1 ( nurl_str_ends alg `384` ) { ^ ( rsa_di_sha384 ) } {}
+    ? == 1 ( nurl_str_ends alg `512` ) { ^ ( rsa_di_sha512 ) } {}
+    ^ ( rsa_di_sha256 )
+}
+
+// ── Signature check ────────────────────────────────────────────────
+
+@ __jws_check_rsa JwkKey jk s alg ( Vec u ) sig ( Vec u ) digest → b {
+    ? == 0 ( vec_len [u] . jk n ) { ^ F } {}
+    ? == 0 ( vec_len [u] . jk e ) { ^ F } {}
+    ? == 1 ( nurl_str_starts alg `PS` ) {
+        ^ ( rsa_pss_verify_sha256 . jk n . jk e sig digest )
+    } {}
+    : ( Vec u ) di ( __jws_rsa_di alg )
+    : b ok ( rsa_pkcs1_verify . jk n . jk e sig di digest )
+    ( vec_free [u] di )
+    ^ ok
+}
+
+@ __jws_check_ec JwkKey jk s alg ( Vec u ) sig ( Vec u ) digest → b {
+    : i width ? == 1 ( nurl_str_eq alg `ES384` ) 48 32
+    ? != ( vec_len [u] sig ) * 2 width { ^ F } {}
+    : ( Vec u ) point ( jwk_ec_point jk )
+    ? == 0 ( vec_len [u] point ) { ( vec_free [u] point ) ^ F } {}
+    : ( Vec u ) r ( bytes_slice sig 0 width )
+    : ( Vec u ) s ( bytes_slice sig width * 2 width )
+    : ~ b ok F
+    ? == width 48 {
+        = ok ( ecdsa_p384_verify point r s digest )
+    } {
+        = ok ( ecdsa_p256_verify point r s digest )
+    }
+    ( vec_free [u] point )
+    ( vec_free [u] r )
+    ( vec_free [u] s )
+    ^ ok
+}
+
+// Verify `token` under `jk`. The key must already have been chosen for
+// this token's kid/alg (jwks_select) — this re-checks the type/curve
+// agreement anyway, because a verifier that trusts its caller's key
+// choice is one refactor away from key confusion.
+@ jws_verify_with_key JwkKey jk s token → !Json OauthErr {
+    : ( Vec i ) slots ( vec_new [i] )
+    ? ( __jws_dots token slots ) {} {
+        ( vec_free [i] slots )
+        ^ @ !Json OauthErr { F OaBadToken }
+    }
+    : i d0 ?? ( vec_get [i] slots 0 ) { T v → v F _ → 0 }
+    : i d1 ?? ( vec_get [i] slots 1 ) { T v → v F _ → 0 }
+    ( vec_free [i] slots )
+
+    // 1. header → alg
+    : !Json OauthErr hj ( __jws_json_seg token 0 d0 )
+    : ~ String alg ( string_new )
+    : ~ b crit F
+    ?? hj {
+        T h → {
+            ( string_free alg )
+            = alg ( _jws_json_str h `alg` )
+            // RFC 7515 §4.1.11: a `crit` member names extensions the
+            // verifier MUST understand. We implement none, so any `crit`
+            // at all is a refusal — never a silent ignore.
+            ? ( json_obj_has h `crit` ) { = crit T } {}
+            ( json_free h )
+        }
+        F e → { ( string_free alg ) ^ @ !Json OauthErr { F # OauthErr e } }
+    }
+    ? crit {
+        ( string_free alg )
+        ^ @ !Json OauthErr { F OaAlgNotAllowed }
+    } {}
+    : s algp ( string_data alg )
+    ? ( jws_alg_supported algp ) {} {
+        ( string_free alg )
+        ^ @ !Json OauthErr { F OaAlgNotAllowed }
+    }
+    ? ( jwk_matches jk `` algp ) {} {
+        ( string_free alg )
+        ^ @ !Json OauthErr { F OaNoKey }
+    }
+
+    // 2. signature over ASCII( header '.' payload )
+    : String signing ( __jws_slice token 0 d1 )
+    : String sig64 ( __jws_slice token + d1 1 ( nurl_str_len token ) )
+    : !( Vec u ) ParseErr sd ( b64_url_decode_vec ( string_data sig64 ) )
+    ( string_free sig64 )
+    : ~ b ok F
+    ?? sd {
+        T sig → {
+            : ( Vec u ) msg ( bytes_from_str ( string_data signing ) )
+            ? ( jws_alg_symmetric algp ) {
+                ? > ( vec_len [u] . jk oct ) 0 {
+                    : ( Vec u ) mac ( hmac_sha256_pure . jk oct msg )
+                    = ok ( constant_time_eq_vec mac sig )
+                    ( vec_free [u] mac )
+                } {}
+            } {
+                : ( Vec u ) digest ( __jws_digest algp msg )
+                ? == 1 ( nurl_str_eq algp `EdDSA` ) {
+                    ? & == ( vec_len [u] . jk x ) 32 == ( vec_len [u] sig ) 64 {
+                        = ok ( ed25519_verify_pure . jk x msg sig )
+                    } {}
+                } {
+                    ? == 1 ( nurl_str_starts algp `ES` ) {
+                        = ok ( __jws_check_ec jk algp sig digest )
+                    } {
+                        = ok ( __jws_check_rsa jk algp sig digest )
+                    }
+                }
+                ( vec_free [u] digest )
+            }
+            ( vec_free [u] msg )
+            ( vec_free [u] sig )
+        }
+        F _ → {}
+    }
+    ( string_free signing )
+    ( string_free alg )
+    ? ok {} { ^ @ !Json OauthErr { F OaBadSignature } }
+
+    // 3. claims
+    ^ ( __jws_json_seg token + d0 1 d1 )
+}

--- a/packages/oauth/src/oauth.nu
+++ b/packages/oauth/src/oauth.nu
@@ -1,0 +1,79 @@
+// oauth — OAuth 2.0 and OpenID Connect for NURL: identify the user,
+// read the claims.
+//
+// One include gives a program both halves of an OpenID Connect relying
+// party, with no C dependency anywhere in the chain — the TLS, the JSON,
+// the RSA/ECDSA/Ed25519 signature checks and the SHA-2 under them are
+// all pure NURL:
+//
+//   $ `deps/oauth/src/oauth.nu`
+//
+// ── Log a user in ──────────────────────────────────────────────────
+//
+//   ?? ( oidc_provider_discover `https://accounts.example.com` ) {
+//       T p → {
+//           : *OauthConfig cfg ( oauth_config_new client_id redirect scope )
+//           : Pkce pk ( pkce_new )
+//           : String state ( oauth_state_new )
+//           : String nonce ( oauth_nonce_new )
+//           : String url ( oauth_authorize_url p cfg
+//                            ( string_data state ) ( string_data nonce ) pk )
+//           //  … send the browser to `url`, receive the redirect …
+//           ?? ( oauth_callback_code query ( string_data state ) ) {
+//               T code → {
+//                   ?? ( oauth_exchange_code p cfg ( string_data code )
+//                            ( string_data . pk verifier ) ) {
+//                       T ts → {
+//                           : *OidcPolicy pol ( oidc_policy_new issuer client_id )
+//                           ( oidc_policy_set_nonce pol ( string_data nonce ) )
+//                           ?? ( oidc_verify_id_token p pol ( token_set_id_token ts ) ) {
+//                               T id → { /* . id subject — the user */ }
+//                               F e → { /* ( oauth_err_name e ) */ }
+//                           }
+//                       }
+//                       F e → {}
+//                   }
+//               }
+//               F e → {}
+//           }
+//       }
+//       F e → {}
+//   }
+//
+// ── Guard an API with the tokens it hands out ──────────────────────
+//
+//   ( http_app_get a `/me` ( with_oidc_bearer p pol
+//       \ HttpRequest req OidcIdentity id → HttpResponse {
+//           ^ ( response_json 200 ( string_data ( oidc_identity_key id ) ) ) } ) )
+//
+// ── What is in here ────────────────────────────────────────────────
+//
+//   errors.nu    OauthErr — one error type for the whole package
+//   jwk.nu       JWK / JWKS: parse a key set, pick the key a token names
+//   jws.nu       verify a JWT against a JWK — RS256/384/512, PS256,
+//                ES256/384, EdDSA, HS256; `none` and `crit` refused
+//   claims.nu    OidcPolicy, claims_check (iss/aud/azp/exp/nbf/iat/
+//                nonce/sub/max_age), the claim accessors, OidcIdentity
+//   pkce.nu      PKCE verifier + S256 challenge, state, nonce
+//   provider.nu  discovery, the JWKS cache with rotation-driven
+//                re-fetch, and oidc_verify_id_token
+//   flow.nu      authorize URL, callback, code exchange, refresh,
+//                client_credentials, UserInfo
+//   guard.nu     with_oidc_bearer / with_oidc_scope for the HTTP server
+//
+// ── What it will not do ────────────────────────────────────────────
+//
+// There is no "just decode the token" convenience that skips
+// verification, no `alg: none`, no HS256 against a published (public)
+// key set unless the caller explicitly says the key is a shared secret,
+// and no PKCE `plain`. Each of those is a real attack that a helpful
+// default has shipped before; none of them is a feature.
+
+$ `errors.nu`
+$ `jwk.nu`
+$ `jws.nu`
+$ `claims.nu`
+$ `pkce.nu`
+$ `provider.nu`
+$ `flow.nu`
+$ `guard.nu`

--- a/packages/oauth/src/pkce.nu
+++ b/packages/oauth/src/pkce.nu
@@ -1,0 +1,73 @@
+// oauth/pkce.nu — PKCE, state and nonce (RFC 7636, OIDC core §3.1.2.1).
+//
+// Three one-use random values, each closing a different hole in the
+// authorization-code flow:
+//
+//   verifier/challenge  binds the code to THIS client instance. The
+//       authorization request carries only SHA-256(verifier); the token
+//       request carries the verifier itself. A code stolen in transit
+//       (a redirect log, a malicious app claiming the same URI scheme)
+//       is worthless without it. Mandatory for public clients, and
+//       recommended for every client by OAuth 2.1.
+//   state    binds the callback to the request the user started here,
+//       which is what defeats login-CSRF.
+//   nonce    binds the ID token to that same request — the check lives
+//       in claims.nu (`oidc_policy_set_nonce`), the value is minted
+//       here.
+//
+// All three come from the OS CSPRNG (std/random.nu → nurl_rand_fill) and
+// are base64url with no padding, so they need no further escaping in a
+// URL and are the RFC 7636 "unreserved" alphabet by construction.
+//
+//   : Pkce pk ( pkce_new )
+//   … authorize with ( string_data . pk challenge ) …
+//   … exchange with ( string_data . pk verifier ) …
+//   ( pkce_free pk )
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/random.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_sha256.nu`
+
+: Pkce {
+    String verifier  // the secret, sent only to the token endpoint
+    String challenge  // base64url(SHA-256(verifier)), sent in the URL
+    String method  // always "S256"; "plain" is not offered
+}
+
+// `nbytes` of CSPRNG output, base64url-unpadded. 32 bytes → 43 chars,
+// the RFC 7636 minimum verifier length and 256 bits of entropy.
+@ oauth_random_token i nbytes → String {
+    : ( Vec u ) raw ( rand_bytes ? > nbytes 0 nbytes 32 )
+    : String out ( b64_url_encode_vec raw )
+    ( vec_free [u] raw )
+    ^ out
+}
+
+@ oauth_state_new → String { ^ ( oauth_random_token 32 ) }
+
+@ oauth_nonce_new → String { ^ ( oauth_random_token 32 ) }
+
+// base64url(SHA-256(ASCII(verifier))) — the S256 transform.
+@ pkce_challenge_for s verifier → String {
+    : ( Vec u ) msg ( bytes_from_str verifier )
+    : ( Vec u ) h ( sha256_pure msg )
+    ( vec_free [u] msg )
+    : String out ( b64_url_encode_vec h )
+    ( vec_free [u] h )
+    ^ out
+}
+
+@ pkce_new → Pkce {
+    : String verifier ( oauth_random_token 32 )
+    : String challenge ( pkce_challenge_for ( string_data verifier ) )
+    ^ @ Pkce { verifier challenge ( string_from `S256` ) }
+}
+
+@ pkce_free Pkce pk → v {
+    ( string_free . pk verifier )
+    ( string_free . pk challenge )
+    ( string_free . pk method )
+}

--- a/packages/oauth/src/provider.nu
+++ b/packages/oauth/src/provider.nu
@@ -1,0 +1,432 @@
+// oauth/provider.nu — the identity provider: discovery, keys, verdict.
+//
+// Everything a relying party needs to know about a provider is published
+// by the provider itself. `OidcProvider` is that knowledge, fetched once
+// and kept:
+//
+//   ( oidc_provider_discover issuer )   → ! *OidcProvider OauthErr
+//       GET <issuer>/.well-known/openid-configuration (RFC 8414 §3), and
+//       CHECK that the document's own `issuer` is the one we asked for —
+//       otherwise a redirect to an attacker's metadata would silently
+//       repoint the token and userinfo endpoints.
+//
+//   ( oidc_verify_id_token p pol token ) → ! OidcIdentity OauthErr
+//       The whole answer to "who is this": parse the JOSE header, find
+//       the key it names in the provider's JWKS (fetching the set on
+//       first use, and re-fetching when a `kid` we have never seen shows
+//       up — that is key rotation, and it must not need a restart),
+//       verify the signature, apply the claim policy, and hand back the
+//       identity with the full claim set attached.
+//
+// The JWKS re-fetch is rate-limited (`oidc_provider_set_min_refetch`,
+// default 300 s): an unknown `kid` is also what a flood of forged tokens
+// looks like, and a verifier that fetches on every one of them is a
+// denial-of-service amplifier pointed at its own provider.
+//
+// A failure that has detail the enum cannot carry — the HTTP status, the
+// claim that was wrong, the provider's own `error_description` — leaves
+// it in `oidc_provider_last_error`.
+//
+// THREADING: an `*OidcProvider` owns one HTTP client and one mutable key
+// cache, and takes no lock. One provider per thread, or one thread that
+// owns it — sharing it across a server's worker pool is a data race, not
+// a slow path. (An `*OidcPolicy` is read-only once built and IS safe to
+// share; so is a verified `OidcIdentity`, which is a value.)
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+$ `deps/http-client/src/http_client.nu`
+$ `errors.nu`
+$ `jwk.nu`
+$ `jws.nu`
+$ `claims.nu`
+
+: OidcProvider {
+    String issuer
+    String authorization_endpoint
+    String token_endpoint
+    String userinfo_endpoint
+    String jwks_uri
+    String end_session_endpoint
+    String device_authorization_endpoint
+    String introspection_endpoint
+    String revocation_endpoint
+    ( Vec JwkKey ) keys
+    i keys_at  // epoch seconds of the last JWKS fetch (0 = never)
+    i min_refetch  // seconds that must pass before another JWKS fetch
+    b discovered
+    String last_error
+    * HttpClient http
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────
+
+@ oidc_provider_new s issuer → *OidcProvider {
+    : *OidcProvider p # *OidcProvider ( nurl_malloc Z OidcProvider )
+    = . p issuer ( string_from issuer )
+    = . p authorization_endpoint ( string_new )
+    = . p token_endpoint ( string_new )
+    = . p userinfo_endpoint ( string_new )
+    = . p jwks_uri ( string_new )
+    = . p end_session_endpoint ( string_new )
+    = . p device_authorization_endpoint ( string_new )
+    = . p introspection_endpoint ( string_new )
+    = . p revocation_endpoint ( string_new )
+    = . p keys ( vec_new [JwkKey] )
+    = . p keys_at 0
+    = . p min_refetch 300
+    = . p discovered F
+    = . p last_error ( string_new )
+    = . p http ( http_client_new )
+    ^ p
+}
+
+@ oidc_provider_free * OidcProvider p → v {
+    ( string_free . p issuer )
+    ( string_free . p authorization_endpoint )
+    ( string_free . p token_endpoint )
+    ( string_free . p userinfo_endpoint )
+    ( string_free . p jwks_uri )
+    ( string_free . p end_session_endpoint )
+    ( string_free . p device_authorization_endpoint )
+    ( string_free . p introspection_endpoint )
+    ( string_free . p revocation_endpoint )
+    ( string_free . p last_error )
+    ( jwks_free . p keys )
+    ( http_client_free . p http )
+    ( nurl_free # s p )
+}
+
+// The HTTP client every request goes through — exposed so a caller can
+// set a timeout, turn off certificate verification for a test provider,
+// or pin HTTP/3.
+@ oidc_provider_http * OidcProvider p → *HttpClient { ^ . p http }
+
+@ oidc_provider_last_error * OidcProvider p → s { ^ ( string_data . p last_error ) }
+
+@ oidc_provider_set_min_refetch * OidcProvider p i secs → v { = . p min_refetch secs }
+
+@ _oidc_err * OidcProvider p s msg → v {
+    ( string_free . p last_error )
+    = . p last_error ( string_from msg )
+}
+
+@ _oidc_err2 * OidcProvider p s msg s detail → v {
+    : String out ( string_with_cap 96 )
+    ( string_push_str out msg )
+    ( string_push_str out detail )
+    ( string_free . p last_error )
+    = . p last_error out
+}
+
+@ _oidc_err_status * OidcProvider p s what i status → v {
+    : String out ( string_with_cap 96 )
+    ( string_push_str out what )
+    ( string_push_str out ` returned HTTP ` )
+    ( string_push_int out status )
+    ( string_free . p last_error )
+    = . p last_error out
+}
+
+// ── Field setters (for a provider configured by hand) ──────────────
+
+@ oidc_provider_set_jwks_uri * OidcProvider p s uri → v {
+    ( string_free . p jwks_uri )
+    = . p jwks_uri ( string_from uri )
+}
+
+@ oidc_provider_set_token_endpoint * OidcProvider p s uri → v {
+    ( string_free . p token_endpoint )
+    = . p token_endpoint ( string_from uri )
+}
+
+@ oidc_provider_set_authorization_endpoint * OidcProvider p s uri → v {
+    ( string_free . p authorization_endpoint )
+    = . p authorization_endpoint ( string_from uri )
+}
+
+@ oidc_provider_set_userinfo_endpoint * OidcProvider p s uri → v {
+    ( string_free . p userinfo_endpoint )
+    = . p userinfo_endpoint ( string_from uri )
+}
+
+// Load a key set the caller already has (a pinned JWKS, an offline
+// verifier, a test). Replaces whatever was cached.
+@ oidc_provider_set_jwks * OidcProvider p s jwks_json → b {
+    : ( Vec JwkKey ) ks ( jwks_parse jwks_json )
+    ? == 0 ( vec_len [JwkKey] ks ) { ( jwks_free ks ) ^ F } {}
+    ( jwks_free . p keys )
+    = . p keys ks
+    = . p keys_at ( now_seconds )
+    ^ T
+}
+
+@ oidc_provider_key_count * OidcProvider p → i { ^ ( vec_len [JwkKey] . p keys ) }
+
+// ── HTTP ───────────────────────────────────────────────────────────
+
+// GET a JSON document. Owns nothing of the caller's; the returned Json
+// is owned by the caller.
+@ __oidc_get_json * OidcProvider p s what s url → !Json OauthErr {
+    ?? ( http_client_get . p http url ) {
+        T r → {
+            : i status ( http_client_status r )
+            ? & >= status 200 < status 300 {} {
+                ( _oidc_err_status p what status )
+                ( http_response_free r )
+                ^ @ !Json OauthErr { F OaHttpStatus }
+            }
+            : !Json JsonError pj ( json_parse_bytes . r body )
+            ( http_response_free r )
+            ?? pj {
+                T j → { ^ @ !Json OauthErr { T j } }
+                F _ → {
+                    ( _oidc_err2 p what ` did not return JSON` )
+                    ^ @ !Json OauthErr { F OaBadResponse }
+                }
+            }
+        }
+        F e → {
+            ( _oidc_err2 p what ( http_client_err_name e ) )
+            ^ @ !Json OauthErr { F OaNetwork }
+        }
+    }
+}
+
+// ── Discovery ──────────────────────────────────────────────────────
+
+// <issuer>/.well-known/openid-configuration, with exactly one slash.
+@ oidc_discovery_url s issuer → String {
+    : ~ String out ( string_from issuer )
+    : i n ( string_len out )
+    ? & > n 0 == ( string_get out - n 1 ) 47 {
+        : String trimmed ( string_substr out 0 - n 1 )
+        ( string_free out )
+        = out trimmed
+    } {}
+    ( string_push_str out `/.well-known/openid-configuration` )
+    ^ out
+}
+
+// Fetch the metadata document and adopt its endpoints. None = success.
+@ oidc_discover * OidcProvider p → ?OauthErr {
+    : String url ( oidc_discovery_url ( string_data . p issuer ) )
+    : !Json OauthErr dj ( __oidc_get_json p `discovery` ( string_data url ) )
+    ( string_free url )
+    ?? dj {
+        T doc → {
+            // RFC 8414 §3.3: the document must claim the issuer we asked
+            // for. Anything else is a metadata substitution.
+            : String iss ( claims_str doc `issuer` )
+            ? ( string_eq iss . p issuer ) {} {
+                ( _oidc_err2 p `discovery issuer mismatch: ` ( string_data iss ) )
+                ( string_free iss )
+                ( json_free doc )
+                ^ @ ?OauthErr { T OaIssuerMismatch }
+            }
+            ( string_free iss )
+            ( string_free . p authorization_endpoint )
+            = . p authorization_endpoint ( claims_str doc `authorization_endpoint` )
+            ( string_free . p token_endpoint )
+            = . p token_endpoint ( claims_str doc `token_endpoint` )
+            ( string_free . p userinfo_endpoint )
+            = . p userinfo_endpoint ( claims_str doc `userinfo_endpoint` )
+            ( string_free . p jwks_uri )
+            = . p jwks_uri ( claims_str doc `jwks_uri` )
+            ( string_free . p end_session_endpoint )
+            = . p end_session_endpoint ( claims_str doc `end_session_endpoint` )
+            ( string_free . p device_authorization_endpoint )
+            = . p device_authorization_endpoint ( claims_str doc `device_authorization_endpoint` )
+            ( string_free . p introspection_endpoint )
+            = . p introspection_endpoint ( claims_str doc `introspection_endpoint` )
+            ( string_free . p revocation_endpoint )
+            = . p revocation_endpoint ( claims_str doc `revocation_endpoint` )
+            ( json_free doc )
+            = . p discovered T
+            ^ @ ?OauthErr { F }
+        }
+        F e → { ^ @ ?OauthErr { T # OauthErr e } }
+    }
+}
+
+@ oidc_provider_discover s issuer → !*OidcProvider OauthErr {
+    : *OidcProvider p ( oidc_provider_new issuer )
+    ?? ( oidc_discover p ) {
+        T e → {
+            ( oidc_provider_free p )
+            ^ @ !*OidcProvider OauthErr { F # OauthErr e }
+        }
+        F _ → { ^ @ !*OidcProvider OauthErr { T p } }
+    }
+}
+
+// ── Key set ────────────────────────────────────────────────────────
+
+// Fetch jwks_uri and replace the cached set. None = success.
+@ oidc_fetch_jwks * OidcProvider p → ?OauthErr {
+    ? == 0 ( string_len . p jwks_uri ) {
+        ( _oidc_err p `no jwks_uri — run discovery or set one` )
+        ^ @ ?OauthErr { T OaConfig }
+    } {}
+    : !Json OauthErr kj ( __oidc_get_json p `jwks` ( string_data . p jwks_uri ) )
+    ?? kj {
+        T doc → {
+            : ( Vec JwkKey ) ks ( jwks_from_json doc )
+            ( json_free doc )
+            // The fetch happened: record the time even for an empty set,
+            // so a provider that answers with junk cannot be polled hard.
+            = . p keys_at ( now_seconds )
+            ? == 0 ( vec_len [JwkKey] ks ) {
+                ( jwks_free ks )
+                ( _oidc_err p `jwks document contains no keys` )
+                ^ @ ?OauthErr { T OaNoJwks }
+            } {}
+            ( jwks_free . p keys )
+            = . p keys ks
+            ^ @ ?OauthErr { F }
+        }
+        F e → { ^ @ ?OauthErr { T # OauthErr e } }
+    }
+}
+
+// Index of the key for (kid, alg), fetching or re-fetching the JWKS when
+// that is what it takes. -1 when the provider has no such key.
+@ oidc_provider_ensure_key * OidcProvider p s kid s alg → i {
+    ? == 0 ( vec_len [JwkKey] . p keys ) {
+        ?? ( oidc_fetch_jwks p ) { T _ → { ^ -1 } F _ → {} }
+    } {}
+    : i idx ( jwks_select . p keys kid alg )
+    ? >= idx 0 { ^ idx } {}
+    // Unknown kid → the provider may have rotated. Re-fetch, but not
+    // more often than min_refetch: forged tokens with random kids must
+    // not turn this verifier into a load generator.
+    : i age - ( now_seconds ) . p keys_at
+    ? < age . p min_refetch {
+        ( _oidc_err2 p `no key for kid ` kid )
+        ^ -1
+    } {}
+    ?? ( oidc_fetch_jwks p ) { T _ → { ^ -1 } F _ → {} }
+    : i idx2 ( jwks_select . p keys kid alg )
+    ? < idx2 0 { ( _oidc_err2 p `no key for kid ` kid ) } {}
+    ^ idx2
+}
+
+// ── Verification ───────────────────────────────────────────────────
+
+// The whole check, at an explicit `now` (epoch seconds).
+@ oidc_verify_token_at * OidcProvider p * OidcPolicy pol s token i now → !OidcIdentity OauthErr {
+    // Read the JOSE header ONCE: a token that is not a well-formed JWS
+    // is malformed, which is a different answer from "the algorithm it
+    // names is not one we accept".
+    : ~ String alg ( string_new )
+    : ~ String kid ( string_new )
+    ?? ( jws_header_json token ) {
+        T h → {
+            ( string_free alg )
+            ( string_free kid )
+            = alg ( _jws_json_str h `alg` )
+            = kid ( _jws_json_str h `kid` )
+            ( json_free h )
+        }
+        F e → {
+            ( string_free alg ) ( string_free kid )
+            ( _oidc_err p `not a well-formed JWS` )
+            ^ @ !OidcIdentity OauthErr { F # OauthErr e }
+        }
+    }
+    : s algp ( string_data alg )
+    : s kidp ( string_data kid )
+
+    // RFC 7515 §4.1.1: `alg` is REQUIRED in the header.
+    ? == 0 ( string_len alg ) {
+        ( _oidc_err p `JOSE header has no alg` )
+        ( string_free alg ) ( string_free kid )
+        ^ @ !OidcIdentity OauthErr { F OaBadToken }
+    } {}
+    ? ( jws_alg_supported algp ) {} {
+        ( _oidc_err2 p `unsupported alg: ` algp )
+        ( string_free alg ) ( string_free kid )
+        ^ @ !OidcIdentity OauthErr { F OaAlgNotAllowed }
+    }
+    ? ( oidc_policy_alg_allowed pol algp ) {} {
+        ( _oidc_err2 p `alg not in policy allowlist: ` algp )
+        ( string_free alg ) ( string_free kid )
+        ^ @ !OidcIdentity OauthErr { F OaAlgNotAllowed }
+    }
+    // A published key set holds PUBLIC keys. Verifying an HS* token
+    // against one turns a public key into a shared secret — the key
+    // confusion attack — so symmetric algorithms need an explicit opt-in.
+    ? ( jws_alg_symmetric algp ) {
+        ? . pol allow_symmetric {} {
+            ( _oidc_err2 p `symmetric alg refused: ` algp )
+            ( string_free alg ) ( string_free kid )
+            ^ @ !OidcIdentity OauthErr { F OaAlgNotAllowed }
+        }
+    } {}
+
+    : i idx ( oidc_provider_ensure_key p kidp algp )
+    ? < idx 0 {
+        ( string_free alg ) ( string_free kid )
+        ^ @ !OidcIdentity OauthErr { F OaNoKey }
+    } {}
+
+    // Try EVERY key the (kid, alg) pair admits, not just the first. With
+    // no `kid` in the header — which is legal — a provider mid-rotation
+    // publishes two keys of the same type, and only one of them signed
+    // this token.
+    : *JwkKey data ( vec_data [JwkKey] . p keys )
+    : ~ Json claims ( json_null )
+    : ~ b verified F
+    : ~ i from idx
+    : ~ b more T
+    ~ more {
+        : i k ( jwks_select_from . p keys kidp algp from )
+        ? < k 0 {
+            = more F
+        } {
+            : JwkKey jk . data k
+            ?? ( jws_verify_with_key jk token ) {
+                T c → {
+                    ( json_free claims )
+                    = claims c
+                    = verified T
+                    = more F
+                }
+                F _ → { = from + k 1 }
+            }
+        }
+    }
+    ( string_free alg )
+    ( string_free kid )
+    ? verified {} {
+        ( json_free claims )
+        ( _oidc_err p `signature did not verify under any published key` )
+        ^ @ !OidcIdentity OauthErr { F OaBadSignature }
+    }
+    ?? ( claims_check claims pol now ) {
+        T ce → {
+            ( _oidc_err p ( claim_err_desc # ClaimErr ce ) )
+            ( json_free claims )
+            ^ @ !OidcIdentity OauthErr { F OaClaims }
+        }
+        F _ → {}
+    }
+    ^ @ !OidcIdentity OauthErr { T ( oidc_identity_from_claims claims ) }
+}
+
+@ oidc_verify_token * OidcProvider p * OidcPolicy pol s token → !OidcIdentity OauthErr {
+    ^ ( oidc_verify_token_at p pol token ( now_seconds ) )
+}
+
+// Named for the caller's intent — the same check either way. An ID token
+// is verified against the client id in `aud`; an access token issued as
+// a JWT (RFC 9068) against the resource server's own audience.
+@ oidc_verify_id_token * OidcProvider p * OidcPolicy pol s token → !OidcIdentity OauthErr {
+    ^ ( oidc_verify_token_at p pol token ( now_seconds ) )
+}
+
+@ oidc_verify_access_token * OidcProvider p * OidcPolicy pol s token → !OidcIdentity OauthErr {
+    ^ ( oidc_verify_token_at p pol token ( now_seconds ) )
+}

--- a/packages/oauth/tests/client.nu
+++ b/packages/oauth/tests/client.nu
@@ -1,0 +1,663 @@
+// tests/client.nu — drive the oauth package against tests/provider.nu.
+//
+// Two halves: the offline checks (PKCE vectors, JWKS parsing, callback
+// handling — no network at all), then the full authorization-code flow
+// against a live provider, including every way a token can be wrong.
+//
+//   client --port N
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/ed25519.nu`
+$ `../src/oauth.nu`
+
+: ~ i g_fail 0
+: ~ i g_pass 0
+
+@ ok b cond s label → v {
+    ? cond {
+        = g_pass + g_pass 1
+        : String m ( string_from `  ok   ` )
+        ( string_push_str m label )
+        ( nurl_println ( string_data m ) )
+        ( string_free m )
+    } {
+        = g_fail + g_fail 1
+        : String m ( string_from `  FAIL ` )
+        ( string_push_str m label )
+        ( nurl_println ( string_data m ) )
+        ( string_free m )
+    }
+}
+
+@ ok_str s got s want s label → v {
+    : b same == 1 ( nurl_str_eq got want )
+    ? same {} {
+        : String m ( string_from `       got "` )
+        ( string_push_str m got )
+        ( string_push_str m `" want "` )
+        ( string_push_str m want )
+        ( string_push_char m 34 )
+        ( nurl_println ( string_data m ) )
+        ( string_free m )
+    }
+    ( ok same label )
+}
+
+@ section s title → v {
+    ( nurl_println `` )
+    ( nurl_println title )
+}
+
+// ── Offline ────────────────────────────────────────────────────────
+
+// RFC 7636 Appendix B: the S256 transform, on the RFC's own vector.
+@ test_pkce_vector → v {
+    : String ch ( pkce_challenge_for `dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk` )
+    ( ok_str ( string_data ch ) `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` `PKCE S256 matches RFC 7636 B` )
+    ( string_free ch )
+    : Pkce pk ( pkce_new )
+    ( ok == ( string_len . pk verifier ) 43 `fresh verifier is 43 chars (256 bits)` )
+    : String again ( pkce_challenge_for ( string_data . pk verifier ) )
+    ( ok ( string_eq again . pk challenge ) `challenge is S256 of the verifier` )
+    ( ok_str ( string_data . pk method ) `S256` `method is S256, never plain` )
+    ( string_free again )
+    ( pkce_free pk )
+    : String s1 ( oauth_state_new )
+    : String s2 ( oauth_state_new )
+    ( ok ! ( string_eq s1 s2 ) `two states differ` )
+    ( string_free s1 ) ( string_free s2 )
+}
+
+@ test_jwks_offline → v {
+    : s doc `{"keys":[{"kty":"EC","crv":"P-256","kid":"a","alg":"ES256","use":"sig","x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU","y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"},{"kty":"RSA","kid":"b","alg":"RS256","n":"AQAB","e":"AQAB"}]}`
+    : ( Vec JwkKey ) ks ( jwks_parse doc )
+    ( ok == ( vec_len [JwkKey] ks ) 2 `JWKS parses both keys` )
+    ( ok == ( jwks_select ks `a` `ES256` ) 0 `selects the EC key by kid` )
+    ( ok == ( jwks_select ks `b` `RS256` ) 1 `selects the RSA key by kid` )
+    ( ok == ( jwks_select ks `a` `RS256` ) -1 `refuses an EC key for RS256` )
+    ( ok == ( jwks_select ks `zz` `ES256` ) -1 `refuses an unknown kid` )
+    ( ok ( jwks_has_kid ks `b` ) `has_kid finds a published kid` )
+    ( ok ! ( jwks_has_kid ks `zz` ) `has_kid rejects an unknown kid` )
+    // RFC 7638 §3.1's own example key thumbprint is defined for RSA; for
+    // the EC key we assert only that it is stable and 43 chars of
+    // base64url — the property callers rely on when using it as a kid.
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : JwkKey k0 . data 0
+    : String tp1 ( jwk_thumbprint k0 )
+    : String tp2 ( jwk_thumbprint k0 )
+    ( ok & == ( string_len tp1 ) 43 ( string_eq tp1 tp2 ) `thumbprint is stable, 43 chars` )
+    ( string_free tp1 ) ( string_free tp2 )
+    : ( Vec u ) pt ( jwk_ec_point k0 )
+    ( ok == ( vec_len [u] pt ) 65 `EC point is 0x04‖X‖Y` )
+    ( vec_free [u] pt )
+    ( jwks_free ks )
+    : ( Vec JwkKey ) empty ( jwks_parse `not json at all` )
+    ( ok == ( vec_len [JwkKey] empty ) 0 `garbage JWKS yields no keys` )
+    ( jwks_free empty )
+}
+
+@ test_callback_offline → v {
+    ?? ( oauth_callback_code `code=abc123&state=st-1` `st-1` ) {
+        T c → {
+            ( ok_str ( string_data c ) `abc123` `callback yields the code` )
+            ( string_free c )
+        }
+        F _ → { ( ok F `callback yields the code` ) }
+    }
+    ?? ( oauth_callback_code `code=abc123&state=WRONG` `st-1` ) {
+        T c → { ( string_free c ) ( ok F `state mismatch is rejected` ) }
+        F e → { ( ok_str ( oauth_err_name e ) `OaState` `state mismatch is rejected` ) }
+    }
+    ?? ( oauth_callback_code `error=access_denied&error_description=user+said+no&state=st-1` `st-1` ) {
+        T c → { ( string_free c ) ( ok F `provider error surfaces` ) }
+        F e → { ( ok_str ( oauth_err_name e ) `OaServer` `provider error surfaces` ) }
+    }
+    : CallbackParams cb ( oauth_callback_parse `error=access_denied&error_description=user+said+no` )
+    ( ok_str ( string_data . cb error_description ) `user said no` `error_description is form-decoded` )
+    ( callback_params_free cb )
+}
+
+@ test_policy_offline → v {
+    : *OidcPolicy pol ( oidc_policy_new `https://iss.example` `client-1` )
+    ( ok ( oidc_policy_alg_allowed pol `ES256` ) `empty allowlist allows any supported alg` )
+    ( oidc_policy_set_algs pol `RS256 ES256` )
+    ( ok ( oidc_policy_alg_allowed pol `ES256` ) `allowlist admits a listed alg` )
+    ( ok ! ( oidc_policy_alg_allowed pol `EdDSA` ) `allowlist excludes an unlisted alg` )
+    ( oidc_policy_set_algs pol `` )
+
+    : s doc `{"iss":"https://iss.example","aud":"client-1","sub":"u1","exp":2000,"iat":1000,"nonce":"n1"}`
+    ?? ( json_parse doc ) {
+        T claims → {
+            ?? ( claims_check claims pol 1500 ) {
+                T _ → { ( ok F `a good claim set passes` ) }
+                F _ → { ( ok T `a good claim set passes` ) }
+            }
+            ?? ( claims_check claims pol 2500 ) {
+                T e → { ( ok_str ( claim_err_desc # ClaimErr e ) `token expired` `exp is enforced` ) }
+                F _ → { ( ok F `exp is enforced` ) }
+            }
+            // 2000 + 60s leeway is still inside the window
+            ?? ( claims_check claims pol 2030 ) {
+                T _ → { ( ok F `leeway covers small clock skew` ) }
+                F _ → { ( ok T `leeway covers small clock skew` ) }
+            }
+            ( oidc_policy_set_nonce pol `n1` )
+            ?? ( claims_check claims pol 1500 ) {
+                T _ → { ( ok F `matching nonce passes` ) }
+                F _ → { ( ok T `matching nonce passes` ) }
+            }
+            ( oidc_policy_set_nonce pol `other` )
+            ?? ( claims_check claims pol 1500 ) {
+                T e → { ( ok_str ( claim_err_desc # ClaimErr e ) `nonce mismatch` `a replayed nonce is caught` ) }
+                F _ → { ( ok F `a replayed nonce is caught` ) }
+            }
+            ( oidc_policy_set_nonce pol `` )
+            ( oidc_policy_set_audience pol `someone-else` )
+            ?? ( claims_check claims pol 1500 ) {
+                T e → { ( ok_str ( claim_err_desc # ClaimErr e ) `wrong audience` `aud is enforced` ) }
+                F _ → { ( ok F `aud is enforced` ) }
+            }
+            ( oidc_policy_set_audience pol `client-1` )
+            ( oidc_policy_set_issuer pol `https://evil.example` )
+            ?? ( claims_check claims pol 1500 ) {
+                T e → { ( ok_str ( claim_err_desc # ClaimErr e ) `wrong issuer` `iss is enforced` ) }
+                F _ → { ( ok F `iss is enforced` ) }
+            }
+            ( json_free claims )
+        }
+        F _ → { ( ok F `policy fixture parses` ) }
+    }
+    ( oidc_policy_free pol )
+}
+
+@ test_claims_shapes → v {
+    : s doc `{"aud":["a","b"],"scope":"read write","groups":["dev","ops"],"email_verified":true}`
+    ?? ( json_parse doc ) {
+        T c → {
+            ( ok ( claims_has_audience c `b` ) `aud as an array matches` )
+            ( ok ! ( claims_has_audience c `c` ) `aud as an array rejects` )
+            ( ok ( claims_has_scope c `write` ) `scope string splits` )
+            ( ok ! ( claims_has_scope c `admin` ) `scope rejects what was not granted` )
+            : ( Vec String ) gs ( claims_string_list c `groups` )
+            ( ok == ( vec_len [String] gs ) 2 `string list claim reads an array` )
+            ( claims_strings_free gs )
+            ( ok ( claims_bool c `email_verified` ) `boolean claim reads` )
+            ( json_free c )
+        }
+        F _ → { ( ok F `claim shapes fixture parses` ) }
+    }
+}
+
+// ── Offline: the asymmetric algorithms ─────────────────────────────
+//
+// RS256 and PS256 against a token minted by OpenSSL with an RSA-2048
+// key — the point of a fixed vector being that it proves the pure-NURL
+// RSA path agrees with an independent implementation, not with itself.
+
+@ rsa_jwks → s {
+    ^ `{"keys":[{"kty":"RSA","kid":"rsa1","use":"sig","n":"yZWWkMEXKhMas316iNWRVVVbD8pZ3jzfE6BTAdBXZ3Hdi-vS588yd6H28_4qZU7G0rlCR5ge4FoqWx_kteobrsVUm_J7zRmFjx7UoATeht1p5WH4FFL42jik12GvYeyfYR1OQAN-orT9f-_Iq3sf5lqaN_V-JIa08mvXfAwE7nbNmiYy30CkGBYBAU0z46R7es6_caRHhq_jwd-2P6nUXm66COpLuLlvrBp_0S3i_ZvDp5wOVyae5_h1p4TELA7LOKIBfnokygT6Q9OEohvundxUjnyit1eXyoXkrVWnvNNRuWXDYHEBsg5JsnT4yXX_1GeSkJ9xnG7wnfBxlVF3Mw","e":"AQAB"}]}`
+}
+
+@ rs256_token → s {
+    ^ `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJzYTEifQ.eyJpc3MiOiJodHRwczovL3JzYS5leGFtcGxlIiwic3ViIjoicnNhLXVzZXIiLCJhdWQiOiJjbGllbnQtMSIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ.BfUZt-me63nppgOZKVNZiJsOYMNy-KT9Z2k4nTImpBa5u8EspTF9-xxMoC-52-0UtVgC8AcrcTJsj9GrghFm8E9ZQ91uwo1hPSsD95LVYa1R_jhiarDzZlCvSZbzL1cZjkuYo1iwHeX_GHEgJraNs7_nXQi2oPrlsK0Ne1AKiyU0b73lcB4HU5lHuVa7vD0HhvHwcTKsjvYTRivTvoGFMqlFTqxNJyYCXz-X782m7v9ZHKz-ipQnsRVLqrT4LjGrA7C_WNJzOJqFrAArC_9SEHXw-Pm8eQNeC5jWP9JOumFArbAIt5AVA4uW3WZLKiWI7vVNCZgSdB4nm2ZoKqbIGw`
+}
+
+@ ps256_token → s {
+    ^ `eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJzYTEifQ.eyJpc3MiOiJodHRwczovL3JzYS5leGFtcGxlIiwic3ViIjoicnNhLXVzZXIiLCJhdWQiOiJjbGllbnQtMSIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ.LvRyx8JFTU4oCzQmD_Qg81ZXgKJznFhjlcliCUOF21C5rptfjKMJm2LSzuug22gC_hEVH9OimklsF0QgkS-cHTcI7S33qyiDpxPI86iu8SovI-SnbnFfFn6ryuzk_B8msW9SVAWOtTmp440Ak5J_vEZDc5D7j_GLLLRrG_K19i1SEYnDx41YGPhCgsfFesuqjdBbXrg4Uom06usEQxwWNh1zL7nifxOvcNR9ruvKEdatVp97HexoAzfphXDgiinBvlToHeiL5GIhwd_WKppBBYLRg7CAmj3-Wto-cjNrbrHEGc2vhue7gs0n2yeKI45cbJDrGY4B0DxrZQnJGaPTKg`
+}
+
+// The same token with its last signature character changed.
+@ flip_last s token → String {
+    : i n ( nurl_str_len token )
+    : String whole ( string_from token )
+    : String out ( string_substr whole 0 - n 1 )
+    ( string_free whole )
+    : i last ( nurl_str_get token - n 1 )
+    ( string_push_char out ? == last 65 66 65 )  // 'A' ↔ 'B'
+    ^ out
+}
+
+@ test_rsa_offline → v {
+    : ( Vec JwkKey ) ks ( jwks_parse ( rsa_jwks ) )
+    ( ok == ( vec_len [JwkKey] ks ) 1 `RSA JWKS parses` )
+    : i idx ( jwks_select ks `rsa1` `RS256` )
+    ( ok == idx 0 `a key with no alg member serves RS256` )
+    ( ok == ( jwks_select ks `rsa1` `PS256` ) 0 `... and PS256` )
+    ( ok == ( jwks_select ks `rsa1` `ES256` ) -1 `... but not ES256` )
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : JwkKey jk . data 0
+    ( ok == ( vec_len [u] . jk n ) 256 `2048-bit modulus decodes to 256 bytes` )
+
+    ?? ( jws_verify_with_key jk ( rs256_token ) ) {
+        F e → { ( ok F `RS256 verifies (OpenSSL vector)` ) ( nurl_eprintln ( oauth_err_name e ) ) }
+        T c → {
+            ( ok T `RS256 verifies (OpenSSL vector)` )
+            : String sub ( claims_str c `sub` )
+            ( ok_str ( string_data sub ) `rsa-user` `RS256 claims are readable` )
+            ( string_free sub )
+            ( json_free c )
+        }
+    }
+    ?? ( jws_verify_with_key jk ( ps256_token ) ) {
+        F e → { ( ok F `PS256 verifies (OpenSSL vector)` ) ( nurl_eprintln ( oauth_err_name e ) ) }
+        T c → { ( ok T `PS256 verifies (OpenSSL vector)` ) ( json_free c ) }
+    }
+    : String bad ( flip_last ( rs256_token ) )
+    ?? ( jws_verify_with_key jk ( string_data bad ) ) {
+        T c → { ( json_free c ) ( ok F `a one-character edit breaks RS256` ) }
+        F e → { ( ok_str ( oauth_err_name e ) `OaBadSignature` `a one-character edit breaks RS256` ) }
+    }
+    ( string_free bad )
+    ( jwks_free ks )
+}
+
+// EdDSA and HS256 as round trips: sign here with the stdlib, verify
+// through the JWK path, so the whole chain is exercised without a
+// vector to paste.
+
+@ jws_make s header s payload ( Vec u ) sig → String {
+    : String h64 ( b64_url_encode header )
+    : String p64 ( b64_url_encode payload )
+    : String s64 ( b64_url_encode_vec sig )
+    : String out ( string_with_cap 512 )
+    ( string_push_str out ( string_data h64 ) )
+    ( string_push_char out 46 )
+    ( string_push_str out ( string_data p64 ) )
+    ( string_push_char out 46 )
+    ( string_push_str out ( string_data s64 ) )
+    ( string_free h64 ) ( string_free p64 ) ( string_free s64 )
+    ^ out
+}
+
+@ jws_signing_bytes s header s payload → ( Vec u ) {
+    : String h64 ( b64_url_encode header )
+    : String p64 ( b64_url_encode payload )
+    : String signing ( string_with_cap 256 )
+    ( string_push_str signing ( string_data h64 ) )
+    ( string_push_char signing 46 )
+    ( string_push_str signing ( string_data p64 ) )
+    ( string_free h64 ) ( string_free p64 )
+    : ( Vec u ) msg ( bytes_from_str ( string_data signing ) )
+    ( string_free signing )
+    ^ msg
+}
+
+@ test_eddsa_offline → v {
+    : ~ ( Vec u ) seed ( vec_new [u] )
+    ?? ( bytes_from_hex `9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60` ) {
+        T v → { ( vec_free [u] seed ) = seed v }
+        F _ → {}
+    }
+    : ( Vec u ) pk ( ed25519_pubkey_pure seed )
+    : String x64 ( b64_url_encode_vec pk )
+    : String jwks ( string_with_cap 256 )
+    ( string_push_str jwks `{"keys":[{"kty":"OKP","crv":"Ed25519","kid":"ed1","alg":"EdDSA","x":"` )
+    ( string_push_str jwks ( string_data x64 ) )
+    ( string_push_str jwks `"}]}` )
+    ( string_free x64 )
+
+    : ( Vec JwkKey ) ks ( jwks_parse ( string_data jwks ) )
+    ( string_free jwks )
+    ( ok == ( jwks_select ks `ed1` `EdDSA` ) 0 `an OKP key serves EdDSA` )
+    ( ok == ( jwks_select ks `ed1` `ES256` ) -1 `... and nothing else` )
+
+    : s hdr `{"alg":"EdDSA","typ":"JWT","kid":"ed1"}`
+    : s pld `{"iss":"https://ed.example","sub":"ed-user","exp":9999999999}`
+    : ( Vec u ) msg ( jws_signing_bytes hdr pld )
+    : ( Vec u ) sig ( ed25519_sign_pure seed msg )
+    : String token ( jws_make hdr pld sig )
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : JwkKey jk . data 0
+    ?? ( jws_verify_with_key jk ( string_data token ) ) {
+        F e → { ( ok F `EdDSA round trip verifies` ) ( nurl_eprintln ( oauth_err_name e ) ) }
+        T c → {
+            : String sub ( claims_str c `sub` )
+            ( ok_str ( string_data sub ) `ed-user` `EdDSA round trip verifies` )
+            ( string_free sub )
+            ( json_free c )
+        }
+    }
+    : String bad ( flip_last ( string_data token ) )
+    ?? ( jws_verify_with_key jk ( string_data bad ) ) {
+        T c → { ( json_free c ) ( ok F `a one-character edit breaks EdDSA` ) }
+        F e → { ( ok_str ( oauth_err_name e ) `OaBadSignature` `a one-character edit breaks EdDSA` ) }
+    }
+    ( string_free bad )
+    ( string_free token )
+    ( vec_free [u] msg ) ( vec_free [u] sig )
+    ( vec_free [u] pk ) ( vec_free [u] seed )
+    ( jwks_free ks )
+}
+
+@ test_hs256_offline → v {
+    : ( Vec u ) secret ( bytes_from_str `a shared secret, configured on both sides` )
+    : String k64 ( b64_url_encode_vec secret )
+    : String jwks ( string_with_cap 256 )
+    ( string_push_str jwks `{"keys":[{"kty":"oct","kid":"h1","alg":"HS256","k":"` )
+    ( string_push_str jwks ( string_data k64 ) )
+    ( string_push_str jwks `"}]}` )
+    ( string_free k64 )
+    : ( Vec JwkKey ) ks ( jwks_parse ( string_data jwks ) )
+    ( string_free jwks )
+    ( ok == ( jwks_select ks `h1` `HS256` ) 0 `an oct key serves HS256` )
+    ( ok == ( jwks_select ks `h1` `RS256` ) -1 `... and never an asymmetric alg` )
+
+    : s hdr `{"alg":"HS256","typ":"JWT","kid":"h1"}`
+    : s pld `{"iss":"https://hs.example","sub":"hs-user","exp":9999999999}`
+    : ( Vec u ) msg ( jws_signing_bytes hdr pld )
+    : ( Vec u ) mac ( hmac_sha256_pure secret msg )
+    : String token ( jws_make hdr pld mac )
+    : *JwkKey data ( vec_data [JwkKey] ks )
+    : JwkKey jk . data 0
+    ?? ( jws_verify_with_key jk ( string_data token ) ) {
+        F e → { ( ok F `HS256 round trip verifies` ) ( nurl_eprintln ( oauth_err_name e ) ) }
+        T c → {
+            : String sub ( claims_str c `sub` )
+            ( ok_str ( string_data sub ) `hs-user` `HS256 round trip verifies` )
+            ( string_free sub )
+            ( json_free c )
+        }
+    }
+    ( string_free token )
+    ( vec_free [u] msg ) ( vec_free [u] mac ) ( vec_free [u] secret )
+    ( jwks_free ks )
+}
+
+// ── Online ─────────────────────────────────────────────────────────
+
+@ fetch_text * HttpClient hc s url → String {
+    ?? ( http_client_get hc url ) {
+        T r → {
+            : String body ( bytes_to_str . r body )
+            ( http_response_free r )
+            ^ body
+        }
+        F _ → { ^ ( string_new ) }
+    }
+}
+
+@ expect_verify_err * OidcProvider p * OidcPolicy pol s token s want s label → v {
+    ?? ( oidc_verify_token p pol token ) {
+        T id → {
+            ( oidc_identity_free id )
+            ( ok F label )
+        }
+        F e → { ( ok_str ( oauth_err_name e ) want label ) }
+    }
+}
+
+@ run_online s base → v {
+    ( section `discovery + keys` )
+    ?? ( oidc_provider_discover base ) {
+        F e → { ( ok F `discovery` ) ( nurl_eprintln ( oauth_err_name e ) ) }
+        T p → {
+            ( ok T `discovery succeeds` )
+            ( ok_str ( string_data . p issuer ) base `issuer round-trips` )
+            ( ok > ( string_len . p token_endpoint ) 0 `token_endpoint discovered` )
+            ( ok > ( string_len . p jwks_uri ) 0 `jwks_uri discovered` )
+            ?? ( oidc_fetch_jwks p ) {
+                T _ → { ( ok F `JWKS fetch` ) }
+                F _ → { ( ok == ( oidc_provider_key_count p ) 2 `JWKS fetch yields both published keys` ) }
+            }
+
+            : *OauthConfig cfg ( oauth_config_new `test-client` `http://127.0.0.1:1/cb` `openid profile` )
+            : Pkce pk ( pkce_new )
+            : String state ( oauth_state_new )
+            : String nonce ( oauth_nonce_new )
+
+            ( section `authorization request` )
+            : String url ( oauth_authorize_url p cfg ( string_data state ) ( string_data nonce ) pk )
+            ( ok ( string_contains url `response_type=code` ) `authorize URL asks for a code` )
+            ( ok ( string_contains url `code_challenge_method=S256` ) `authorize URL commits to S256` )
+            ( ok ( string_contains url ( string_data . pk challenge ) ) `authorize URL carries the challenge` )
+            ( ok ( string_contains url `redirect_uri=http%3A%2F%2F127.0.0.1%3A1%2Fcb` ) `redirect_uri is percent-encoded` )
+            ( ok ( string_contains url `scope=openid%20profile` ) `scope is percent-encoded` )
+            ( string_free url )
+
+            ( section `token exchange` )
+            // The provider's stateless code carries the challenge and
+            // the nonce the authorization request committed to.
+            : String code ( string_from `c.` )
+            ( string_push_str code ( string_data . pk challenge ) )
+            ( string_push_char code 46 )
+            ( string_push_str code ( string_data nonce ) )
+
+            : *OidcPolicy pol ( oidc_policy_new base `test-client` )
+            ( oidc_policy_set_nonce pol ( string_data nonce ) )
+
+            ?? ( oauth_exchange_code p cfg ( string_data code ) ( string_data . pk verifier ) ) {
+                F e → {
+                    ( ok F `code exchange` )
+                    ( nurl_eprintln ( oidc_provider_last_error p ) )
+                }
+                T ts → {
+                    ( ok T `code exchange succeeds` )
+                    ( ok > ( string_len . ts id_token ) 0 `an ID token came back` )
+                    ( ok_str ( token_set_token_type ts ) `Bearer` `token_type is Bearer` )
+                    ( ok == . ts expires_in 300 `expires_in is carried` )
+                    ( ok ! ( token_set_stale ts ( now_seconds ) ) `a fresh token is not stale` )
+                    ( ok ( token_set_stale ts + ( now_seconds ) 300 ) `a token past its life is stale` )
+
+                    ( section `who is this` )
+                    ?? ( oidc_verify_id_token p pol ( token_set_id_token ts ) ) {
+                        F e → {
+                            ( ok F `ID token verifies` )
+                            ( nurl_eprintln ( oidc_provider_last_error p ) )
+                        }
+                        T id → {
+                            ( ok T `ID token verifies` )
+                            ( ok_str ( string_data . id subject ) `user-42` `subject is read` )
+                            ( ok_str ( string_data . id email ) `user42@example.com` `email is read` )
+                            ( ok_str ( string_data . id name ) `Test User` `name is read` )
+                            ( ok_str ( string_data . id username ) `tuser` `preferred_username is read` )
+                            ( ok . id email_verified `email_verified is read` )
+                            : String key ( oidc_identity_key id )
+                            : String want ( string_from `user-42@` )
+                            ( string_push_str want base )
+                            ( ok ( string_eq key want ) `identity key is sub@issuer` )
+                            ( string_free key ) ( string_free want )
+                            : String desc ( oidc_identity_describe id )
+                            ( ok ( string_contains desc `Test User` ) `describe renders the profile` )
+                            ( string_free desc )
+                            ( oidc_identity_free id )
+                        }
+                    }
+
+                    ( section `the access token as a credential` )
+                    : *OidcPolicy apol ( oidc_policy_new base `test-api` )
+                    ?? ( oidc_verify_access_token p apol ( token_set_access_token ts ) ) {
+                        F e → {
+                            ( ok F `access token verifies for the API audience` )
+                            ( nurl_eprintln ( oidc_provider_last_error p ) )
+                        }
+                        T id → {
+                            ( ok T `access token verifies for the API audience` )
+                            ( ok ( oidc_identity_has_scope id `read:things` ) `granted scope is visible` )
+                            ( ok ! ( oidc_identity_has_scope id `write:things` ) `ungranted scope is not` )
+                            ( oidc_identity_free id )
+                        }
+                    }
+                    // The same token must NOT pass for a different audience.
+                    : *OidcPolicy wrong ( oidc_policy_new base `some-other-api` )
+                    ( expect_verify_err p wrong ( token_set_access_token ts ) `OaClaims` `a token for another audience is refused` )
+                    ( oidc_policy_free wrong )
+                    ( oidc_policy_free apol )
+
+                    ( section `userinfo` )
+                    ?? ( oauth_userinfo_identity p ( token_set_access_token ts ) `user-42` ) {
+                        F _ → { ( ok F `userinfo identity` ) }
+                        T id → {
+                            ( ok_str ( string_data . id subject ) `user-42` `userinfo identity` )
+                            ( oidc_identity_free id )
+                        }
+                    }
+                    ?? ( oauth_userinfo_identity p ( token_set_access_token ts ) `somebody-else` ) {
+                        T id → { ( oidc_identity_free id ) ( ok F `userinfo sub is cross-checked` ) }
+                        F e → { ( ok_str ( oauth_err_name e ) `OaClaims` `userinfo sub is cross-checked` ) }
+                    }
+
+                    ( section `refresh` )
+                    ?? ( oauth_refresh p cfg ( token_set_refresh_token ts ) ) {
+                        F _ → { ( ok F `refresh grant` ) }
+                        T ts2 → {
+                            ( ok > ( string_len . ts2 access_token ) 0 `refresh grant returns a new token` )
+                            ( token_set_free ts2 )
+                        }
+                    }
+                    ?? ( oauth_refresh p cfg `rt-nope` ) {
+                        T ts2 → { ( token_set_free ts2 ) ( ok F `a bad refresh token is refused` ) }
+                        F e → { ( ok_str ( oauth_err_name e ) `OaServer` `a bad refresh token is refused` ) }
+                    }
+
+                    ( token_set_free ts )
+                }
+            }
+
+            ( section `client credentials` )
+            ?? ( oauth_client_credentials p cfg ) {
+                F _ → { ( ok F `client_credentials grant` ) }
+                T ts → {
+                    ( ok > ( string_len . ts access_token ) 0 `client_credentials returns a token` )
+                    ( ok == ( string_len . ts id_token ) 0 `machine grant carries no ID token` )
+                    ( token_set_free ts )
+                }
+            }
+
+            ( section `PKCE is actually checked` )
+            : String code2 ( string_from `c.` )
+            ( string_push_str code2 ( string_data . pk challenge ) )
+            ( string_push_str code2 `.n` )
+            ?? ( oauth_exchange_code p cfg ( string_data code2 ) `a-different-verifier` ) {
+                T ts → { ( token_set_free ts ) ( ok F `the wrong verifier is rejected` ) }
+                F e → { ( ok_str ( oauth_err_name e ) `OaServer` `the wrong verifier is rejected` ) }
+            }
+            ( string_free code2 )
+
+            ( section `every way a token can be wrong` )
+            : *HttpClient hc ( oidc_provider_http p )
+            : String mintbase ( string_from base )
+            ( string_push_str mintbase `/mint/` )
+
+            : String u_exp ( string_from ( string_data mintbase ) )
+            ( string_push_str u_exp `expired` )
+            : String t_exp ( fetch_text hc ( string_data u_exp ) )
+            ( expect_verify_err p pol ( string_data t_exp ) `OaClaims` `an expired token is refused` )
+
+            : String u_bad ( string_from ( string_data mintbase ) )
+            ( string_push_str u_bad `badsig` )
+            : String t_bad ( fetch_text hc ( string_data u_bad ) )
+            ( expect_verify_err p pol ( string_data t_bad ) `OaBadSignature` `a tampered signature is refused` )
+
+            : String u_aud ( string_from ( string_data mintbase ) )
+            ( string_push_str u_aud `wrongaud` )
+            : String t_aud ( fetch_text hc ( string_data u_aud ) )
+            ( expect_verify_err p pol ( string_data t_aud ) `OaClaims` `a token minted for someone else is refused` )
+
+            : String u_kid ( string_from ( string_data mintbase ) )
+            ( string_push_str u_kid `unknownkid` )
+            : String t_kid ( fetch_text hc ( string_data u_kid ) )
+            ( expect_verify_err p pol ( string_data t_kid ) `OaNoKey` `an unpublished kid is refused` )
+
+            : String u_none ( string_from ( string_data mintbase ) )
+            ( string_push_str u_none `none` )
+            : String t_none ( fetch_text hc ( string_data u_none ) )
+            ( expect_verify_err p pol ( string_data t_none ) `OaAlgNotAllowed` `alg:none is refused` )
+
+            : String u_hs ( string_from ( string_data mintbase ) )
+            ( string_push_str u_hs `hs256` )
+            : String t_hs ( fetch_text hc ( string_data u_hs ) )
+            ( expect_verify_err p pol ( string_data t_hs ) `OaAlgNotAllowed` `HS256 against a public key set is refused` )
+
+            // A token with no `kid`, against a key set whose FIRST key is
+            // a decoy: the verifier must walk to the second one.
+            : String u_nk ( string_from ( string_data mintbase ) )
+            ( string_push_str u_nk `nokid` )
+            : String t_nk ( fetch_text hc ( string_data u_nk ) )
+            // (minted outside an authorization request, so no nonce)
+            : *OidcPolicy nopol ( oidc_policy_new base `test-client` )
+            ?? ( oidc_verify_token p nopol ( string_data t_nk ) ) {
+                F e → {
+                    ( ok F `a token with no kid verifies against the right key` )
+                    ( nurl_eprintln ( oidc_provider_last_error p ) )
+                }
+                T id → {
+                    ( ok_str ( string_data . id subject ) `user-42` `a token with no kid verifies against the right key` )
+                    ( oidc_identity_free id )
+                }
+            }
+            ( oidc_policy_free nopol )
+            ( string_free u_nk ) ( string_free t_nk )
+
+            ( expect_verify_err p pol `not.a.token` `OaBadToken` `garbage is refused` )
+            ( expect_verify_err p pol `` `OaBadToken` `an empty token is refused` )
+
+            ( string_free u_exp ) ( string_free t_exp )
+            ( string_free u_bad ) ( string_free t_bad )
+            ( string_free u_aud ) ( string_free t_aud )
+            ( string_free u_kid ) ( string_free t_kid )
+            ( string_free u_none ) ( string_free t_none )
+            ( string_free u_hs ) ( string_free t_hs )
+            ( string_free mintbase )
+
+            ( oidc_policy_free pol )
+            ( string_free code )
+            ( string_free state )
+            ( string_free nonce )
+            ( pkce_free pk )
+            ( oauth_config_free cfg )
+            ( oidc_provider_free p )
+        }
+    }
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `client` `oauth package test` )
+    ( args_opt ap `port` 112 `N` `provider port on 127.0.0.1` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+    : ~ i port 0
+    ?? ( args_value ap `port` ) {
+        T v → {
+            ?? ( string_to_int v ) { T x → { = port x } F _ → {} }
+            ( string_free v )
+        }
+        F _ → {}
+    }
+    ( args_free ap )
+
+    ( section `offline: PKCE` )
+    ( test_pkce_vector )
+    ( section `offline: JWKS` )
+    ( test_jwks_offline )
+    ( section `offline: callback` )
+    ( test_callback_offline )
+    ( section `offline: policy` )
+    ( test_policy_offline )
+    ( section `offline: claim shapes` )
+    ( test_claims_shapes )
+    ( section `offline: RSA (RS256 + PS256 vectors)` )
+    ( test_rsa_offline )
+    ( section `offline: EdDSA` )
+    ( test_eddsa_offline )
+    ( section `offline: HS256` )
+    ( test_hs256_offline )
+
+    ? > port 0 {
+        : String base ( string_from `http://127.0.0.1:` )
+        ( string_push_int base port )
+        ( run_online ( string_data base ) )
+        ( string_free base )
+    } {}
+
+    ( nurl_println `` )
+    : String sum ( string_from `` )
+    ( string_push_int sum g_pass )
+    ( string_push_str sum ` passed, ` )
+    ( string_push_int sum g_fail )
+    ( string_push_str sum ` failed` )
+    ( nurl_println ( string_data sum ) )
+    ( string_free sum )
+    ^ ? > g_fail 0 1 0
+}

--- a/packages/oauth/tests/oauth_test.sh
+++ b/packages/oauth/tests/oauth_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/oauth_test.sh — build the test OIDC provider and the
+#  client-side test, then drive the whole package against it:
+#  discovery, JWKS, PKCE, the code exchange, ID-token and
+#  access-token verification, UserInfo, refresh, client
+#  credentials, and every way a token can be wrong.
+#
+#  Run from the package dir:  ./tests/oauth_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t oauth-test.XXXXXX)"
+PROV=""; API=""
+cleanup() {
+    [ -n "$PROV" ] && kill "$PROV" 2>/dev/null
+    [ -n "$API" ] && kill "$API" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "[1/5] build tests/provider.nu"
+if ! $NURL tests/provider.nu "$WORK/provider" >/dev/null 2>"$WORK/provider.err"; then
+    echo "FAIL: could not build the provider:"; tail -20 "$WORK/provider.err"; exit 1
+fi
+
+echo "[2/5] build tests/client.nu"
+if ! $NURL tests/client.nu "$WORK/client" >/dev/null 2>"$WORK/client.err"; then
+    echo "FAIL: could not build the client:"; tail -20 "$WORK/client.err"; exit 1
+fi
+
+echo "[3/5] start the provider"
+PORT=$((23000 + RANDOM % 9000))
+"$WORK/provider" --port "$PORT" 2>"$WORK/prov.err" &
+PROV=$!
+for _ in $(seq 1 60); do
+    curl -s -o /dev/null "http://127.0.0.1:$PORT/.well-known/openid-configuration" && break
+    sleep 0.1
+done
+
+echo "[4/5] run the package tests"
+"$WORK/client" --port "$PORT"
+RC=$?
+
+# ── The resource-server guard, driven with curl ──────────────────────
+#
+# examples/protected_api.nu is the guard's own test: a real HTTP API
+# wrapped in with_oidc_scope, answering real tokens minted by the
+# provider above.
+echo "[5/5] guard the API (examples/protected_api.nu)"
+if ! $NURL examples/protected_api.nu "$WORK/api" >/dev/null 2>"$WORK/api.err"; then
+    echo "  FAIL could not build examples/protected_api.nu:"; tail -20 "$WORK/api.err"
+    exit 1
+fi
+APORT=$((PORT + 1))
+"$WORK/api" --issuer "http://127.0.0.1:$PORT" --audience test-api \
+            --scope read:things --port "$APORT" 2>"$WORK/api.run.err" &
+API=$!
+for _ in $(seq 1 60); do
+    curl -s -o /dev/null "http://127.0.0.1:$APORT/me" && break
+    sleep 0.1
+done
+
+gpass=0; gfail=0
+guard() {  # guard <label> <expected-status> [auth header value]
+    local label="$1" want="$2" auth="${3:-}"
+    local got
+    if [ -n "$auth" ]; then
+        got=$(curl -s -o "$WORK/body" -w '%{http_code}' -H "Authorization: Bearer $auth" "http://127.0.0.1:$APORT/me")
+    else
+        got=$(curl -s -o "$WORK/body" -w '%{http_code}' "http://127.0.0.1:$APORT/me")
+    fi
+    if [ "$got" = "$want" ]; then
+        echo "  ok   $label"; gpass=$((gpass + 1))
+    else
+        echo "  FAIL $label (HTTP $got, want $want)"; cat "$WORK/body"; gfail=$((gfail + 1))
+    fi
+}
+
+guard "no token is 401" 401
+guard "a valid access token is 200" 200 "$(curl -s "http://127.0.0.1:$PORT/mint/access")"
+guard "an expired token is 401" 401 "$(curl -s "http://127.0.0.1:$PORT/mint/expired")"
+guard "a tampered token is 401" 401 "$(curl -s "http://127.0.0.1:$PORT/mint/badsig")"
+guard "a token for another audience is 401" 401 "$(curl -s "http://127.0.0.1:$PORT/mint/wrongaud")"
+guard "a token without the scope is 403" 403 "$(curl -s "http://127.0.0.1:$PORT/mint/noscope")"
+
+# The challenge itself must name the reason (RFC 6750 §3).
+chal=$(curl -s -D - -o /dev/null "http://127.0.0.1:$APORT/me" | tr -d '\r' | grep -i '^WWW-Authenticate:')
+case "$chal" in
+    *Bearer*) echo "  ok   401 carries a Bearer challenge"; gpass=$((gpass + 1)) ;;
+    *) echo "  FAIL 401 carries a Bearer challenge (got: $chal)"; gfail=$((gfail + 1)) ;;
+esac
+chal=$(curl -s -D - -o /dev/null -H "Authorization: Bearer $(curl -s "http://127.0.0.1:$PORT/mint/expired")" \
+        "http://127.0.0.1:$APORT/me" | tr -d '\r' | grep -i '^WWW-Authenticate:')
+case "$chal" in
+    *invalid_token*) echo "  ok   an invalid token is named invalid_token"; gpass=$((gpass + 1)) ;;
+    *) echo "  FAIL an invalid token is named invalid_token (got: $chal)"; gfail=$((gfail + 1)) ;;
+esac
+# A `kid` carrying CR LF must not become a header of its own: the
+# challenge quotes what the token said, so it has to sanitize it.
+hdrs=$(curl -s -D - -o /dev/null -H "Authorization: Bearer $(curl -s "http://127.0.0.1:$PORT/mint/evilkid")" \
+        "http://127.0.0.1:$APORT/me")
+# (the name may still appear INSIDE the quoted description — what must
+#  not exist is a header line of its own)
+if printf '%s' "$hdrs" | tr -d '\r' | grep -qi '^X-Injected:'; then
+    echo "  FAIL a CRLF in kid cannot inject a header"; gfail=$((gfail + 1))
+else
+    echo "  ok   a CRLF in kid cannot inject a header"; gpass=$((gpass + 1))
+fi
+
+# The identity actually reaches the handler.
+body=$(curl -s -H "Authorization: Bearer $(curl -s "http://127.0.0.1:$PORT/mint/access")" \
+        "http://127.0.0.1:$APORT/whoami")
+case "$body" in
+    user-42@*) echo "  ok   the handler sees the caller's identity"; gpass=$((gpass + 1)) ;;
+    *) echo "  FAIL the handler sees the caller's identity (got: $body)"; gfail=$((gfail + 1)) ;;
+esac
+
+echo ""
+echo "$gpass passed, $gfail failed (guard)"
+[ "$gfail" != 0 ] && RC=1
+
+if [ "$RC" != 0 ]; then
+    echo "--- provider stderr ---"; tail -20 "$WORK/prov.err"
+    echo "--- api stderr ---"; tail -20 "$WORK/api.run.err"
+fi
+exit $RC

--- a/packages/oauth/tests/provider.nu
+++ b/packages/oauth/tests/provider.nu
@@ -1,0 +1,583 @@
+// tests/provider.nu — a real (if minimal) OpenID Connect provider, so the
+// package is tested against the protocol rather than against a mock of
+// itself. It discovers, publishes a JWKS, mints ES256-signed ID tokens
+// with a `kid`, and CHECKS PKCE on the token request.
+//
+// It is stateless by design: the authorization code carries what a real
+// provider would have stored server-side —
+//
+//     code = "c." <code_challenge> "." <nonce>
+//
+// — so /token can verify that S256(code_verifier) is the challenge the
+// authorization request committed to, and can put the right nonce in the
+// ID token, without a session store. Everything on the wire is the
+// standard shape; only the code's INTERNAL format is a shortcut.
+//
+// /mint/<kind> hands out deliberately broken tokens for the negative
+// tests: expired, badsig, none (alg: none), unknownkid, wrongaud, hs256.
+//
+//   provider --port N
+
+$ `stdlib/std/args.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/url.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+
+: ~ i g_port 0
+
+@ prov_kid → s { ^ `k1` }
+
+@ prov_client_id → s { ^ `test-client` }
+
+@ prov_api_audience → s { ^ `test-api` }
+
+@ prov_subject → s { ^ `user-42` }
+
+// A fixed test scalar — this key is public by construction, which is
+// exactly what a test key should be.
+@ prov_sk → ( Vec u ) {
+    ?? ( bytes_from_hex `c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721` ) {
+        T v → { ^ v }
+        F _ → { ^ ( vec_new [u] ) }
+    }
+}
+
+// A SECOND key, published beside the real one and never used to sign —
+// the decoy a relying party must walk past when the token names no kid.
+@ prov_sk2 → ( Vec u ) {
+    ?? ( bytes_from_hex `1122334455667788990011223344556677889900112233445566778899001122` ) {
+        T v → { ^ v }
+        F _ → { ^ ( vec_new [u] ) }
+    }
+}
+
+@ prov_base → String {
+    : String out ( string_from `http://127.0.0.1:` )
+    ( string_push_int out g_port )
+    ^ out
+}
+
+@ prov_url s path → String {
+    : String out ( prov_base )
+    ( string_push_str out path )
+    ^ out
+}
+
+// ── JSON out ───────────────────────────────────────────────────────
+
+@ prov_json i status String body → HttpResponse {
+    : HttpResponse r ( response_new status )
+    ( response_set_header r `Content-Type` `application/json` )
+    ( response_set_body_str r ( string_data body ) )
+    ( string_free body )
+    ^ r
+}
+
+@ prov_kv String out s key s value b first → v {
+    ? first {} { ( string_push_char out 44 ) }
+    ( string_push_char out 34 )
+    ( string_push_str out key )
+    ( string_push_str out `":"` )
+    ( string_push_str out value )
+    ( string_push_char out 34 )
+}
+
+// ── Signing ────────────────────────────────────────────────────────
+
+// header '.' payload '.' signature — `corrupt` flips a signature bit so
+// the token is well-formed and wrong, which is the interesting case.
+@ prov_sign s header s payload b corrupt → String {
+    : String h64 ( b64_url_encode header )
+    : String p64 ( b64_url_encode payload )
+    : String signing ( string_with_cap 512 )
+    ( string_push_str signing ( string_data h64 ) )
+    ( string_push_char signing 46 )
+    ( string_push_str signing ( string_data p64 ) )
+    ( string_free h64 )
+    ( string_free p64 )
+
+    : ( Vec u ) msg ( bytes_from_str ( string_data signing ) )
+    : ( Vec u ) h ( sha256_pure msg )
+    ( vec_free [u] msg )
+    : ( Vec u ) sk ( prov_sk )
+    : ( Vec u ) sig ( ecdsa_p256_sign sk h )
+    ( vec_free [u] sk )
+    ( vec_free [u] h )
+    ? corrupt {
+        ?? ( vec_get [u] sig 0 ) {
+            T b0 → { : b _ok ( vec_set [u] sig 0 # u ^^ # i b0 1 ) }
+            F _ → {}
+        }
+    } {}
+    : String s64 ( b64_url_encode_vec sig )
+    ( vec_free [u] sig )
+    ( string_push_char signing 46 )
+    ( string_push_str signing ( string_data s64 ) )
+    ( string_free s64 )
+    ^ signing
+}
+
+// The JSON-source text `x\r\nX-Injected: yes` — which the JOSE header
+// parser decodes into a kid containing a real CR LF.
+@ prov_evil_kid → String {
+    : String out ( string_from `x` )
+    ( string_push_char out 92 ) ( string_push_char out 114 )
+    ( string_push_char out 92 ) ( string_push_char out 110 )
+    ( string_push_str out `X-Injected: yes` )
+    ^ out
+}
+
+@ prov_header s alg s kid → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out `{"alg":"` )
+    ( string_push_str out alg )
+    ( string_push_str out `","typ":"JWT"` )
+    ? > ( nurl_str_len kid ) 0 {
+        ( string_push_str out `,"kid":"` )
+        ( string_push_str out kid )
+        ( string_push_char out 34 )
+    } {}
+    ( string_push_char out 125 )
+    ^ out
+}
+
+// An ID token: the standard claim set plus the profile.
+@ prov_id_claims s aud s nonce i exp_delta → String {
+    : i now ( now_seconds )
+    : String base ( prov_base )
+    : String out ( string_with_cap 512 )
+    ( string_push_char out 123 )
+    ( prov_kv out `iss` ( string_data base ) T )
+    ( prov_kv out `sub` ( prov_subject ) F )
+    ( prov_kv out `aud` aud F )
+    ( string_free base )
+    ? > ( nurl_str_len nonce ) 0 { ( prov_kv out `nonce` nonce F ) } {}
+    ( prov_kv out `email` `user42@example.com` F )
+    ( prov_kv out `name` `Test User` F )
+    ( prov_kv out `preferred_username` `tuser` F )
+    ( string_push_str out `,"email_verified":true` )
+    ( string_push_str out `,"iat":` )
+    ( string_push_int out now )
+    ( string_push_str out `,"auth_time":` )
+    ( string_push_int out now )
+    ( string_push_str out `,"exp":` )
+    ( string_push_int out + now exp_delta )
+    ( string_push_char out 125 )
+    ^ out
+}
+
+// An access token in the RFC 9068 shape: audience = the API, with scopes.
+@ prov_access_claims → String {
+    ^ ( prov_access_claims_scope `openid profile read:things` )
+}
+
+@ prov_access_claims_scope s scope → String {
+    : i now ( now_seconds )
+    : String base ( prov_base )
+    : String out ( string_with_cap 384 )
+    ( string_push_char out 123 )
+    ( prov_kv out `iss` ( string_data base ) T )
+    ( prov_kv out `sub` ( prov_subject ) F )
+    ( prov_kv out `aud` ( prov_api_audience ) F )
+    ( prov_kv out `scope` scope F )
+    ( string_free base )
+    ( string_push_str out `,"iat":` )
+    ( string_push_int out now )
+    ( string_push_str out `,"exp":` )
+    ( string_push_int out + now 300 )
+    ( string_push_char out 125 )
+    ^ out
+}
+
+// ── Endpoints ──────────────────────────────────────────────────────
+
+@ prov_discovery → HttpResponse {
+    : String out ( string_with_cap 512 )
+    : String base ( prov_base )
+    : String auth ( prov_url `/authorize` )
+    : String tok ( prov_url `/token` )
+    : String ui ( prov_url `/userinfo` )
+    : String jwks ( prov_url `/jwks.json` )
+    ( string_push_char out 123 )
+    ( prov_kv out `issuer` ( string_data base ) T )
+    ( prov_kv out `authorization_endpoint` ( string_data auth ) F )
+    ( prov_kv out `token_endpoint` ( string_data tok ) F )
+    ( prov_kv out `userinfo_endpoint` ( string_data ui ) F )
+    ( prov_kv out `jwks_uri` ( string_data jwks ) F )
+    ( string_push_str out `,"response_types_supported":["code"]` )
+    ( string_push_str out `,"id_token_signing_alg_values_supported":["ES256"]` )
+    ( string_push_str out `,"code_challenge_methods_supported":["S256"]` )
+    ( string_push_char out 125 )
+    ( string_free base ) ( string_free auth ) ( string_free tok )
+    ( string_free ui ) ( string_free jwks )
+    ^ ( prov_json 200 out )
+}
+
+// One JWK object for a private scalar, under `kid`.
+@ prov_jwk_for ( Vec u ) sk s kid → String {
+    : ( Vec u ) point ( p256_ecdh_keygen sk )
+    : ( Vec u ) x ( bytes_slice point 1 33 )
+    : ( Vec u ) y ( bytes_slice point 33 65 )
+    ( vec_free [u] point )
+    : String x64 ( b64_url_encode_vec x )
+    : String y64 ( b64_url_encode_vec y )
+    ( vec_free [u] x ) ( vec_free [u] y )
+    : String out ( string_with_cap 256 )
+    ( string_push_str out `{"kty":"EC","crv":"P-256","use":"sig","alg":"ES256","kid":"` )
+    ( string_push_str out kid )
+    ( string_push_str out `","x":"` )
+    ( string_push_str out ( string_data x64 ) )
+    ( string_push_str out `","y":"` )
+    ( string_push_str out ( string_data y64 ) )
+    ( string_push_str out `"}` )
+    ( string_free x64 ) ( string_free y64 )
+    ^ out
+}
+
+// The decoy is published FIRST, so a token with no `kid` only verifies
+// for a relying party that walks past a key that does not fit.
+@ prov_jwks → HttpResponse {
+    : ( Vec u ) sk2 ( prov_sk2 )
+    : String decoy ( prov_jwk_for sk2 `k0` )
+    ( vec_free [u] sk2 )
+    : ( Vec u ) sk ( prov_sk )
+    : String real ( prov_jwk_for sk ( prov_kid ) )
+    ( vec_free [u] sk )
+    : String out ( string_with_cap 640 )
+    ( string_push_str out `{"keys":[` )
+    ( string_push_str out ( string_data decoy ) )
+    ( string_push_char out 44 )
+    ( string_push_str out ( string_data real ) )
+    ( string_push_str out `]}` )
+    ( string_free decoy ) ( string_free real )
+    ^ ( prov_json 200 out )
+}
+
+@ prov_param ( Vec UrlParam ) ps s key → String {
+    : i n ( vec_len [UrlParam] ps )
+    : *UrlParam data ( vec_data [UrlParam] ps )
+    : ~ i k 0
+    ~ < k n {
+        : UrlParam pp . data k
+        ? == 1 ( nurl_str_eq ( string_data . pp key ) key ) {
+            ^ ( string_from ( string_data . pp val ) )
+        } {}
+        = k + k 1
+    }
+    ^ ( string_new )
+}
+
+@ prov_error i status s code s desc → HttpResponse {
+    : String out ( string_with_cap 128 )
+    ( string_push_char out 123 )
+    ( prov_kv out `error` code T )
+    ( prov_kv out `error_description` desc F )
+    ( string_push_char out 125 )
+    ^ ( prov_json status out )
+}
+
+// The i-th '.'-separated field of the code, or "".
+@ prov_code_field String code i want → String {
+    : ( Vec String ) parts ( string_split code `.` )
+    : ~ String out ( string_new )
+    ?? ( vec_get [String] parts want ) {
+        T p → { ( string_free out ) = out ( string_from ( string_data p ) ) }
+        F _ → {}
+    }
+    ( vec_free_with [String] parts \ String s → v { ( string_free s ) } )
+    ^ out
+}
+
+@ prov_token HttpRequest req → HttpResponse {
+    : String body ( bytes_to_str . req body )
+    : ( Vec UrlParam ) ps ( url_query_decode ( string_data body ) )
+    ( string_free body )
+    : String grant ( prov_param ps `grant_type` )
+    : String client ( prov_param ps `client_id` )
+    : String code ( prov_param ps `code` )
+    : String verifier ( prov_param ps `code_verifier` )
+    : String refresh ( prov_param ps `refresh_token` )
+    ( url_params_free ps )
+
+    : ~ HttpResponse resp ( response_new 0 )
+    : ~ b done F
+
+    ? == 0 ( nurl_str_eq ( string_data client ) ( prov_client_id ) ) {
+        ( http_response_free resp )
+        = resp ( prov_error 401 `invalid_client` `unknown client_id` )
+        = done T
+    } {}
+
+    ? done {} {
+        ? == 1 ( nurl_str_eq ( string_data grant ) `authorization_code` ) {
+            : String want ( prov_code_field code 1 )
+            : String nonce ( prov_code_field code 2 )
+            : ( Vec u ) msg ( bytes_from_str ( string_data verifier ) )
+            : ( Vec u ) h ( sha256_pure msg )
+            ( vec_free [u] msg )
+            : String got ( b64_url_encode_vec h )
+            ( vec_free [u] h )
+            ? & > ( string_len want ) 0 ( string_eq got want ) {
+                : String idc ( prov_id_claims ( prov_client_id ) ( string_data nonce ) 300 )
+                : String hdr ( prov_header `ES256` ( prov_kid ) )
+                : String idt ( prov_sign ( string_data hdr ) ( string_data idc ) F )
+                : String ac ( prov_access_claims )
+                : String at ( prov_sign ( string_data hdr ) ( string_data ac ) F )
+                : String out ( string_with_cap 2048 )
+                ( string_push_char out 123 )
+                ( prov_kv out `access_token` ( string_data at ) T )
+                ( prov_kv out `id_token` ( string_data idt ) F )
+                ( prov_kv out `refresh_token` `rt-1` F )
+                ( prov_kv out `token_type` `Bearer` F )
+                ( prov_kv out `scope` `openid profile read:things` F )
+                ( string_push_str out `,"expires_in":300}` )
+                ( string_free idc ) ( string_free hdr ) ( string_free idt )
+                ( string_free ac ) ( string_free at )
+                ( http_response_free resp )
+                = resp ( prov_json 200 out )
+            } {
+                ( http_response_free resp )
+                = resp ( prov_error 400 `invalid_grant` `PKCE verification failed` )
+            }
+            ( string_free want ) ( string_free nonce ) ( string_free got )
+            = done T
+        } {}
+    }
+
+    ? done {} {
+        ? == 1 ( nurl_str_eq ( string_data grant ) `refresh_token` ) {
+            ? == 1 ( nurl_str_eq ( string_data refresh ) `rt-1` ) {
+                : String hdr ( prov_header `ES256` ( prov_kid ) )
+                : String ac ( prov_access_claims )
+                : String at ( prov_sign ( string_data hdr ) ( string_data ac ) F )
+                : String out ( string_with_cap 1024 )
+                ( string_push_char out 123 )
+                ( prov_kv out `access_token` ( string_data at ) T )
+                ( prov_kv out `token_type` `Bearer` F )
+                ( prov_kv out `refresh_token` `rt-2` F )
+                ( string_push_str out `,"expires_in":300}` )
+                ( string_free hdr ) ( string_free ac ) ( string_free at )
+                ( http_response_free resp )
+                = resp ( prov_json 200 out )
+            } {
+                ( http_response_free resp )
+                = resp ( prov_error 400 `invalid_grant` `unknown refresh token` )
+            }
+            = done T
+        } {}
+    }
+
+    ? done {} {
+        ? == 1 ( nurl_str_eq ( string_data grant ) `client_credentials` ) {
+            : String hdr ( prov_header `ES256` ( prov_kid ) )
+            : String ac ( prov_access_claims )
+            : String at ( prov_sign ( string_data hdr ) ( string_data ac ) F )
+            : String out ( string_with_cap 1024 )
+            ( string_push_char out 123 )
+            ( prov_kv out `access_token` ( string_data at ) T )
+            ( prov_kv out `token_type` `Bearer` F )
+            ( string_push_str out `,"expires_in":300}` )
+            ( string_free hdr ) ( string_free ac ) ( string_free at )
+            ( http_response_free resp )
+            = resp ( prov_json 200 out )
+        } {
+            ( http_response_free resp )
+            = resp ( prov_error 400 `unsupported_grant_type` `no such grant` )
+        }
+    }
+
+    ( string_free grant ) ( string_free client ) ( string_free code )
+    ( string_free verifier ) ( string_free refresh )
+    ^ resp
+}
+
+@ prov_userinfo HttpRequest req → HttpResponse {
+    : ~ b authed F
+    ?? ( header_get . req headers `Authorization` ) {
+        T v → {
+            = authed == 1 ( nurl_str_starts ( string_data v ) `Bearer ` )
+            ( string_free v )
+        }
+        F _ → {}
+    }
+    ? authed {} {
+        : HttpResponse r ( response_text 401 `Unauthorized\n` )
+        ( response_set_header r `WWW-Authenticate` `Bearer` )
+        ^ r
+    }
+    : String out ( string_with_cap 256 )
+    ( string_push_char out 123 )
+    ( prov_kv out `sub` ( prov_subject ) T )
+    ( prov_kv out `email` `user42@example.com` F )
+    ( prov_kv out `name` `Test User` F )
+    ( string_push_str out `,"email_verified":true}` )
+    ^ ( prov_json 200 out )
+}
+
+// Deliberately broken tokens, one per failure mode the verifier must
+// catch. Served as text/plain so the test can feed them in directly.
+@ prov_mint String kind → HttpResponse {
+    : String hdr_ok ( prov_header `ES256` ( prov_kid ) )
+    : ~ String token ( string_new )
+    ? ( string_eq kind ( string_from `expired` ) ) {
+        : String c ( prov_id_claims ( prov_client_id ) `` -600 )
+        ( string_free token )
+        = token ( prov_sign ( string_data hdr_ok ) ( string_data c ) F )
+        ( string_free c )
+    } {}
+    ? ( string_eq kind ( string_from `badsig` ) ) {
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        ( string_free token )
+        = token ( prov_sign ( string_data hdr_ok ) ( string_data c ) T )
+        ( string_free c )
+    } {}
+    ? ( string_eq kind ( string_from `wrongaud` ) ) {
+        : String c ( prov_id_claims `someone-else` `` 300 )
+        ( string_free token )
+        = token ( prov_sign ( string_data hdr_ok ) ( string_data c ) F )
+        ( string_free c )
+    } {}
+    ? ( string_eq kind ( string_from `unknownkid` ) ) {
+        : String h ( prov_header `ES256` `rotated-away` )
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        ( string_free token )
+        = token ( prov_sign ( string_data h ) ( string_data c ) F )
+        ( string_free c ) ( string_free h )
+    } {}
+    ? ( string_eq kind ( string_from `none` ) ) {
+        // alg: none — header and claims, and an EMPTY signature.
+        : String h ( string_from `{"alg":"none","typ":"JWT"}` )
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        : String h64 ( b64_url_encode ( string_data h ) )
+        : String c64 ( b64_url_encode ( string_data c ) )
+        ( string_free token )
+        = token ( string_with_cap 512 )
+        ( string_push_str token ( string_data h64 ) )
+        ( string_push_char token 46 )
+        ( string_push_str token ( string_data c64 ) )
+        ( string_push_char token 46 )
+        ( string_free h ) ( string_free c ) ( string_free h64 ) ( string_free c64 )
+    } {}
+    ? ( string_eq kind ( string_from `evilkid` ) ) {
+        // A `kid` carrying CR LF and a header of its own. It names no
+        // published key, so the token is refused — the point is what the
+        // refusal PUTS IN THE RESPONSE.
+        : String ek ( prov_evil_kid )
+        : String h ( prov_header `ES256` ( string_data ek ) )
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        ( string_free token )
+        = token ( prov_sign ( string_data h ) ( string_data c ) F )
+        ( string_free c ) ( string_free h ) ( string_free ek )
+    } {}
+    ? ( string_eq kind ( string_from `nokid` ) ) {
+        // Legal, and common: no `kid` at all. The verifier has to try
+        // every key the algorithm admits.
+        : String h ( prov_header `ES256` `` )
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        ( string_free token )
+        = token ( prov_sign ( string_data h ) ( string_data c ) F )
+        ( string_free c ) ( string_free h )
+    } {}
+    ? ( string_eq kind ( string_from `access` ) ) {
+        : String c ( prov_access_claims )
+        ( string_free token )
+        = token ( prov_sign ( string_data hdr_ok ) ( string_data c ) F )
+        ( string_free c )
+    } {}
+    ? ( string_eq kind ( string_from `noscope` ) ) {
+        : String c ( prov_access_claims_scope `openid` )
+        ( string_free token )
+        = token ( prov_sign ( string_data hdr_ok ) ( string_data c ) F )
+        ( string_free c )
+    } {}
+    ? ( string_eq kind ( string_from `hs256` ) ) {
+        // HS256 over the same claims, "signed" with the PUBLIC x
+        // coordinate — the key-confusion attack, spelled out.
+        : ( Vec u ) sk ( prov_sk )
+        : ( Vec u ) point ( p256_ecdh_keygen sk )
+        ( vec_free [u] sk )
+        : ( Vec u ) x ( bytes_slice point 1 33 )
+        ( vec_free [u] point )
+        : String h ( prov_header `HS256` ( prov_kid ) )
+        : String c ( prov_id_claims ( prov_client_id ) `` 300 )
+        : String h64 ( b64_url_encode ( string_data h ) )
+        : String c64 ( b64_url_encode ( string_data c ) )
+        : String signing ( string_with_cap 512 )
+        ( string_push_str signing ( string_data h64 ) )
+        ( string_push_char signing 46 )
+        ( string_push_str signing ( string_data c64 ) )
+        : ( Vec u ) msg ( bytes_from_str ( string_data signing ) )
+        : ( Vec u ) mac ( hmac_sha256_pure x msg )
+        : String m64 ( b64_url_encode_vec mac )
+        ( string_push_char signing 46 )
+        ( string_push_str signing ( string_data m64 ) )
+        ( string_free token )
+        = token signing
+        ( vec_free [u] x ) ( vec_free [u] msg ) ( vec_free [u] mac )
+        ( string_free h ) ( string_free c ) ( string_free h64 )
+        ( string_free c64 ) ( string_free m64 )
+    } {}
+    ( string_free hdr_ok )
+    ? == 0 ( string_len token ) {
+        ( string_free token )
+        ^ ( response_text 404 `no such mint\n` )
+    } {}
+    : HttpResponse r ( response_text 200 ( string_data token ) )
+    ( string_free token )
+    ^ r
+}
+
+@ prov_handle HttpRequest req → HttpResponse {
+    : s path ( string_data . req path )
+    ? == 1 ( nurl_str_eq path `/.well-known/openid-configuration` ) { ^ ( prov_discovery ) } {}
+    ? == 1 ( nurl_str_eq path `/jwks.json` ) { ^ ( prov_jwks ) } {}
+    ? == 1 ( nurl_str_eq path `/token` ) { ^ ( prov_token req ) } {}
+    ? == 1 ( nurl_str_eq path `/userinfo` ) { ^ ( prov_userinfo req ) } {}
+    ? == 1 ( nurl_str_starts path `/mint/` ) {
+        : String kind ( string_substr . req path 6 - ( string_len . req path ) 6 )
+        : HttpResponse r ( prov_mint kind )
+        ( string_free kind )
+        ^ r
+    } {}
+    ^ ( response_text 404 `not found\n` )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `provider` `test OIDC provider` )
+    ( args_opt ap `port` 112 `N` `bind port on 127.0.0.1` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+    ?? ( args_value ap `port` ) {
+        T v → {
+            ?? ( string_to_int v ) { T x → { = g_port x } F _ → {} }
+            ( string_free v )
+        }
+        F _ → {}
+    }
+    ( args_free ap )
+    ? == g_port 0 { ( nurl_eprintln `provider: --port is required` ) ^ 2 } {}
+
+    ?? ( tcp_listen `127.0.0.1` g_port ) {
+        T l → {
+            // A pool, not one serial accept loop: a relying party's HTTP
+            // client keeps its connection to the provider alive, and a
+            // single-connection provider would then starve every other
+            // caller — including the curl in the test script.
+            : HttpServer srv ( server_new l \ HttpRequest req → HttpResponse { ^ ( prov_handle req ) } )
+            ?? ( server_run_pool srv 4 ) {
+                T _ → { ^ 0 }
+                F _ → { ( nurl_eprintln `provider: listener failed` ) ^ 1 }
+            }
+        }
+        F _ → {
+            ( nurl_eprintln `provider: cannot bind` )
+            ^ 1
+        }
+    }
+}


### PR DESCRIPTION
An OpenID Connect relying party and resource-server guard in pure NURL —
nothing in the chain is C, down to the RSA/ECDSA/Ed25519 and SHA-2 that
decide whether a token is real.

## The two halves

**Get a token.** Authorization-code flow with PKCE (S256 only), OIDC
discovery with the metadata document's own `issuer` cross-checked
(RFC 8414 §3.3 — otherwise a redirect to an attacker's metadata silently
repoints the token endpoint), the token endpoint (`authorization_code`,
`refresh_token`, `client_credentials`; `client_secret_post` or
`_basic`), and UserInfo.

**Believe a token** — the part that decides who someone is. Fetch the
provider's JWKS, walk *every* key the token's `kid`/`alg` admits (which
is what a rotation looks like when the token carries no `kid`), re-fetch
on an unseen `kid` so a rotation needs no restart — rate-limited, because
a flood of forged `kid`s is otherwise a load generator aimed at the
provider — and check the signature: RS256/384/512, PS256, ES256/384,
EdDSA, and HS256 only against a deliberately configured shared secret.
Then the claims: `iss`, `aud` with `azp`, `exp`/`nbf`/`iat` with leeway,
`nonce`, `sub`, `max_age` — each named when it fails. `alg: none` and an
unrecognised `crit` are refused, not ignored.

The result is an `OidcIdentity`: subject, issuer, email, name, picture,
and the full claim set for whatever else the provider sent.

**Guard a route.** `with_oidc_bearer` / `with_oidc_scope` wrap a handler
so it is only ever entered for a caller the package could name; 401 with
an RFC 6750 challenge naming the reason, 403 `insufficient_scope` for a
caller who is who they say but was not granted it.

## Layout

| File | |
| --- | --- |
| `src/errors.nu` | `OauthErr` + the RFC 6750 error code for each |
| `src/jwk.nu` | JWK/JWKS parse, key selection, EC point, RFC 7638 thumbprint |
| `src/jws.nu` | header-driven verification against a JWK |
| `src/claims.nu` | `OidcPolicy`, `claims_check`, accessors, `OidcIdentity` |
| `src/pkce.nu` | verifier/challenge, state, nonce |
| `src/provider.nu` | discovery, the JWKS cache, `oidc_verify_id_token` |
| `src/flow.nu` | authorize URL, callback, exchange, refresh, UserInfo |
| `src/guard.nu` | `with_oidc_bearer`, `with_oidc_scope` |
| `examples/` | `login` (browser + loopback redirect), `verify`, `protected_api` |

One dependency: `http-client` (path `../http-client`).

## Two defects found and fixed at the root on the way

1. **Header injection.** The 401 challenge quotes back the reason, and
   part of that text is copied from the token — an attacker-supplied
   `kid`. A CR LF there is response splitting. `_oidc_safe_param` now
   renders every auth-param, and `/mint/evilkid` + a curl assertion prove
   no header of the attacker's choosing appears.
2. **A serial server starved by a pooled client.** `packages/http-client`
   keeps one keep-alive connection per origin and sends no
   `Connection: close`, so a single-threaded `server_run` upstream never
   accepts anything else. The test provider runs `server_run_pool`;
   `src/provider.nu` documents that an `*OidcProvider` (one HTTP client,
   one mutable key cache, no lock) is not shareable across threads.

## Tests

`./tests/oauth_test.sh` — 95 in-process assertions + 10 driving
`examples/protected_api.nu` over curl. **Clean under ASan + UBSan with
LeakSanitizer on.**

`tests/provider.nu` is a real (if minimal) OIDC provider: it publishes
discovery metadata and a two-key JWKS, mints ES256-signed ID and access
tokens with a `kid`, and genuinely verifies PKCE on the token request —
its authorization code carries the challenge and nonce the authorization
request committed to, which is what a real provider keeps in a session
store, so `/token` stays the standard shape.

`/mint/<kind>` hands out the deliberately broken tokens the verifier must
refuse — expired, tampered, wrong audience, unpublished `kid`,
`alg: none`, HS256 signed with the public key, a `kid` carrying CR LF,
and a legal token with no `kid` at all against a key set whose first key
is a decoy — each asserted to fail (or pass) for the **right** reason.

Offline, RS256 and PS256 are checked against tokens minted by OpenSSL
with an RSA-2048 key, so the pure-NURL RSA path is proven to agree with
an independent implementation rather than with itself; EdDSA and HS256
are round-tripped through the stdlib; PKCE is checked against RFC 7636's
own S256 vector.

Not wired into compiler CI (registry packages aren't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYeQekePshxtAu2A9dguw