### PR TITLE
pqc 0.2.2, swarm 0.2.1: republish after the print-family rule

### DIFF
--- a/packages/pqc/CHANGELOG.md
+++ b/packages/pqc/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `pqc` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-09-06
+
+### Fixed
+
+- `probe HOST:PORT` ends the port on its own line again. The toolchain's
+  print family settled on one rule (`print` = no newline, `println` =
+  newline) and `nurl_print_int` stopped adding one; 0.2.1 built with a
+  current toolchain ran the port into the next line.
+
 ## [0.2.1] — 2026-08-19
 
 ### Fixed

--- a/packages/pqc/nurl.toml
+++ b/packages/pqc/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pqc"
-version = "0.2.1"
+version = "0.2.2"
 description = "Post-quantum cryptography on the command line, and a probe for whether the servers you talk to are ready for it. Implements both halves of the migration in pure NURL — ML-KEM (FIPS 203, formerly CRYSTALS-Kyber) for key encapsulation and ML-DSA (FIPS 204, formerly CRYSTALS-Dilithium) for signatures, at all three parameter sets each — checked byte-for-byte against NIST's own ACVP vectors, 660 published cases in all. The part worth having on a laptop is `pqc probe HOST`: it completes a real TLS 1.3 handshake and reports which key-exchange group the server actually chose, because offering the hybrid group is not the same as getting it and a server without ML-KEM falls back to X25519 silently. Built on stdlib/std/mlkem.nu, stdlib/std/mldsa.nu and the pure-NURL TLS stack, which negotiates X25519MLKEM768 with the servers that support it — no libcrypto, no liboqs, libc and nothing else."
 license = "MIT OR Apache-2.0"
 

--- a/packages/swarm/nurl.toml
+++ b/packages/swarm/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarm"
-version = "0.2.0"
+version = "0.2.1"
 description = "A distributed compute cluster you join by installing it. Run `swarm worker <relay> <port>` on any machine and it announces itself over the relay group, every node folds it into the consistent-hash ring, and it starts taking its share of real work. `swarm submit` shards a genuine numeric workload (prime counting, sum-of-squares) across the live workers and sums the partial results, and `swarm relay --verbose` logs peers as they join and leave. Built entirely on the standard distributed stack (net/relay, net/transport, dist/ring, dist/job) — no external frameworks. Requires NURL >= v0.10.3."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Version-only bumps. #1025 changed `nurl_print_int` to print without a newline and converted both packages' port lines to `nurl_println_int` in the tree — but neither package was re-released, so the registry's pqc 0.2.1 / swarm 0.2.0, built with a current toolchain, run `host:port` into the next line.

- pqc 0.2.1 → 0.2.2 (CHANGELOG entry)
- swarm 0.2.0 → 0.2.1

Both `nurlpkg publish --dry-run` clean against the released v0.61.0. Published once this merges.

Found by the drift check (packages whose source moved after their last version bump); nwasm / wasmbuilder / oauth also moved but only in tests, which are not install-time content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxLjWgGyferfDAkXCAhZyp