### PR TITLE
anomaly README: the app registration an MCP client needs

### DIFF
--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -350,7 +350,7 @@ README.
 enabled     = true
 issuer      = "https://login.example.com/<tenant>/v2.0"
 client_id   = "<application (client) id>"
-audience    = "api://<application (client) id>"   # optional; this is the default
+audience    = "https://<your-host>/mcp"   # optional; default api://<client id>. See "An agent's client" below
 open_ingest = true
 
 [service]
@@ -500,6 +500,7 @@ secret to store anywhere. Register:
 | redirect URIs | `https://<your-host>/oauth/callback` and `http://localhost:8811/oauth/callback` |
 | scopes | `openid profile email`, plus one scope for this API |
 | claims | `email` and `preferred_username` in the ID and access tokens |
+| for agents on `/mcp` | the MCP client's redirect URI as a **public client**, and `https://<your-host>/mcp` as an identifier of this API — see [An agent's client](#an-agents-client) |
 
 #### One organization, or any
 
@@ -532,6 +533,44 @@ tenant '…' and cannot access the application '…' in that tenant.
 
 which names the mismatch exactly.
 
+#### An agent's client
+
+An MCP client that signs the person in — Claude, or any client that follows
+the MCP authorization spec — is an OAuth client of its own, and it differs
+from the dashboard in two ways the registration has to allow for.
+
+**Its redirect URI is not on your host.** The client names its own callback
+(Claude's is `https://claude.ai/api/mcp/auth_callback`, and
+`https://claude.com/api/mcp/auth_callback` alongside it), and it exchanges
+the code from its own servers, without a secret: authorization-code with
+PKCE. Register that URI as a **public client** — in Entra, the *Mobile and
+desktop applications* platform. The other two platforms refuse exactly this
+exchange: *Web* demands a client secret, and *Single-page application*
+demands a browser's `Origin` header on the token request.
+
+**It names the resource it wants a token for.** The client reads the
+`resource` this service publishes at `/.well-known/oauth-protected-resource/mcp`
+— `https://<your-host>/mcp` — and sends it with every authorization request
+([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)). Entra checks that the
+scope requested belongs to that resource, and `api://<client id>` is a
+different resource, so the sign-in ends in
+
+```
+AADSTS9010010: The resource parameter provided in the request doesn't match
+with the requested scopes.
+```
+
+The fix is one name for one thing: add `https://<your-host>/mcp` as a second
+*Application ID URI* of the registration (Entra accepts an `https://` URI
+only on a domain verified in your tenant) and set `auth.audience` to it. The
+service then advertises `https://<your-host>/mcp/access_as_user` as the
+scope, resource and scope agree, and the dashboard keeps working — it
+requests the same permission under the new name, and the access token's
+`aud` is the client id either way, which is the second spelling the service
+accepts.
+
+Give the MCP client the same `client_id` as the dashboard and no secret.
+
 #### Azure AD (Entra ID), with `az`
 
 `az ad app create` has no flags for SPA redirect URIs, for exposing an API, or
@@ -552,7 +591,10 @@ az rest --method PATCH \
   "spa": { "redirectUris": [
       "https://<your-host>/oauth/callback",
       "http://localhost:8811/oauth/callback" ] },
-  "identifierUris": [ "api://$APPID" ],
+  "publicClient": { "redirectUris": [
+      "https://claude.ai/api/mcp/auth_callback",
+      "https://claude.com/api/mcp/auth_callback" ] },
+  "identifierUris": [ "api://$APPID", "https://<your-host>/mcp" ],
   "api": {
     "requestedAccessTokenVersion": 2,
     "oauth2PermissionScopes": [ {
@@ -598,6 +640,10 @@ Two steps there bite:
 - **`preAuthorizedApplications` needs the scope to already exist**, hence two
   PATCHes. A single one fails with *"has a Permission Id that cannot be found
   in the AppPermissions sets"*.
+- **`https://<your-host>/mcp` must be on a domain your tenant has verified**,
+  or the PATCH is refused. Without it an MCP client cannot sign in at all
+  (`AADSTS9010010`, above); the dashboard does not need it. Set
+  `auth.audience = "https://<your-host>/mcp"` to match.
 
 Sanity-check the registration without a browser by building the authorize URL
 the dashboard would and fetching it: a real sign-in page means the client id,
@@ -669,8 +715,10 @@ In `oidc` mode the endpoint answers an unauthenticated call with the standard
 challenge — `401`, `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/mcp"` —
 and that document names the issuer and the scope, so an MCP client that
 speaks OAuth signs the person in by itself against the same identity provider
-the dashboard uses (the same `client_id`; the client's loopback redirect must
-be registered on the app). A machine agent uses an API key instead:
+the dashboard uses — the same `client_id`, with the client's own redirect
+URI and this service's `/mcp` URL registered on the app as
+[An agent's client](#an-agents-client) describes. A machine agent uses an
+API key instead:
 `--header "X-API-Key: anok_…"`. In `simple` mode there is no sign-in and
 every call is an administrator's, as everywhere else.
 

--- a/packages/anomaly/anomaly.toml.example
+++ b/packages/anomaly/anomaly.toml.example
@@ -38,7 +38,14 @@ mode = "simple"
 # What the access token's `aud` must be. Defaults to api://<client_id>. Both
 # that and the bare client id are accepted, because which one a token carries
 # is the provider's choice, not yours.
-# audience = "api://<application (client) id>"
+#
+# For agents on /mcp set this to the MCP resource itself, registered as a
+# second Application ID URI of the same app. An MCP client sends
+# resource=https://<your-host>/mcp with the scope (RFC 8707), and Entra
+# refuses the pair unless the scope belongs to that resource
+# (AADSTS9010010) -- api://<client id> is a different resource. The
+# dashboard works with either. README: "An agent's client".
+# audience = "https://<your-host>/mcp"
 
 # Accept users from ANY organization the provider will sign for.
 #


### PR DESCRIPTION
Docs only. An MCP client that signs the person in (Claude, or any client following the MCP authorization spec) is an OAuth client of its own, and the identity-provider section did not say what that needs from the app registration:

- its redirect URI is on the client's host and must be registered as a **public client** (Entra: *Mobile and desktop applications*) — Web demands a secret, SPA demands a browser `Origin`;
- it sends `resource=https://<your-host>/mcp` (RFC 8707) with the scope, and Entra refuses the pair unless the scope belongs to that resource (`AADSTS9010010`) — `api://<client id>` is a different resource.

New subsection *An agent's client* explains both, the `az` script registers the public-client redirects and `https://<your-host>/mcp` as a second Application ID URI, `auth.audience` is documented to point at it (dashboard keeps working: same permission, `aud` is the client id either way), and `anomaly.toml.example` carries the same note. No version bump — README and example config are not install-time content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxLjWgGyferfDAkXCAhZyp