### PR TITLE
Flood to the ceiling, not past it: the Windows h2 test race

### DIFF
--- a/compiler/tests/http2_continuation_flood.nu
+++ b/compiler/tests/http2_continuation_flood.nu
@@ -9,8 +9,24 @@
 // it the server raises a connection error → GOAWAY + close.
 //
 // We craft the raw frames with h2_write_frame and assert the server
-// answers the flood with a GOAWAY (or closes) rather than swallowing an
-// unbounded block. main returns the failure count.
+// answers the flood with a GOAWAY rather than swallowing an unbounded
+// block. main returns the failure count.
+//
+// Two things this test used to be loose about, both fixed 2026-09-12:
+//
+//   * it accepted a read FAILURE as "defended", so a regression that
+//     dropped the connection without ever sending a GOAWAY would have
+//     passed. A dropped connection is now a failure with its own name.
+//   * it sent one CONTINUATION more than the ceiling needs. The server
+//     stops reading the moment the block is over budget, so the surplus
+//     frame stayed unread in its receive queue — and a close over unread
+//     data is a TCP RESET, not a FIN. Linux still hands the application
+//     the bytes queued ahead of that reset, Winsock throws them away;
+//     that is exactly what made http2_flood_budget.nu flaky on Windows
+//     CI, and only the lenient assertion above kept it from surfacing
+//     here too. The flood now stops at the first frame that crosses the
+//     ceiling, taken from the stdlib constant, and the clean EOF that
+//     proves nothing was left behind is asserted rather than assumed.
 // requires: live
 
 $ `stdlib/std/net.nu`
@@ -76,36 +92,75 @@ $ `stdlib/ext/http2_server.nu`
                 // Client SETTINGS (empty) — required first frame (§3.4).
                 : b _s ( wf conn ( h2_type_settings ) 0 0 ( vec_new [u] ) )
                 // HEADERS on stream 1, NO END_HEADERS → opens an
-                // accumulation the CONTINUATION flood feeds.
-                : b _h ( wf conn ( h2_type_headers ) 0 1 ( filler 16000 ) )
-                // 5 × 16000 + 16000 = 96 KiB > the 64 KiB cap.
-                : ~ i c 0
+                // accumulation the CONTINUATION flood feeds. Keep adding
+                // 16000-byte CONTINUATIONs until the accumulated block is
+                // over the ceiling — and then stop, so every byte written
+                // is a byte the server reads before it bails.
+                : i chunk 16000
+                : i cap ( _h2_max_header_block_bytes )
+                : b _h ( wf conn ( h2_type_headers ) 0 1 ( filler chunk ) )
+                : ~ i acc chunk
                 : ~ b wok T
