### PR TITLE
the package version gate could not see a constant

### DIFF
--- a/packages/anomaly/src/mcp.nu
+++ b/packages/anomaly/src/mcp.nu
@@ -39,7 +39,7 @@ $ `src/authz.nu`
 $ `src/imptime.nu`
 
 // One version for the CLI banner and the MCP handshake.
-: s ANOMALY_VERSION `0.31.0`
+: s ANOMALY_VERSION `0.32.0`
 
 // ── Wiring ───────────────────────────────────────────────────────────
 

--- a/tools/check_package_version_strings.sh
+++ b/tools/check_package_version_strings.sh
@@ -32,6 +32,10 @@ for toml in packages/*/nurl.toml; do
     manifest=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
     [ -n "$manifest" ] || continue
 
+    # Every source of the package, comments stripped, for the rules that
+    # must look past the file a literal happens to sit in.
+    pkgsrc=$(sed 's://.*::' packages/"$pkg"/src/*.nu 2>/dev/null || true)
+
     for src in packages/"$pkg"/src/*.nu; do
         [ -e "$src" ] || continue
         # Strip `//` comments, then find `cli_new … `X.Y.Z``.
@@ -85,8 +89,10 @@ for toml in packages/*/nurl.toml; do
         stripped=$(sed 's://.*::' "$src")
         while IFS='|' read -r fn lit; do
             [ -n "$fn" ] || continue
-            printf '%s\n' "$stripped" \
-                | grep -q "\`$pkg\`.*( *$fn *)" || continue
+            # A here-string, not a pipe — see the constant rule below for
+            # why a `grep -q` at the end of a pipeline can make this gate
+            # skip the check it just passed.
+            grep -q "\`$pkg\`.*( *$fn *)" <<<"$stripped" || continue
             checked=$((checked + 1))
             if [ "$lit" != "$manifest" ]; then
                 echo "MISMATCH: $pkg — nurl.toml says '$manifest' but $src returns '$lit' from $fn"
@@ -95,6 +101,34 @@ for toml in packages/*/nurl.toml; do
         done < <(printf '%s\n' "$stripped" \
                  | grep -oE '@ [A-Za-z_][A-Za-z0-9_]* → s \{ \^ `[0-9]+\.[0-9]+\.[0-9]+` \}' \
                  | sed -E 's/@ ([A-Za-z_][A-Za-z0-9_]*) → s \{ \^ `([0-9]+\.[0-9]+\.[0-9]+)` \}/\1|\2/')
+
+        # …and a FOURTH spelling, which is the third one without the
+        # function: a top-level CONSTANT, `: s ANOMALY_VERSION `0.31.0``,
+        # named at the call site instead of a literal. Every rule above
+        # reads the call site, and a call site that names a constant hides
+        # the number from all of them — so anomaly 0.32.0 published a
+        # `--version` and an MCP `initialize` reply that both said 0.31.0,
+        # through a gate written twice over to stop exactly this. Resolved
+        # like the accessor and keyed the same way (the package's own name
+        # beside the constant at a call site), but searched over the whole
+        # package: the constant and the call that uses it need not share a
+        # file, and in anomaly they do not.
+        # A here-string, not a pipe: under `set -o pipefail` a `grep -q`
+        # that matches early closes the pipe, the writer takes SIGPIPE,
+        # the PIPELINE reports failure — and `|| continue` then skips the
+        # very check that just succeeded. This gate is silent when it is
+        # wrong, so it must not have a way to be silently right either.
+        while IFS='|' read -r cname lit; do
+            [ -n "$cname" ] || continue
+            grep -q "\`$pkg\`.*\b$cname\b" <<<"$pkgsrc" || continue
+            checked=$((checked + 1))
+            if [ "$lit" != "$manifest" ]; then
+                echo "MISMATCH: $pkg — nurl.toml says '$manifest' but $src binds $cname = '$lit'"
+                fail=1
+            fi
+        done < <(printf '%s\n' "$stripped" \
+                 | grep -oE '^: s [A-Za-z_][A-Za-z0-9_]* `[0-9]+\.[0-9]+\.[0-9]+`' \
+                 | sed -E 's/^: s ([A-Za-z_][A-Za-z0-9_]*) `([0-9]+\.[0-9]+\.[0-9]+)`/\1|\2/')
     done
 done
 


### PR DESCRIPTION
`anomaly --version` and the MCP `initialize` reply both said **0.31.0** in the 0.32.0 release. The number lives in one constant, `ANOMALY_VERSION`, and the manifest bump did not reach it. Found the only way it can be found without a gate: by installing the published package and running the binary.

## The gate had a fourth blind spot

`tools/check_package_version_strings.sh` exists to stop exactly this, and has been extended twice already — once for a literal hidden behind a parenthesis in an about-string (yoloe shipped 0.6.6 announcing 0.6.0), once for one behind a function accessor (swarm-mcp and nurl-mcp both drifted). It could not see a **constant**: every rule reads the *call site*, and a call site that names a constant hides the number from all of them.

```
: s ANOMALY_VERSION `0.31.0`
…
( cli_new `anomaly` `…` ANOMALY_VERSION )
( mcp_server_new `anomaly` ANOMALY_VERSION )
```

Resolved now, keyed the way the accessor rule is keyed — the package's own name beside it at a call site, which is what keeps a genuine version *of something else* out of it — and searched across the whole package rather than one file: the constant and the call that uses it need not share a file, and in anomaly they do not.

## And a way to be silently right

```sh
sed 's://.*::' packages/\"\$pkg\"/src/*.nu | grep -q \"…\" || continue
```

Under \`set -o pipefail\` a \`grep -q\` that matches exits at once, the writer takes SIGPIPE, the **pipeline** reports failure, and \`|| continue\` then skips the check that had just succeeded. Both call-site rules now use a here-string.

That silence was live, not hypothetical: the run that first caught the anomaly mismatch counted one *fewer* literal than the run before it. A gate that is silent when it is wrong must not also have a way to be silent when it is right.

## No release here

The constant is brought back in step with the manifest it is published under (0.32.0). The published 0.32.0 keeps reporting 0.31.0 — a version can be yanked, never replaced — and the next release is where it comes right, now under a gate that can see it.

## Testing

- The gate reports the mismatch on the unfixed tree, and `OK — 17 hand-written --version literal(s)` on this one (15 before; the two new ones are the constant and a call-site check the pipefail bug had been skipping).
- `mcp_test: 226 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn9aEWGTskWRRjmfWk9CDb