### PR TITLE
Release v0.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.61.1] — 2026-09-07
+
+### Added
+
+- **`packages/anomaly` 0.14.0 → 0.19.0 — data sources.** An administrator
+  points the service at something that publishes data and the server
+  fetches it on a schedule into a model: an OGC WFS 2.0 endpoint's stored
+  queries (the Finnish Meteorological Institute) or feature types (a
+  GeoServer's or MapServer's — Helsinki, Väylä, SYKE, DWD), or any URL
+  answering JSON, polled with the headers it needs. The service's
+  catalogue is browsed and picked in the dashboard, the answer previewed,
+  the columns tapped as features — as numbers, or as categories so a
+  place or a station is an identity the anomaly is judged against — and
+  each run asks only for what it has not seen. Before that, 0.14–0.16
+  brought a range guard, events, labels and votes, GPU scoring bound to
+  the calling thread, CSV/JSONL export and a dashboard polish;
+  [`packages/anomaly/CHANGELOG.md`](packages/anomaly/CHANGELOG.md) has the
+  full text. `pqc` 0.2.2 and `swarm` 0.2.1 were republished after the
+  print-family rule.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-09-06 · Current release: **0.61.0** · Language: **Grammar
+_Last reviewed: 2026-09-07 · Current release: **0.61.1** · Language: **Grammar
 v2.7** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Patch release: two stdlib fixes found while pointing the anomaly service at other people's WFS servers (#1083), and the package releases since 0.61.0.

**Fixed**
- `stdlib/ext/xml.nu`: a comment right before a closing tag ended the element inside the comment and lost every later sibling (a MapServer `GetCapabilities` parsed to one child). Regression in `compiler/tests/xml_basic.nu`.
- `stdlib/std/tls.nu`: the ALPN a TLS 1.2 ServerHello selects was never read, so `http-client` spoke HTTP/1.1 to a load balancer that had chosen h2 (`avoinapi.vaylapilvi.fi`) and every request failed.

**Packages since 0.61.0:** `anomaly` 0.14.0 → 0.19.0 (data sources: WFS stored queries and feature types, HTTP/JSON with headers, categorical columns; range guard, events, labels, votes, GPU scoring on the calling thread, export), `pqc` 0.2.2, `swarm` 0.2.1.

Toolchain diff since the tag is these two files plus the regression test; `./build.sh` bootstrap + corpus and the stdlib symbol gate were green on #1083. ROADMAP's release line updated. Tag `v0.61.1` follows the merge, per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn9aEWGTskWRRjmfWk9CDb