-                ~ & wok < c 5 {
-                    = wok ( wf conn ( h2_type_continuation ) 0 1 ( filler 16000 ) )
-                    = c + c 1
+                ~ & wok <= acc cap {
+                    = wok ( wf conn ( h2_type_continuation ) 0 1 ( filler chunk ) )
+                    = acc + acc chunk
                 }
-                // The server must answer with GOAWAY (or close) — it must
-                // NOT keep accepting an unbounded block. Read frames,
-                // skipping the server's own SETTINGS etc., until GOAWAY or
-                // the connection drops.
+                ? wok {} {
+                    ( nurl_print `  FAIL CONTINUATION write failed mid-flood\n` )
+                    = fails + fails 1
+                }
+                // The server must answer with a GOAWAY — dropping the
+                // connection silently is NOT a defence, it is the outcome
+                // a crash would produce too. Read frames, skipping the
+                // server's own SETTINGS etc., until the GOAWAY arrives.
                 : ~ b defended F
+                : ~ b dead F
                 : ~ i reads 0
-                ~ & ! defended < reads 20 {
+                ~ & ! defended & ! dead < reads 20 {
                     : !H2Frame H2FrameErr rr ( h2_read_frame conn 16384 )
                     ?? rr {
                         T fr → {
                             ? == . fr frame_type ( h2_type_goaway ) { = defended T } {}
                             ( h2_frame_free fr )
                         }
-                        F _ → { = defended T }
+                        F fe → {
+                            ( nurl_print `  FAIL connection dropped without GOAWAY: ` )
+                            ( nurl_print ( h2_frame_err_name fe ) )
+                            ( nurl_print `\n` )
+                            = dead T
+                        }
                     }
                     = reads + reads 1
                 }
-                ? defended {} {
-                    ( nurl_print `  FAIL no GOAWAY/close on CONTINUATION flood\n` )
+                ? dead { = fails + fails 1 } {}
+                ? | defended dead {} {
+                    ( nurl_print `  FAIL no GOAWAY on CONTINUATION flood\n` )
                     = fails + fails 1
                 }
+                // Nothing was left unread, so the peer's close must reach
+                // us as a clean end-of-stream. A reset here would mean the
+                // flood overshot again (see the header).
+                ? defended {
+                    : !H2Frame H2FrameErr er ( h2_read_frame conn 16384 )
+                    ?? er {
+                        T fr2 → {
+                            ( nurl_print `  FAIL frame after GOAWAY where EOF was due\n` )
+                            ( h2_frame_free fr2 )
+                            = fails + fails 1
+                        }
+                        F fe2 → {
+                            ?? fe2 {
+                                H2FrameReadShort → {}
+                                _ → {
+                                    ( nurl_print `  FAIL close was a RESET, not a FIN: ` )
+                                    ( nurl_print ( h2_frame_err_name fe2 ) )
+                                    ( nurl_print `\n` )
+                                    = fails + fails 1
+                                }
+                            }
+                        }
+                    }
+                } {}
                 ( tcp_close_conn conn )
             }
             : i _sj ?? st { T th → ( thread_join th ) F _ → 0 }

--- a/compiler/tests/http2_flood_budget.nu
+++ b/compiler/tests/http2_flood_budget.nu
@@ -9,14 +9,41 @@
 //
 // Now three per-connection counters (streams_opened, peer_resets,
 // idle_frames) each have an absolute ceiling; crossing one is answered
-// with GOAWAY(ENHANCE_YOUR_CALM). This test opens one stream and then
-// floods RST_STREAM on it past __h2_max_resets (1000); the server must
-// respond with a GOAWAY carrying error code 11 (ENHANCE_YOUR_CALM).
+// with GOAWAY(ENHANCE_YOUR_CALM). This test opens one stream and drives
+// the reset counter to the ceiling and then one past it:
+//
+//   phase 1 — exactly `_h2_max_resets` RST_STREAMs, then a PING. The
+//             PING ACK proves the connection is still being served, so
+//             the ceiling is not tripped EARLY.
+//   phase 2 — one more RST_STREAM. The server must answer with GOAWAY
+//             carrying error code 11 (ENHANCE_YOUR_CALM).
+//
+// Why exactly the ceiling, and not "some number comfortably past it"
+// (this test flooded 1100 before 2026-09-12): the client must not leave
+// bytes the server will never read. The server stops reading the instant
+// the budget trips, so an overshooting client's surplus frames sit
+// unread in the server's receive queue — and closing a socket with
+// unread data is a TCP RESET, not a FIN. Linux hands an application the
+// bytes already queued before it reports that reset, so the overshooting
+// client here still read its GOAWAY; Winsock discards them and fails the
+// recv outright. That is the shape of the flakiness this test carried on
+// Windows — ten of the last eighty-seven windows-tests runs red, every
+// one of them this test, every one of them "FAIL no GOAWAY on RST
+// flood", every re-run green.
+//
+// Sending exactly what the server will consume makes the close a FIN on
+// every platform, and a FIN never destroys data already in flight. The
+// count comes from the stdlib ceiling itself (`_h2_max_resets`) so the
+// two can never drift apart. The FIN is asserted, not assumed, at the
+// end of the run; and every other exit names its own step, so if the
+// diagnosis above were wrong the next failure would say which step
+// actually broke instead of blaming the GOAWAY.
 // requires: live
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_frame.nu`
@@ -58,6 +85,161 @@ $ `stdlib/ext/http2_server.nu`
     ^ p
 }
 
+// PING opaque data — exactly 8 bytes (§6.7); the server echoes it back.
+@ ping_payload → ( Vec u ) {
+    : ( Vec u ) p ( vec_new [u] )
+    : ~ i k 0
+    ~ < k 8 {
+        ( vec_push [u] p # u 0x5a )
+        = k + k 1
+    }
+    ^ p
+}
+
+// Read the 32-bit error code out of a GOAWAY payload (last_stream_id
+// then error_code, §6.8); -1 when the payload is too short to carry one.
+@ goaway_code ( Vec u ) pl → i {
+    ? < ( vec_len [u] pl ) 8 { ^ - 0 1 } {}
+    : *u pp ( vec_data [u] pl )
+    ^ + + + << & 255 # i . pp 4 24 << & 255 # i . pp 5 16 << & 255 # i . pp 6 8 & 255 # i . pp 7
+}
+
+// Drive the flood on an already-connected socket. Returns the number of
+// failures, having printed which step failed and why — every exit names
+// itself, so a broken budget is never reported as a lost frame and a
+// lost frame is never reported as a broken budget.
+@ flood_client TcpConn conn → i {
+    : ~ i fails 0
+    : !v H2FrameErr pf ( h2_write_preface conn )
+    ?? pf { T _ → {} F _ → {} }
+    : b _s ( wf conn ( h2_type_settings ) 0 0 ( vec_new [u] ) )
+    // Open stream 1 (END_STREAM | END_HEADERS) so RST on it is a valid,
+    // silently-ignored frame — one that still counts toward the budget.
+    : b _h ( wf conn ( h2_type_headers ) 5 1 ( req_headers ) )
+
+    : i budget ( _h2_max_resets )
+    // ── Phase 1: resets UP TO the ceiling must not trip it ──────────
+    : ~ i c 0
+    : ~ i badwrite - 0 1
+    ~ & < badwrite 0 < c budget {
+        ? ( wf conn ( h2_type_rst_stream ) 0 1 ( rst_payload ) ) {} { = badwrite c }
+        = c + c 1
+    }
+    ? >= badwrite 0 {
+        ( nurl_print `  FAIL RST_STREAM write failed at ` )
+        ( nurl_print ( nurl_str_int badwrite ) )
+        ( nurl_print `\n` )
+        ^ + fails 1
+    } {}
+    ? ( wf conn ( h2_type_ping ) 0 0 ( ping_payload ) ) {} {
+        ( nurl_print `  FAIL PING write failed\n` )
+        ^ + fails 1
+    }
+    : ~ b alive F
+    : ~ b sank F
+    : ~ i reads 0
+    ~ & ! alive & ! sank < reads 40 {
+        : !H2Frame H2FrameErr rr ( h2_read_frame conn 16384 )
+        ?? rr {
+            T fr → {
+                ? == . fr frame_type ( h2_type_ping ) {
+                    ? != 0 & . fr flags ( h2_flag_ack ) { = alive T } {}
+                } {}
+                ? == . fr frame_type ( h2_type_goaway ) {
+                    ( nurl_print `  FAIL budget tripped EARLY, at or below ` )
+                    ( nurl_print ( nurl_str_int budget ) )
+                    ( nurl_print ` resets\n` )
+                    = sank T
+                } {}
+                ( h2_frame_free fr )
+            }
+            F fe → {
+                ( nurl_print `  FAIL no PING ACK below the ceiling: ` )
+                ( nurl_print ( h2_frame_err_name fe ) )
+                ( nurl_print `\n` )
+                = sank T
+            }
+        }
+        = reads + reads 1
+    }
+    ? sank { ^ + fails 1 } {}
+    ? ! alive {
+        ( nurl_print `  FAIL no PING ACK below the ceiling: 40 frames read\n` )
+        ^ + fails 1
+    } {}
+    ( nurl_print `budget holds to the ceiling: PING ACK\n` )
+
+    // ── Phase 2: one more reset CROSSES it ──────────────────────────
+    ? ( wf conn ( h2_type_rst_stream ) 0 1 ( rst_payload ) ) {} {
+        ( nurl_print `  FAIL ceiling-crossing RST_STREAM write failed\n` )
+        ^ + fails 1
+    }
+    : ~ b calmed F
+    : ~ b stop F
+    : ~ i reads2 0
+    ~ & ! calmed & ! stop < reads2 40 {
+        : !H2Frame H2FrameErr rr ( h2_read_frame conn 16384 )
+        ?? rr {
+            T fr → {
+                ? == . fr frame_type ( h2_type_goaway ) {
+                    : i code ( goaway_code . fr payload )
+                    ? == code 11 {
+                        = calmed T
+                    } {
+                        ( nurl_print `  FAIL GOAWAY error code ` )
+                        ( nurl_print ( nurl_str_int code ) )
+                        ( nurl_print ` not 11 (ENHANCE_YOUR_CALM)\n` )
+                        = stop T
+                    }
+                } {}
+                ( h2_frame_free fr )
+            }
+            F fe → {
+                ( nurl_print `  FAIL connection died before GOAWAY: ` )
+                ( nurl_print ( h2_frame_err_name fe ) )
+                ( nurl_print `\n` )
+                = stop T
+            }
+        }
+        = reads2 + reads2 1
+    }
+    ? stop { ^ + fails 1 } {}
+    ? ! calmed {
+        ( nurl_print `  FAIL no GOAWAY on RST flood\n` )
+        ^ + fails 1
+    } {}
+    // ── The close must be a FIN, not a RESET ────────────────────────
+    // This is the invariant the whole shape of the test rests on, so
+    // assert it rather than assume it: one more read has to end in a
+    // CLEAN end-of-stream. A reset surfaces as H2FrameReadIo instead,
+    // and a reset is what discards the GOAWAY on Winsock — so if a
+    // future edit starts overshooting the ceiling again, this line
+    // fails on Linux too, where the flakiness would otherwise be
+    // invisible.
+    : !H2Frame H2FrameErr er ( h2_read_frame conn 16384 )
+    ?? er {
+        T fr2 → {
+            ( nurl_print `  FAIL frame after GOAWAY where EOF was due\n` )
+            ( h2_frame_free fr2 )
+            = fails + fails 1
+        }
+        F fe2 → {
+            ?? fe2 {
+                H2FrameReadShort → {
+                    ( nurl_print `rapid-reset defended: GOAWAY ENHANCE_YOUR_CALM\n` )
+                }
+                _ → {
+                    ( nurl_print `  FAIL close was a RESET, not a FIN: ` )
+                    ( nurl_print ( h2_frame_err_name fe2 ) )
+                    ( nurl_print `\n` )
+                    = fails + fails 1
+                }
+            }
+        }
+    }
+    ^ fails
+}
+
 @ run → i {
     : ~ i fails 0
     : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18831 )
@@ -83,53 +265,7 @@ $ `stdlib/ext/http2_server.nu`
             } {
                 : TcpConn conn @ TcpConn { # s craw }
                 ( tcp_set_timeout conn 3000 )
-                : !v H2FrameErr pf ( h2_write_preface conn )
-                ?? pf { T _ → {} F _ → {} }
-                : b _s ( wf conn ( h2_type_settings ) 0 0 ( vec_new [u] ) )
-                // Open stream 1 (END_STREAM | END_HEADERS) so RST on it is
-                // a valid, silently-ignored frame — one that still counts
-                // toward the reset budget.
-                : b _h ( wf conn ( h2_type_headers ) 5 1 ( req_headers ) )
-                // Flood RST_STREAM on stream 1 past __h2_max_resets (1000).
-                : ~ i c 0
-                : ~ b wok T
-                ~ & wok < c 1100 {
-                    = wok ( wf conn ( h2_type_rst_stream ) 0 1 ( rst_payload ) )
-                    = c + c 1
-                }
-                // The server must GOAWAY with ENHANCE_YOUR_CALM (code 11).
-                : ~ b calmed F
-                : ~ b sawgoaway F
-                : ~ i reads 0
-                ~ & ! calmed < reads 40 {
-                    : !H2Frame H2FrameErr rr ( h2_read_frame conn 16384 )
-                    ?? rr {
-                        T fr → {
-                            ? == . fr frame_type ( h2_type_goaway ) {
-                                = sawgoaway T
-                                : ( Vec u ) pl . fr payload
-                                ? >= ( vec_len [u] pl ) 8 {
-                                    : *u pp ( vec_data [u] pl )
-                                    : i code + + + << & 255 # i . pp 4 24 << & 255 # i . pp 5 16 << & 255 # i . pp 6 8 & 255 # i . pp 7
-                                    ? == code 11 { = calmed T } {}
-                                } {}
-                            } {}
-                            ( h2_frame_free fr )
-                        }
-                        F _ → { = reads 40 }
-                    }
-                    = reads + reads 1
-                }
-                ? calmed {
-                    ( nurl_print `rapid-reset defended: GOAWAY ENHANCE_YOUR_CALM\n` )
-                } {
-                    ? sawgoaway {
-                        ( nurl_print `  FAIL GOAWAY but not ENHANCE_YOUR_CALM\n` )
-                    } {
-                        ( nurl_print `  FAIL no GOAWAY on RST flood\n` )
-                    }
-                    = fails + fails 1
-                }
+                = fails + fails ( flood_client conn )
                 ( tcp_close_conn conn )
             }
             : i _sj ?? st { T th → ( thread_join th ) F _ → 0 }

--- a/compiler/tests/outputs/http2_flood_budget.txt
+++ b/compiler/tests/outputs/http2_flood_budget.txt
@@ -2,4 +2,5 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
+budget holds to the ceiling: PING ACK
 rapid-reset defended: GOAWAY ENHANCE_YOUR_CALM

--- a/stdlib/ext/http2_conn.nu
+++ b/stdlib/ext/http2_conn.nu
@@ -547,7 +547,12 @@ $ `stdlib/ext/http2_hpack.nu`
 // unbounded CONTINUATION frames, growing `header_block` without limit
 // (the CONTINUATION-flood DoS, CVE-2024-27316 class). 64 KiB of ENCODED
 // header bytes is far beyond any legitimate request yet bounds memory.
-@ __h2_max_header_block_bytes → i { ^ 65536 }
+//
+// ONE underscore, for the same reason as _h2_max_resets: compiler/tests/
+// http2_continuation_flood.nu reads the ceiling so it can flood to
+// exactly it, leaving the server no unread bytes to abort the connection
+// over.
+@ _h2_max_header_block_bytes → i { ^ 65536 }
 
 // Hard cap on the accumulated DATA body per stream. HTTP/2 receive flow
 // control (the recv_window enforcement below) bounds the IN-FLIGHT unacked
@@ -570,7 +575,14 @@ $ `stdlib/ext/http2_hpack.nu`
 // we treat the peer as launching a reset flood. Legitimate cancellation
 // is rare; a client that resets 1 000 streams on one connection is
 // abusive regardless of whether each was dispatched.
-@ __h2_max_resets → i { ^ 1000 }
+//
+// ONE underscore, unlike its two neighbours: compiler/tests/
+// http2_flood_budget.nu reads the ceiling instead of restating it, so
+// the regression test floods to exactly this boundary rather than to a
+// hand-picked number that has to be kept in step by hand. A `__` name
+// stops resolving across files, so the shared ones are spelled `_`
+// (same reason as _h2_prune_closed, which http2_stream_prune.nu calls).
+@ _h2_max_resets → i { ^ 1000 }
 // No-progress frames (PING / SETTINGS / PRIORITY / WINDOW_UPDATE / empty
 // DATA / unknown / surplus CONTINUATION) tolerated between two moments of
 // real request progress. Reset to zero whenever a stream is opened or a
@@ -1272,7 +1284,7 @@ $ `stdlib/ext/http2_hpack.nu`
                 ? == ft ( h2_type_rst_stream ) {
                     = . cur peer_resets + . cur peer_resets 1
                 } {}
-                ? & ok | > . cur idle_frames ( __h2_max_idle_frames ) > . cur peer_resets ( __h2_max_resets ) {
+                ? & ok | > . cur idle_frames ( __h2_max_idle_frames ) > . cur peer_resets ( _h2_max_resets ) {
                     = err H2ConnEnhanceCalm = ok F
                 } {}
 
@@ -1518,7 +1530,7 @@ $ `stdlib/ext/http2_hpack.nu`
                                     // peer that keeps offering streams past
                                     // the cap is a flood, not a client.
                                     = . cur peer_resets + . cur peer_resets 1
-                                    ? > . cur peer_resets ( __h2_max_resets ) {
+                                    ? > . cur peer_resets ( _h2_max_resets ) {
                                         = err H2ConnEnhanceCalm = ok F
                                     } {}
                                 } {
@@ -1531,7 +1543,7 @@ $ `stdlib/ext/http2_hpack.nu`
                                         T hb → {
                                             ( vec_extend [u] . new_s header_block hb )
                                             ( vec_free [u] hb )
-                                            ? > ( vec_len [u] . new_s header_block ) ( __h2_max_header_block_bytes ) {
+                                            ? > ( vec_len [u] . new_s header_block ) ( _h2_max_header_block_bytes ) {
                                                 = err H2ConnProtocol = ok F
                                             } {}
                                             = . new_s state ( h2_state_open )
@@ -1605,8 +1617,8 @@ $ `stdlib/ext/http2_hpack.nu`
                                 ( vec_extend [u] . s header_block . frame payload )
                                 // CONTINUATION-flood guard: bound the total
                                 // accumulated header block (see
-                                // __h2_max_header_block_bytes).
-                                ? > ( vec_len [u] . s header_block ) ( __h2_max_header_block_bytes ) {
+                                // _h2_max_header_block_bytes).
+                                ? > ( vec_len [u] . s header_block ) ( _h2_max_header_block_bytes ) {
                                     = err H2ConnProtocol = ok F
                                 } {}
                                 ? != 0 & . frame flags ( h2_flag_end_headers ) {


### PR DESCRIPTION
Ten of the last eighty-seven `windows-tests` runs were red, every one of them the same line:

```
--- http2_flood_budget ---
+   FAIL no GOAWAY on RST flood
```

and every re-run was green.

## The cause is not scheduling noise

`http2_flood_budget` floods 1100 RST_STREAMs at a ceiling of 1000. The server stops reading the instant the ceiling trips — at 1001 — so the surplus ~99 frames stay unread in its receive queue, and **closing a socket over unread data is a TCP RESET, not a FIN**. Linux still hands the application the bytes queued ahead of that reset, so the client read its GOAWAY anyway; Winsock discards them and fails the `recv` outright. That is the whole race: the client's `recv` against the server's RST, lost about one run in nine, and only on Windows.

Confirmed locally that the server really does close while the peer is still writing — with the flood widened to 20000 frames the client's writes die at 2441.

## The fix is to stop overshooting

**`http2_flood_budget`** now drives the counter in two phases:

- phase 1 — exactly `_h2_max_resets` resets, then a PING. The PING ACK proves the ceiling did not trip *early*, which the test never checked before.
- phase 2 — one more reset, requiring `GOAWAY(ENHANCE_YOUR_CALM)`.

The count is read from the stdlib constant, so test and ceiling cannot drift apart. The FIN is **asserted, not assumed**: one more read after the GOAWAY has to end in a clean EOF, so a future edit that starts overshooting again fails on Linux too — where the flakiness would otherwise be invisible. And every exit names its own step; `no GOAWAY` used to absorb a write failure, a read failure and a wrong error code alike, which is why the CI logs could never say which one it was.

**`http2_continuation_flood`** carried the same violation and hid it: it overshot by one CONTINUATION and then counted a read *failure* as `defended`, so a regression that dropped the connection without ever sending a GOAWAY would have passed. It now floods to the first frame that crosses `_h2_max_header_block_bytes` and stops, demands a real GOAWAY, and asserts the same clean EOF.

Both ceilings lose an underscore (`__h2_max_resets` → `_h2_max_resets`, `__h2_max_header_block_bytes` → `_h2_max_header_block_bytes`): a `__` name stops resolving across files, and these are now read by their tests.

## Mutation-checked — "never fails when fine" is only half of it

| mutation | before | after |
| --- | --- | --- |
| GOAWAY suppressed | `continuation_flood` **passed** | `FAIL connection dropped without GOAWAY: H2FrameReadShort` |
| reset counter frozen | — | `FAIL connection died before GOAWAY: H2FrameReadIo` (3.2 s) |
| wrong GOAWAY error code | — | `FAIL GOAWAY error code 1 not 11 (ENHANCE_YOUR_CALM)` |

Full corpus 992/992, 25 repeats of each test, 40 repeats under 12 competing CPU hogs, and the sanitized run clean (0 SAN_FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g5UXhMGuUv7dyRnaD8D7r