### PR TITLE
stdlib ext/xml: free the placeholder node the element parser drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ext/xml`: the parser leaked a placeholder node per element.** A
+  child loop ends on a `</` that `__xml_parse_node` answers with an empty
+  node (two Strings, two Vecs) and `ok = 0`; the element parser read the
+  flag and dropped the node. ~2 KB per WFS response in `anomaly`'s
+  source scheduler, forever. The placeholder is freed where the flag is
+  read.
+
 ### Added
 
 - **`packages/arima` 0.4.0 — a linear drift among the regressors**

--- a/stdlib/ext/xml.nu
+++ b/stdlib/ext/xml.nu
@@ -543,6 +543,12 @@ $ `stdlib/core/vec.nu`
                 = cdone T
             } {
                 : __XmlNode nd ( __xml_parse_node src cp n + depth 1 )
+                // A node that is not one (ok ≤ 0) still carries the
+                // placeholder __xml_empty built — two Strings and two
+                // Vecs — and nobody else will free it. Left alone it
+                // leaked once per element: every child loop ends on a
+                // `</` that comes back as an empty node.
+                ? <= . nd ok 0 { ( xml_free . nd node ) } {}
                 ? < . nd ok 0 {
                     = cerr T
                     = cdone T


### PR DESCRIPTION
## Summary

ASan on the anomaly package's sources suite reported ~790 leaked allocations, most of them from `__xml_parse_element`/`__xml_parse_node`. Every element's child loop ends on a `</`, which `__xml_parse_node` answers with `ok = 0` and an `__xml_empty` placeholder — two Strings and two Vecs — that the element parser read the flag from and dropped. The same for the error return (`ok < 0`). Once per element, for every WFS response the anomaly source scheduler fetches, forever.

The placeholder is freed where the flag is read.

## Evidence

- An ASan probe parsing the anomaly package's two WFS fixtures three times with `xml_parse` + `xml_free`: 396 leaked allocations before, none after.
- The anomaly sources suite under ASan: 790 leaked allocations → 316, all of the remainder in `source_update` (fixed separately in #1097).
- Compiler corpus 943/943 against the fixed stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn9aEWGTskWRRjmfWk9CDb
