### PR TITLE
Six more of the same shape: a check the other spelling never got

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -96,9 +96,19 @@ jobs:
             libzstd-dev
 
       - name: Install Rust (stable, minimal profile)
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Record toolchain versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,15 @@ jobs:
         # kept handing out the destructive version.
         run: ./tools/check_installer_sync.sh
 
+      - name: Downloaded tools are pinned by content
+        # A version-pinned URL says what was asked for, not what came back.
+        # The release job unpacks a downloaded zig INTO the published archive,
+        # so those bytes reach users; two benchmark jobs took their reference
+        # runtime from `curl … | bash`, which can change between runs of a
+        # number we publish. Every such download now carries a checksum, and
+        # this keeps the next one from arriving without.
+        run: python3 tools/check_pinned_downloads.py
+
       - name: Windows goldens not stale (they are checked on main, not per-PR)
         # outputs-windows/ is a parallel corpus and windows-tests.yml runs
         # on pushes to main, so a PR that adds assertions updates outputs/
@@ -520,9 +529,10 @@ jobs:
         # image. Whether it actually boots depends on the runner having
         # /dev/kvm; the gate reports which half it ran.
         run: |
-          sudo curl -fsSL --retry 5 -o /usr/local/bin/cloud-hypervisor \
+          curl -fsSL --retry 5 -o /tmp/cloud-hypervisor \
             https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v46.0/cloud-hypervisor-static
-          sudo chmod +x /usr/local/bin/cloud-hypervisor
+          echo "00b5cf2976847d2f21d2b7266038c8fc40bd14f2a542115055e9e214867edc9e  /tmp/cloud-hypervisor" | sha256sum -c -
+          sudo install -m755 /tmp/cloud-hypervisor /usr/local/bin/cloud-hypervisor
           # The runner HAS /dev/kvm and denies the job user access to it
           # (group kvm). Granting it turns the gate's boot half from a
           # skip into a real boot on a real hypervisor — which is the

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -117,12 +117,27 @@ jobs:
         # needed (same recipe release.yml uses for the bundled backend).
         run: |
           ZIG_VER=0.16.0
+          ZIG_SHA=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
           curl -fsSL "https://ziglang.org/download/${ZIG_VER}/zig-x86_64-linux-${ZIG_VER}.tar.xz" -o /tmp/zig.tar.xz
+          echo "$ZIG_SHA  /tmp/zig.tar.xz" | sha256sum -c -
           mkdir -p "$HOME/zig-toolchain"
           tar -xf /tmp/zig.tar.xz -C "$HOME/zig-toolchain" --strip-components=1
           echo "$HOME/zig-toolchain" >> "$GITHUB_PATH"
           "$HOME/zig-toolchain/zig" version
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          # A pinned, checksum-verified release archive rather than
+          # `curl https://wasmtime.dev/install.sh | bash`: that piped whatever
+          # the script said that day straight into a shell, and installed
+          # whatever version it chose, so a differential leg could change
+          # oracle underneath a campaign without anything in the diff.
+          WASMTIME_VER=v48.0.2
+          WASMTIME_SHA=f2b0ad1ce9253f2f9a38793c2c42cd1cba4e90b27dc40d685eaf723dc8438d94
+          WASMTIME_DIR="wasmtime-${WASMTIME_VER}-x86_64-linux"
+          curl -fsSL --retry 5 -o /tmp/wasmtime.tar.xz \
+            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VER}/${WASMTIME_DIR}.tar.xz"
+          echo "$WASMTIME_SHA  /tmp/wasmtime.tar.xz" | sha256sum -c -
+          mkdir -p "$HOME/.wasmtime/bin"
+          tar -xf /tmp/wasmtime.tar.xz -C /tmp
+          install -m755 "/tmp/${WASMTIME_DIR}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
           "$HOME/.wasmtime/bin/wasmtime" --version
 

--- a/.github/workflows/http-bench.yml
+++ b/.github/workflows/http-bench.yml
@@ -62,9 +62,19 @@ jobs:
         # The Rust peer's TLS path uses tokio-rustls, whose current
         # releases need a recent stable toolchain — rustup stable is well
         # ahead of that floor.
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install oha (load generator)

--- a/.github/workflows/http-torture.yml
+++ b/.github/workflows/http-torture.yml
@@ -79,9 +79,19 @@ jobs:
             libzstd-dev
 
       - name: Install Rust (stable, minimal profile)
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install oha (load generator)

--- a/.github/workflows/http2-bench.yml
+++ b/.github/workflows/http2-bench.yml
@@ -61,9 +61,19 @@ jobs:
             libzstd-dev
 
       - name: Install Rust (stable, minimal profile)
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install oha (load generator)

--- a/.github/workflows/http3-bench.yml
+++ b/.github/workflows/http3-bench.yml
@@ -66,9 +66,19 @@ jobs:
             libzstd-dev
 
       - name: Install Rust (stable, minimal profile)
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build h2load with HTTP/3 (nghttp2 v1.70.0 docker image)

--- a/.github/workflows/pq-bench.yml
+++ b/.github/workflows/pq-bench.yml
@@ -63,9 +63,19 @@ jobs:
       - name: Install Rust (stable, minimal profile)
         # The RustCrypto PQ crates track recent stable; rustup stable is
         # well ahead of their floor.
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Record toolchain versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,16 +136,27 @@ jobs:
       # the box's LLVM version. zig 0.16 ships LLVM 21; keep it >= the clang
       # used above so `zig cc -flto` can read the shipped runtime.o bitcode.
       - name: Fetch bundled zig backend
+        # Pinned by VERSION and by CONTENT. This archive is unpacked into the
+        # published release, so whatever it contains is what users install:
+        # a version-pinned URL alone trusts whatever those bytes are on the
+        # day the release runs. The two digests are ziglang.org's own, from
+        # https://ziglang.org/download/index.json for 0.16.0. Bumping ZIG_VER
+        # without bumping them fails the build, which is the point.
         run: |
           ZIG_VER=0.16.0
           case "${{ matrix.target }}" in
-            linux-x86_64-glibc) ZA=x86_64 ;;
-            linux-arm64-glibc)  ZA=aarch64 ;;
+            linux-x86_64-glibc)
+              ZA=x86_64
+              ZIG_SHA=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00 ;;
+            linux-arm64-glibc)
+              ZA=aarch64
+              ZIG_SHA=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17 ;;
             *) echo "no zig mapping for ${{ matrix.target }}" >&2; exit 1 ;;
           esac
           url="https://ziglang.org/download/${ZIG_VER}/zig-${ZA}-linux-${ZIG_VER}.tar.xz"
           echo "Downloading $url"
           curl -fsSL "$url" -o /tmp/zig.tar.xz
+          echo "$ZIG_SHA  /tmp/zig.tar.xz" | sha256sum -c -
           mkdir -p vendor
           tar -xf /tmp/zig.tar.xz -C vendor
           mv "vendor/zig-${ZA}-linux-${ZIG_VER}" vendor/zig

--- a/.github/workflows/wasm-bench.yml
+++ b/.github/workflows/wasm-bench.yml
@@ -80,9 +80,19 @@ jobs:
         # rustc ships wasm32-wasip1 as a rustup component, not by default;
         # wasmbench.sh refuses to start without it rather than leaving a
         # hole in the table.
+        # rustup-init pinned by version and checksum, from the archive URL —
+        # `curl https://sh.rustup.rs | sh` pipes whatever that endpoint serves
+        # into a shell. The TOOLCHAIN stays `stable` on purpose: the point of
+        # this column is what current stable Rust does, and the version it
+        # resolved to is recorded in the run's toolchain-versions step.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal
+          RUSTUP_VER=1.29.1
+          RUSTUP_SHA=dda7234360b7f578ca8b0ddcb80145646fa61a67c1720a5abc7051b35c9fcb71
+          curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/x86_64-unknown-linux-gnu/rustup-init"
+          echo "$RUSTUP_SHA  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/rustup" target add wasm32-wasip1
 
@@ -99,7 +109,9 @@ jobs:
         # it has to match how the repo builds it everywhere else.
         run: |
           ZIG_VER=0.16.0
+          ZIG_SHA=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
           curl -fsSL "https://ziglang.org/download/${ZIG_VER}/zig-x86_64-linux-${ZIG_VER}.tar.xz" -o /tmp/zig.tar.xz
+          echo "$ZIG_SHA  /tmp/zig.tar.xz" | sha256sum -c -
           mkdir -p "$HOME/zig-toolchain"
           tar -xf /tmp/zig.tar.xz -C "$HOME/zig-toolchain" --strip-components=1
           echo "$HOME/zig-toolchain" >> "$GITHUB_PATH"
@@ -117,8 +129,20 @@ jobs:
         # the very runtime it exists to compare against. It is now installed
         # as `nwasm` and the names cannot collide, but pinning stays — it
         # documents which binary the column measured.
+        #
+        # Pinned by version and checksum, not `curl … | bash`: a benchmark
+        # whose reference runtime can change between runs cannot be compared
+        # across runs, and the number is published.
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          WASMTIME_VER=v48.0.2
+          WASMTIME_SHA=f2b0ad1ce9253f2f9a38793c2c42cd1cba4e90b27dc40d685eaf723dc8438d94
+          WASMTIME_DIR="wasmtime-${WASMTIME_VER}-x86_64-linux"
+          curl -fsSL --retry 5 -o /tmp/wasmtime.tar.xz \
+            "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VER}/${WASMTIME_DIR}.tar.xz"
+          echo "$WASMTIME_SHA  /tmp/wasmtime.tar.xz" | sha256sum -c -
+          mkdir -p "$HOME/.wasmtime/bin"
+          tar -xf /tmp/wasmtime.tar.xz -C /tmp
+          install -m755 "/tmp/${WASMTIME_DIR}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
           echo "WASMTIME=$HOME/.wasmtime/bin/wasmtime" >> "$GITHUB_ENV"
 

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2763,9 +2763,17 @@
 // gen_sizeof: Z type  →  i64 byte size of type.
 // Base types return an immediate constant; struct types use the
 // getelementptr-null trick to let LLVM compute the size at codegen.
-@ gen_sizeof i lex i cg → s {
+@ gen_sizeof i lex i syms i cg → s {
     ( nurl_lex_advance lex )
+    : i __zt_line ( nurl_lex_line lex )
+    : i __zt_col ( nurl_lex_col lex )
     : s lty ( parse_type lex )  // parse_type already returns the LLVM type
+    // Every other type position runs this; `Z` did not. `Z NoSuchType`
+    // reached the getelementptr-null path below and emitted
+    // `getelementptr %NoSuchType, %NoSuchType* null, i64 1` for a type
+    // nothing declares — nurlc exited 0 and clang said "base element of
+    // getelementptr must be sized", about generated IR, not the source.
+    ( check_type_known lex syms lty `a 'Z' size-of type` __zt_line __zt_col )
     // Known-size base types: return string constant directly
     ? ( seq lty `void` ) { ( nurl_set_last_type `i64` ) ^ ( nurl_str_cat `0` `` ) } {}
     ? ( seq lty `i64` ) { ( nurl_set_last_type `i64` ) ^ ( nurl_str_cat `8` `` ) } {}
@@ -3688,7 +3696,7 @@
     ? == tt TT_FLOAT ( gen_float_lit lex )
     ? == tt TT_STR ( gen_str_lit_expr lex syms cg )
     ? == tt TT_BOOL ( gen_bool_lit lex )
-    ? == tt TT_SIZEOF ( gen_sizeof lex cg )
+    ? == tt TT_SIZEOF ( gen_sizeof lex syms cg )
     ? == tt TT_CARET ( gen_ret lex syms cg )
     ? == tt TT_BANG ( gen_unary_not lex syms cg )
     ? == tt TT_QUEST ( gen_cond lex syms cg )
@@ -11875,9 +11883,29 @@
                         ? has_lit { ( die lex ( nurl_str_cat `an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own arm.` `` ) ) } {}
                         ? is_bool_pat { ( die lex ( nurl_str_cat `an or-pattern lists named enum variants; 'T' and 'F' are the option/result arms and there are only two of them, so 'T | F' is the wildcard. Write '_ → body' instead.` `` ) ) } {}
                         : ~ s orr ( nurl_str_cat or_names `` )
+                        // The first name is checked against the enum's own
+                        // variants above. An ALTERNATIVE was not: it fell
+                        // through to the same `load i64, i64* @<name>` for
+                        // a global nothing defines, so nurlc exited 0 and
+                        // clang reported generated IR instead.
+                        : s __or_en ? & > ( nurl_str_len match_type ) 1
+                        == ( nurl_str_get match_type 0 ) 37
+                        ( nurl_str_slice match_type 1 - ( nurl_str_len match_type ) 1 )
+                        ``
+                        : s __or_vl ? != 0 ( nurl_str_len __or_en )
+                        ( nurl_sym_get2 syms __or_en `__variants` )
+                        ``
                         ~ != 0 ( nurl_str_len orr ) {
                             : s vn ( str_first_word orr )
                             = orr ( str_skip_word orr )
+                            ? & != 0 ( nurl_str_len __or_vl )
+                            ! ( str_contains_word __or_vl vn )
+                            { ( die_pos lex pat_line pat_col ( nurl_str_cat4
+                                ( nurl_str_cat3 `'` vn `' is not a variant of enum '` )
+                                ( nurl_str_cat3 __or_en `'. Its variants are: ` __or_vl )
+                                `. An or-pattern's alternatives all belong to the enum being matched — `
+                                `check the spelling, or write '_ → body' for a catch-all.` ) ) }
+                            {}
                             ? ( str_contains_word seen_variants vn )
                             { ( die lex ( nurl_str_cat3 `this or-pattern repeats variant '` vn `' — an or-pattern lists each alternative once, and a repeat is either a typo or a variant the arms above already took. Remove it.` ) ) } {}
                             = seen_variants ? == 0 ( nurl_str_len seen_variants )
@@ -13016,6 +13044,12 @@
     ( nurl_lex_advance lex )
     : s target ? is_break ( nurl_sym_get syms `__loop_exit__` )
     ( nurl_sym_get syms `__loop_check__` )
+    ? & == 0 ( nurl_str_len target )
+    ( seq ( nurl_sym_get g_fn_escapes `__in_defer_body__` ) `1` )
+    { ( die_pos lex jline jcol ? is_break
+        `'break' inside a ';' defer block — the defer chain runs DURING return, after the loop has already exited, so there is no iteration to leave. Move the jump out of the defer, or put the loop it belongs to inside the defer body.`
+        `'continue' inside a ';' defer block — the defer chain runs DURING return, after the loop has already exited, so there is no next iteration. Move the jump out of the defer, or put the loop it belongs to inside the defer body.` ) }
+    {}
     ? == 0 ( nurl_str_len target )
     { ( die_pos lex jline jcol ? is_break
         `'break' outside a loop — there is nothing to leave. It is valid only inside a '~' loop body.`
@@ -13255,7 +13289,21 @@
     ( nurl_sym_def syms `__cur_lbl__` lbody )
     = g_did_ret 0
     ( nurl_sym_set g_fn_escapes `__in_defer_body__` `1` )
+    // The enclosing loop's labels do not reach into this body. The defer
+    // chain runs DURING return, after that loop has already exited, so a
+    // `break`/`continue` here branched BACKWARDS into the exit block —
+    // which then re-entered the defer chain, because the armed flag is
+    // still set. `; { break }` inside a loop compiled, exited 0 and ran
+    // forever. `^` was already rejected for the same reason; these are
+    // the other two block terminators. A loop written INSIDE the defer
+    // body redefines both labels, so its own break still works.
+    : s old_df_exit ( nurl_sym_get syms `__loop_exit__` )
+    : s old_df_check ( nurl_sym_get syms `__loop_check__` )
+    ( nurl_sym_def syms `__loop_exit__` `` )
+    ( nurl_sym_def syms `__loop_check__` `` )
     ( gen_block_stmts lex syms cg )
+    ( nurl_sym_def syms `__loop_exit__` old_df_exit )
+    ( nurl_sym_def syms `__loop_check__` old_df_check )
     ( nurl_sym_set g_fn_escapes `__in_defer_body__` `` )
     // After the defer block: chain to previous defer or to fn_cleanup
     : s lnext ? != 0 ( nurl_str_len prev_top ) prev_top ( nurl_sym_get syms `__fn_cleanup__` )
@@ -23720,8 +23768,26 @@
     // several lines and a diagnostic inside an instantiation must keep
     // pointing at the template's real lines.
     : ~ s src ( nurl_str_cat `` `` )
+    // Where the SIGNATURE ends, found first with a lexer-only walk and then
+    // used as the collection loop's stop. The old rule was "collect until the
+    // next '{' anywhere", which is not the same thing: a template whose body
+    // brace was missing — `@ f [T: Send] T x → i  ^ 0 }` — collected the NEXT
+    // declaration's '{' as its own body opener and swallowed that declaration
+    // whole. nurlc exited 0, emitted no `main`, and printed nothing at all.
+    // Found by the token-deletion sweep. The concrete path has always
+    // required the brace; this is the same rule for a template.
+    : i __gc_sig_start ( nurl_lex_cur_start lex )
+    ~ & & != ( nurl_lex_type lex ) TT_ARROW != ( nurl_lex_type lex ) TT_LBRACE
+    != ( nurl_lex_type lex ) TT_EOF {
+        ( nurl_lex_advance lex )
+    }
+    ? == ( nurl_lex_type lex ) TT_ARROW
+    { ( nurl_lex_advance lex ) ( skip_one_type lex ) }
+    {}
+    : i __gc_sig_end ( nurl_lex_cur_start lex )
+    ( nurl_lex_set_pos lex __gc_sig_start )
     : ~ i __gc_prev_ln ( nurl_lex_line lex )
-    ~ & != ( nurl_lex_type lex ) TT_LBRACE != ( nurl_lex_type lex ) TT_EOF {
+    ~ & < ( nurl_lex_cur_start lex ) __gc_sig_end != ( nurl_lex_type lex ) TT_EOF {
         : i __gc_ln ( nurl_lex_line lex )
         ~ < __gc_prev_ln __gc_ln {
             = src ( nurl_str_cat src `\n` )
@@ -23730,6 +23796,11 @@
         = src ( nurl_str_cat src ( nurl_str_cat ( __tok_src_text lex ) ` ` ) )
         ( nurl_lex_advance lex )
     }
+    ? != ( nurl_lex_type lex ) TT_LBRACE
+    { ( die lex ( nurl_str_cat3
+        `expected '{' to open the body of generic function '` fname
+        ( nurl_str_cat3 `', found ` ( tok_here lex ) `. A generic is declared '@ name [T] params → ret { body }' — the brace follows the return type. A template with no body cannot be instantiated.` ) ) ) }
+    {}
     ? != ( nurl_lex_type lex ) TT_EOF
     { : i __gc_bln ( nurl_lex_line lex )
         ~ < __gc_prev_ln __gc_bln {
@@ -28846,6 +28917,47 @@
 // Both loops guard against EOF so a malformed source (e.g. missing
 // `→` in a function header, or an unclosed `{`) cannot park the
 // compiler in an infinite loop.
+// skip_one_type: consume exactly one TYPE at the current position — enough to
+// know where it ENDS, without judging whether it is valid. `parse_type` cannot
+// stand in for this inside a trait DECLARATION: the type parameter there lexes
+// as the boolean literal (`% Maker [T] { @ make T self → T }`) and only the
+// declaration's own context knows it names a type, so parse_type reports it as
+// "expected a type, found 'T'".
+//
+// A type is a chain of prefixes ending in one base token. Counting the base
+// tokens still owed keeps this iterative: a prefix leaves the count alone, `!`
+// (result) adds one because it takes two, and anything else settles one.
+@ skip_one_type i lex → v {
+    : ~ i owed 1
+    ~ & > owed 0 != ( nurl_lex_type lex ) TT_EOF {
+        : i tt ( nurl_lex_type lex )
+        ? | | | == tt TT_STAR == tt TT_QUEST == tt TT_QUESTQUEST == tt TT_LBRACK
+        { ( nurl_lex_advance lex ) }  // prefix: '* T', '? T', '?? T', '[ T'
+        { ? == tt TT_BANG
+            { ( nurl_lex_advance lex ) = owed + owed 1 }  // '! T E' takes two
+            { ? == tt TT_LPAREN
+                { ( skip_balanced_parens lex ) = owed - owed 1 }  // '( @ R P* )', '( Name A B )'
+                { ? == tt TT_PERCENT
+                    { ( nurl_lex_advance lex )  // '%' Trait
+                        ? != ( nurl_lex_type lex ) TT_EOF { ( nurl_lex_advance lex ) } {}
+                        = owed - owed 1 }
+                    { ( nurl_lex_advance lex ) = owed - owed 1 } } } }
+    }
+}
+
+// skip_balanced_parens: consume a '( ... )' group, nesting included. The
+// brace version below is the same walk over '{' / '}'.
+@ skip_balanced_parens i lex → v {
+    : ~ i depth 0
+    ~ != ( nurl_lex_type lex ) TT_EOF {
+        : i tt ( nurl_lex_type lex )
+        ? == tt TT_LPAREN { = depth + depth 1 } {}
+        ? == tt TT_RPAREN { = depth - depth 1 } {}
+        ( nurl_lex_advance lex )
+        ? <= depth 0 { ^ } {}
+    }
+}
+
 @ skip_balanced i lex → v {
     ~ & != ( nurl_lex_type lex ) TT_LBRACE != ( nurl_lex_type lex ) TT_EOF
     { ( nurl_lex_advance lex ) }
@@ -28904,14 +29016,30 @@
                     ( lint_note_def mname )
                     ( nurl_lex_advance lex )  // consume method name
                     : i sig_start ( nurl_lex_cur_start lex )
-                    // Skip params / → / ret_ty until we hit '{' (body), next '@',
-                    // or '}' (end of trait).
-                    ~ & & & != ( nurl_lex_type lex ) TT_LBRACE
+                    // Params up to the '→', then EXACTLY the return type.
+                    // Scanning to the first '{' instead — which is what this
+                    // did — runs off the end of an UNTERMINATED trait body:
+                    // `% Sp [T] { @ speak T self → i` with no '}' read the
+                    // NEXT declaration's `{ i pitch }` as this method's
+                    // default body, and the two passes then disagreed about
+                    // where the trait ended (the emit pass skips balanced
+                    // braces, so it ate the rest of the file). nurlc exited
+                    // 0, emitted no `main`, and printed nothing at all.
+                    // Found by the token-deletion sweep, deleting one '}'.
+                    ~ & & & & != ( nurl_lex_type lex ) TT_ARROW
+                    != ( nurl_lex_type lex ) TT_LBRACE
                     != ( nurl_lex_type lex ) TT_AT
                     != ( nurl_lex_type lex ) TT_RBRACE
                     != ( nurl_lex_type lex ) TT_EOF {
                         ( nurl_lex_advance lex )
                     }
+                    // No arrow at all: a malformed header (the ASCII '->' is
+                    // the usual cause). Leave the slice as scanned — the
+                    // paths that consume it report that with a trait, a
+                    // method and a Self type, which this scan cannot give.
+                    ? == ( nurl_lex_type lex ) TT_ARROW
+                    { ( nurl_lex_advance lex ) ( skip_one_type lex ) }
+                    {}
                     // Dynamic-dispatch seam (docs/spec.md §4.9): record the trait's
                     // method set in declaration order plus each method's signature
                     // ("params → ret") — the vtable layout a future `dyn Trait` would
@@ -28953,9 +29081,9 @@
                     }
                     {}  // header only — required method, no template to store
                 }
-                { ( nurl_lex_advance lex ) }
+                { ( die lex ( nurl_str_cat3 `expected a method name after '@' in this trait body, found ` ( tok_here lex ) `. A trait declares each method as '@ name params → ret' — a signature alone for a required method, or a signature and a body for a default one.` ) ) }
             }
-            { ( nurl_lex_advance lex ) } }
+            { ( die lex ( nurl_str_cat3 `expected a method ('@ name params → ret') or an associated type ('type Name') in this trait body, found ` ( tok_here lex ) `. Nothing else belongs between a trait's braces; a token that is neither used to be skipped, which silently swallowed whatever followed an unterminated body.` ) ) } }
     }
     ( expect lex TT_RBRACE )  // consume '}' — clean error if unterminated at EOF
 }
@@ -29210,6 +29338,7 @@
         ( nurl_str_cat spos ` ` ) ) ) ) ) ) ) )
         ( expect lex TT_LBRACE )
         : ~ s provided ``
+        : ~ b malformed F
         : ~ s bindings ``  // "name val …" associated-type bindings of this impl
         ~ & != ( nurl_lex_type lex ) TT_RBRACE != ( nurl_lex_type lex ) TT_EOF {
             ? & == ( nurl_lex_type lex ) TT_IDENT ( seq ( nurl_lex_val lex ) `type` )
@@ -29233,16 +29362,28 @@
                         ( nurl_sym_def syms mangled ret_ty )
                         ( skip_balanced lex )  // skip method body
                     }
-                    { ( nurl_lex_advance lex ) }
+                    {  // `@` with no method name after it. The emit pass
+                        // reports that with the position and the form; note
+                        // it so the contract check does not shadow it with a
+                        // "missing required method" the parse error explains.
+                        = malformed T
+                        ( nurl_lex_advance lex ) }
                 }
-                { ( nurl_lex_advance lex ) } }
+                { ? malformed
+                    {  // The '@' above had no method name. The emit pass
+                        // reports THAT, with the position and the form the
+                        // reader needs; a second complaint about the tokens
+                        // it left behind would only get there first and say
+                        // less. Skip to the end of the body as before.
+                        ( nurl_lex_advance lex ) }
+                    { ( die lex ( nurl_str_cat3 `expected a method ('@ name params → ret { ... }') or an associated-type binding ('type Name ConcreteType') in this impl body, found ` ( tok_here lex ) `. Nothing else belongs between an impl's braces; a token that is neither used to be skipped, which silently swallowed whatever followed an unterminated body.` ) ) } } }
         }
         ( expect lex TT_RBRACE )  // consume '}' — clean error if unterminated at EOF
         // The trait may be declared later, in this file or a later import.
         // Record the dependency instead of consulting a partial trait table.
         // Explicit signatures are already registered; defaults and associated
         // type coherence are resolved after the complete signature scan.
-        ( defer_trait_impl lex impl_pos tname impl_nurl impl_llvm impl_mangle provided bindings )
+        ( defer_trait_impl lex impl_pos tname impl_nurl impl_llvm impl_mangle provided bindings malformed )
     }
 }
 
@@ -29251,7 +29392,7 @@
 // Fields are separate symbol entries (paths and type strings may contain
 // spaces). Keep one effective-source snapshot per file, not per impl, so
 // deferred diagnostics retain their real source and alias rewriting.
-@ defer_trait_impl i lex i impl_pos s tname s impl_nurl s impl_llvm s impl_mangle s provided s bindings → v {
+@ defer_trait_impl i lex i impl_pos s tname s impl_nurl s impl_llvm s impl_mangle s provided s bindings b malformed → v {
     : s file ( nurl_lex_filename lex )
     : s pos ( nurl_str_int impl_pos )
     : s seen ( nurl_str_cat4 `seen##` file `##` pos )
@@ -29268,6 +29409,7 @@
     ( nurl_sym_def g_trait_pending ( nurl_str_cat key `mangle` ) impl_mangle )
     ( nurl_sym_def g_trait_pending ( nurl_str_cat key `provided` ) provided )
     ( nurl_sym_def g_trait_pending ( nurl_str_cat key `bindings` ) bindings )
+    ? malformed { ( nurl_sym_def g_trait_pending ( nurl_str_cat key `malformed` ) `1` ) } {}
     : s skey ( nurl_str_cat `src##` file )
     // Test key existence, not snapshot length: strlen of the whole file
     // for every impl would make this ostensibly shared capture quadratic.
@@ -29302,6 +29444,10 @@
         : s impl_nurl ( nurl_sym_get2 g_trait_pending key `nurl` )
         : s bindings ( nurl_sym_get2 g_trait_pending key `bindings` )
         ( verify_assoc_bindings lex tname impl_nurl bindings )
+        ( check_impl_contract lex tname impl_nurl
+        ( nurl_sym_get2 g_trait_pending key `llvm` )
+        ( nurl_sym_get2 g_trait_pending key `provided` ) bindings
+        != 0 ( nurl_str_len ( nurl_sym_get2 g_trait_pending key `malformed` ) ) )
         ? != 0 ( nurl_str_len impl_nurl )
         { ( register_missing_defaults lex tname impl_nurl
             ( nurl_sym_get2 g_trait_pending key `llvm` )
@@ -29358,6 +29504,129 @@
             ( nurl_str_cat ( nurl_str_cat3 impl_nurl `' must bind associated type '` an )
             `' (add a 'type' line)` ) ) ) }
         {}
+    }
+}
+
+// __ptypes_head / __ptypes_tail: the first entry of a ';'-separated lowered
+// parameter list, and everything after it. The receiver slot is compared
+// separately from the rest, because a NON-generic trait writes it as a
+// placeholder — `% Show { @ show i n → s }` is implemented for `i` AND for
+// `b` — while a generic one writes it as the type parameter, which
+// substitution makes exact.
+@ __ptypes_head s pt → s {
+    : i n ( nurl_str_len pt )
+    : ~ i i 0
+    ~ < i n {
+        ? == ( nurl_str_get pt i ) 59 { ^ ( nurl_str_slice pt 0 i ) } {}
+        = i + i 1
+    }
+    ( nurl_str_cat pt `` )
+}
+
+@ __ptypes_tail s pt → s {
+    : i n ( nurl_str_len pt )
+    : ~ i i 0
+    ~ < i n {
+        ? == ( nurl_str_get pt i ) 59 { ^ ( nurl_str_slice pt + i 1 - n + i 1 ) } {}
+        = i + i 1
+    }
+    ( nurl_str_cat `` `` )
+}
+
+// __impl_sig_check: one provided method against the trait's own declaration.
+// The trait records each method's signature source ("params → ret") at scan
+// time. Substituting the type parameter with this impl's Self type and the
+// associated types with this impl's bindings gives the signature the impl is
+// required to have — the same two substitutions `register_missing_defaults`
+// applies to a default body. Both sides are then lowered by the SAME scanner
+// the impl's own registration went through, so the comparison is of lowered
+// types and conventions (`inout` included), not of source spelling.
+@ __impl_sig_check i lex s tname s mname s impl_nurl s impl_llvm s ty s tparam s bindings → v {
+    : s sig ( nurl_sym_get2 g_trait_syms tname ( nurl_str_cat3 `__` mname `__sig` ) )
+    ? == 0 ( nurl_str_len sig ) { ^ } {}
+    // A type parameter with no Self name to put in its place (a compound impl
+    // type such as `* T`) cannot be substituted — the same restriction trait
+    // defaults already carry. Leave those impls unchecked rather than compare
+    // against a signature that still says `T`.
+    ? & != 0 ( nurl_str_len tparam ) == 0 ( nurl_str_len impl_nurl ) { ^ } {}
+    // A header with no arrow is not a signature at all. Nothing rejects that
+    // at the trait declaration yet (recorded in the v1 hardening ledger); the
+    // paths that consume it report it with a location and a context, and a
+    // second report here would only shadow theirs.
+    ? < ( nurl_str_find sig `→` ) 0 { ^ } {}
+    // Bound, never inline in an argument list: an owned temp handed straight
+    // to a user function is not collected (the LSan lesson this file repeats).
+    : s subst0 ? != 0 ( nurl_str_len tparam )
+    ( subst_source_raw sig tparam impl_nurl )
+    ( nurl_str_cat sig `` )
+    : s subst ( subst_assoc subst0 bindings )
+    : s key ( nurl_str_cat3 mname `##` impl_llvm )
+    : s skey ( nurl_str_cat3 mname `##__traitsig##` impl_llvm )
+    : i siglex ( nurl_lex_new subst `<trait_method_signature>` )
+    : s saved_ctx ( nurl_str_cat g_diag_ctx `` )
+    = g_diag_ctx ( nurl_str_cat ( nurl_str_cat4
+    ` [in the declared signature of method '` mname `' of trait '` tname )
+    ( nurl_str_cat3 `' (Self = '` ty `') — fix it at the trait declaration]` ) )
+    : s want_ret ( scan_method_signature siglex skey `__traitsig` `__traitsig` )
+    = g_diag_ctx saved_ctx
+    ( nurl_lex_free siglex )
+    : s got_ret ( nurl_sym_get g_impl_ret_syms key )
+    : s want_ar ( nurl_sym_get2 g_impl_ret_syms skey `__arity` )
+    : s got_ar ( nurl_sym_get2 g_impl_ret_syms key `__arity` )
+    : s want_all ( nurl_sym_get2 g_impl_ret_syms skey `__ptypes` )
+    : s got_all ( nurl_sym_get2 g_impl_ret_syms key `__ptypes` )
+    : s want_recv ( __ptypes_head want_all )
+    : s got_recv ( __ptypes_head got_all )
+    : s want_pt ( __ptypes_tail want_all )
+    : s got_pt ( __ptypes_tail got_all )
+    : s where ( nurl_str_cat ( nurl_str_cat4 `method '` mname `' of trait '` tname )
+    ( nurl_str_cat3 `' implemented for type '` ty `'` ) )
+    ? ! ( seq want_ar got_ar )
+    { ( die lex ( nurl_str_cat ( nurl_str_cat3 where ` takes ` got_ar )
+        ( nurl_str_cat3 ` parameter(s), but the trait declares ` want_ar ` — an impl must have the signature the trait declares, because every call site is type-checked against the declaration and a 'dyn' object dispatches through it.` ) ) ) }
+    {}
+    ? & != 0 ( nurl_str_len tparam ) ! ( seq want_recv got_recv )
+    { ( die lex ( nurl_str_cat ( nurl_str_cat3 where ` takes a receiver of type '` got_recv )
+        ( nurl_str_cat3 `', but the trait declares '` want_recv `' for this Self. An impl must have the signature the trait declares.` ) ) ) }
+    {}
+    ? ! ( seq want_pt got_pt )
+    { ( die lex ( nurl_str_cat ( nurl_str_cat3 where ` has non-receiver parameter types '` got_pt )
+        ( nurl_str_cat3 `', but the trait declares '` want_pt `' (';'-separated, lowered). An impl must have the signature the trait declares, because every call site is type-checked against the declaration.` ) ) ) }
+    {}
+    ? ! ( seq want_ret got_ret )
+    { ( die lex ( nurl_str_cat ( nurl_str_cat3 where ` returns '` got_ret )
+        ( nurl_str_cat3 `', but the trait declares '` want_ret `'. A 'dyn' object calls through a vtable built from the DECLARATION, so a disagreeing return type reaches the caller as the declared type with no conversion and no diagnostic.` ) ) ) }
+    {}
+}
+
+// check_impl_contract: an impl must satisfy the trait it names. Nothing did.
+// An impl that omitted a REQUIRED method compiled, though the grammar says
+// that is an error; and a method whose signature disagreed with the trait's
+// was registered exactly as written. The second is not cosmetic: `dyn` builds
+// its thunk from the DECLARED signature, so an impl returning `s` where the
+// trait declares `i` handed the caller a pointer read as an i64 — exit 0, no
+// diagnostic, wrong value at run time.
+//
+// A trait that is not DECLARED anywhere is not an error: `Drop`, `Ord` and
+// `Show` are implemented with no declaration, which is how the built-in
+// protocols work. There is simply no contract to check for one.
+@ check_impl_contract i lex s tname s impl_nurl s impl_llvm s provided s bindings b malformed → v {
+    ? == 0 ( nurl_str_len ( nurl_sym_get2 g_trait_syms tname `__istrait` ) ) { ^ } {}
+    : s ty ? != 0 ( nurl_str_len impl_nurl ) impl_nurl impl_llvm
+    : s tparam ( nurl_sym_get2 g_trait_syms tname `__tparam` )
+    : s defaults ( nurl_sym_get2 g_trait_syms tname `__defaults` )
+    : ~ s methods ( nurl_sym_get2 g_trait_syms tname `__methods` )
+    ~ != 0 ( nurl_str_len methods ) {
+        : s mname ( str_first_word methods )
+        = methods ( str_skip_word methods )
+        ? ( str_contains_word provided mname )
+        { ( __impl_sig_check lex tname mname impl_nurl impl_llvm ty tparam bindings ) }
+        { ? | malformed ( str_contains_word defaults mname )
+            {}  // the trait supplies a body, or the impl body did not parse
+            { ( die lex ( nurl_str_cat
+                ( nurl_str_cat3 `impl of trait '` tname `' for type '` )
+                ( nurl_str_cat ( nurl_str_cat3 ty `' is missing required method '` mname )
+                `'. The trait declares it with a signature and no body, so every impl must provide one — add it, or give the trait a default body.` ) ) ) } }
     }
 }
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -635,13 +635,36 @@ default) adds three further checks, all diagnostic-only and all emitting
    owned binding whose pointer may outlive that binding's drop is
    reported — a narrow check on the otherwise-untracked `*T` surface
    (§3).
-3. **Conditional double-free (the maybe-moved hole, §6.2/§6.5).**
-   Consuming a binding that is *maybe*-moved — freed on one arm of a
-   `?`, still owned on the other — is reported: it is a real
-   double-free on the path where the first free ran. Off by default
-   because it also flags the legitimate mutually-exclusive-frees
-   pattern (free under `cond` here, free under `! cond` later), which
-   the default no-false-positive contract protects.
+3. **Consuming a MAYBE-MOVED binding (§6.2/§6.5).** It is a real
+   double-free on the path where the first consume ran. The check is
+   one rule, but a binding reaches the maybe-moved state by more than
+   one route, and every one of them is covered here — the heading used
+   to name only the first, which read as though the other shapes were
+   a fourth check:
+   - freed on one arm of a `?` and still owned on the other;
+   - its handle selected by a value-producing `?` / `??` and bound
+     elsewhere;
+   - stored into an aggregate literal (`@ Wrap { h }`) — recorded as
+     maybe-moved rather than moved on purpose, because recording it as
+     definite rejects the option-wrapper idiom;
+   - pushed into a container that will free its elements;
+   - handed to another name by an alias assignment (`= z a`);
+   - captured by a closure whose body frees it (the closure may run
+     zero times, once, or many);
+   - passed to a call whose effect is not decidable at that point —
+     the callee may `sink` the parameter or hand the handle back.
+
+   Off by default because it also flags the legitimate
+   mutually-exclusive-frees pattern (free under `cond` here, free under
+   `! cond` later), which the default no-false-positive contract
+   protects.
+
+   What this check does NOT cover is a *read* of a maybe-moved binding
+   (§2.1): a free on one arm of a `?` followed by an unconditional read
+   after the join is a use-after-free on the taken path and is reported
+   in neither mode. That is a known boundary with a witness, not an
+   oversight; see the v1 hardening ledger for the two measurements that
+   bear on closing it.
 
 It is **off by default** because the extensions have a meaningful
 false-positive rate against existing stdlib code; it is a tightening

--- a/docs/dev/COMPILER_INTERNALS.md
+++ b/docs/dev/COMPILER_INTERNALS.md
@@ -248,8 +248,8 @@ Regenerate after adding/renaming globals:
 | `g_bck_gen` | :1196 | `bck_analyze` |  |
 | `g_bck_inn` | :1200 | `bck_analyze`, `bck_intern` | intern table — bumped per bck_analyze so entries from earlier functions read as misses without any table clear |
 | `g_bck_rec_off` | :1211 | (init only) | >0 while the borrow checker's capture hooks must not record. Used to be spelled `g_bck_closure_depth != 0`, wh |
-| `g_blk_tail_lit_col` | :3633 | `gen_block_expr`, `gen_block_ret` |  |
-| `g_blk_tail_lit_line` | :3632 | `gen_block_expr`, `gen_block_ret`, `gen_block_stmts`, `gen_cond` +1 | g_blk_tail_lit_line/col — the dangling-literal exemption's escape hatch, closed. A bare literal as a value blo |
+| `g_blk_tail_lit_col` | :3641 | `gen_block_expr`, `gen_block_ret` |  |
+| `g_blk_tail_lit_line` | :3640 | `gen_block_expr`, `gen_block_ret`, `gen_block_stmts`, `gen_cond` +1 | g_blk_tail_lit_line/col — the dangling-literal exemption's escape hatch, closed. A bare literal as a value blo |
 | `g_borrowck` | :1153 | `main` | ── Borrow-checker state ───────────────────────────────────────── g_borrowck is 1 (ON) by default; `--no-borro |
 | `g_closure_consumed` | :1117 | `bck_stash_move`, `gen_closure_expr` | Names a closure BODY consumed. bck_stash_move drops its records while inside a closure — the body's statements |
 | `g_closure_defs` | :1139 | `main` |  |
@@ -272,18 +272,18 @@ Regenerate after adding/renaming globals:
 | `g_dbg_placeholder_ty` | :1443 | `dbg_init` | dbg_init and reused for every fn. Phase 6 will replace with per-fn signature types. |
 | `g_dbg_subroutine_ty` | :1440 | `dbg_init` | emit_dbg_eol then omits `, !dbg !N`) |
 | `g_dbg_type_syms` | :1482 | `dbg_init` |  |
-| `g_dce` | :31074 | `main` |  |
-| `g_dce_end` | :31100 | `dce_emit_module`, `dce_free` |  |
-| `g_dce_keep` | :31085 | `main` | `--keep=a,b,c` — extra DCE roots.  The pass's root set is `main` plus whatever module-scope constants name. Th |
-| `g_dce_live` | :31101 | `dce_emit_module`, `dce_free` |  |
-| `g_dce_map` | :31104 | `dce_emit_module`, `dce_free` |  |
-| `g_dce_mod` | :31098 | `dce_emit_module` | The module text, as an integer cast of a BORROWED `s`. Deliberately not a `: ~ s` global: a mutable string glo |
-| `g_dce_qn` | :31103 | `__dce_mark_name`, `dce_emit_module` |  |
-| `g_dce_queue` | :31102 | `dce_emit_module`, `dce_free` |  |
-| `g_dce_start` | :31099 | `dce_emit_module`, `dce_free` |  |
+| `g_dce` | :31343 | `main` |  |
+| `g_dce_end` | :31369 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_keep` | :31354 | `main` | `--keep=a,b,c` — extra DCE roots.  The pass's root set is `main` plus whatever module-scope constants name. Th |
+| `g_dce_live` | :31370 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_map` | :31373 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_mod` | :31367 | `dce_emit_module` | The module text, as an integer cast of a BORROWED `s`. Deliberately not a `: ~ s` global: a mutable string glo |
+| `g_dce_qn` | :31372 | `__dce_mark_name`, `dce_emit_module` |  |
+| `g_dce_queue` | :31371 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_start` | :31368 | `dce_emit_module`, `dce_free` |  |
 | `g_defer_count` | :954 | `gen_defer`, `gen_fn_decl_concrete` |  |
 | `g_deferred_bck` | :1347 | `main` | Functions whose borrow-check walk is parked until the whole module has compiled (see borrowck_fn_end). `n` is  |
-| `g_diag_ctx` | :124 | `dyn_subst_parts`, `emit_missing_defaults`, `emit_one_instantiation`, `register_missing_defaults` | Diagnostic context suffix, appended to every die/warn message while non-empty. Set (and saved/restored — insta |
+| `g_diag_ctx` | :124 | `__impl_sig_check`, `dyn_subst_parts`, `emit_missing_defaults`, `emit_one_instantiation` +1 | Diagnostic context suffix, appended to every die/warn message while non-empty. Set (and saved/restored — insta |
 | `g_diag_recover_active` | :115 | `main`, `parse_program` |  |
 | `g_did_ret` | :921 | `__close_dead_block`, `__handle_unreachable_stmt`, `__tail_noreturn_close`, `gen_closure_expr` +9 |  |
 | `g_dyn_dtout` | :1044 | `dyn_method_decltrait` | dyn_method_decltrait's result rides a global too: its callers sit ABOVE its definition, so an owned return wou |
@@ -319,11 +319,11 @@ Regenerate after adding/renaming globals:
 | `g_impl_ret_syms` | :960 | `main` |  |
 | `g_impl_trait_syms` | :962 | `main` |  |
 | `g_in_match_arm` | :942 | `gen_match` | Non-zero while parsing a `??` match-arm body. The XOR-confusion warning in gen_ret keys off "a non-terminator  |
-| `g_input_key` | :31229 | `main` |  |
-| `g_input_source` | :31228 | `main` | Borrowed aliases to main's live source/key bindings when --stdin supplies an overlay. Every source read (inclu |
+| `g_input_key` | :31498 | `main` |  |
+| `g_input_source` | :31497 | `main` | Borrowed aliases to main's live source/key bindings when --stdin supplies an overlay. Every source read (inclu |
 | `g_last_closure_nonsend` | :1055 | `gen_closure_expr` | record per impl block, verified after scan_fn_sigs once every impl across the program (incl. imports) is regis |
 | `g_last_closure_sharedmut` | :1082 | `gen_call`, `gen_closure_expr` | Thread-safety, the SHARED-MUTATION half (docs/MEMORY.md §6.5). Set to the offending binding name while a closu |
-| `g_last_type_ptr` | :5890 | `nurl_set_last_type` |  |
+| `g_last_type_ptr` | :5898 | `nurl_set_last_type` |  |
 | `g_lint` | :2019 | `main` | Unused-symbol lint (opt-in via `--lint`). Default OFF so ordinary builds — and the compiler's own bootstrap, w |
 | `g_lint_gen` | :2034 | `lint_fn_begin` |  |
 | `g_lint_handles` | :2032 | `lint_init` | g_lint_handles — per-function roster of MANUALLY-MANAGED handles (docs/MEMORY.md §7.4: Vec and String, the two |
@@ -332,15 +332,15 @@ Regenerate after adding/renaming globals:
 | `g_lint_released` | :2033 | `lint_init` |  |
 | `g_lint_syms` | :2020 | `lint_init` |  |
 | `g_lint_used` | :2021 | `lint_init` |  |
-| `g_live_lexers` | :6017 | `nurl_lex_free`, `nurl_lex_new` |  |
-| `g_live_symtables` | :6016 | `nurl_sym_free`, `nurl_sym_new` |  |
+| `g_live_lexers` | :6025 | `nurl_lex_free`, `nurl_lex_new` |  |
+| `g_live_symtables` | :6024 | `nurl_sym_free`, `nurl_sym_new` |  |
 | `g_lock_depth` | :1107 | `gen_call`, `gen_closure_expr` | Lock depth, for the same check. A mutation of shared contents is only a race when nothing serialises it, so th |
 | `g_loop_break_used` | :1424 | `main` | `g_loop_break_used[exit_label]` is `1` when a `break` targeting that loop's exit label was compiled. Exit labe |
 | `g_mono_tparam_tys` | :1481 | `emit_one_instantiation` | Space-separated list of the concrete type-arguments substituted for a generic function's type parameters in th |
-| `g_origin_functions` | :22489 | `main` |  |
-| `g_origin_nodes` | :22487 | `origin_free`, `origin_new` | Return-escape inference (docs/MEMORY.md §2.8): record that the enclosing function may RETURN this bare-identif |
-| `g_origin_returns` | :22490 | `main` |  |
-| `g_origin_work` | :22488 | `origin_free`, `origin_queue`, `origin_resolve` |  |
+| `g_origin_functions` | :22537 | `main` |  |
+| `g_origin_nodes` | :22535 | `origin_free`, `origin_new` | Return-escape inference (docs/MEMORY.md §2.8): record that the enclosing function may RETURN this bare-identif |
+| `g_origin_returns` | :22538 | `main` |  |
+| `g_origin_work` | :22536 | `origin_free`, `origin_queue`, `origin_resolve` |  |
 | `g_owned_globals` | :925 | `gen_const_decl` | Names of the mutable string globals that own their buffer (each has a compiler-emitted `<name>__nurlown` flag) |
 | `g_pending_escape` | :1319 | `main` | Deferred interprocedural-escape checks (docs/MEMORY.md §3 forward / generic boundary). A stack reference passe |
 | `g_pending_impl` | :1341 | `main` | Deferred summary IMPLICATIONS (docs/MEMORY.md §2.7 / §2.8). A summary is inferred as each body compiles, so a  |
@@ -355,19 +355,19 @@ Regenerate after adding/renaming globals:
 | `g_ptrtab` | :1191 | `main` |  |
 | `g_res_type_syms` | :338 | `main` | ── Res-type NURL tracking (must be declared before parse_type_res) ── g_res_type_syms is initialized to a new  |
 | `g_ret_forbidden` | :936 | `gen_cond`, `gen_logical_or_bitwise_and`, `gen_logical_or_bitwise_or`, `gen_operand` +1 | Cascade guard: 1 while parsing a VALUE OPERAND (a binary/unary/cast/ member operand, a call argument, a `?`/`? |
-| `g_sanitize_address` | :31223 | `main` | Emission policy, set by main's --sanitize-address flag. |
-| `g_split_fh` | :31094 | `__sp_close`, `__sp_open` |  |
-| `g_split_fill` | :31092 | `split_emit_module` |  |
-| `g_split_max` | :31088 | `main` |  |
-| `g_split_min` | :31089 | `main` |  |
-| `g_split_n` | :31087 | `__sp_whole`, `dce_emit_module`, `split_emit_module` | Partitioned emission — see "Partitioned emission" below. |
-| `g_split_out` | :31090 | `main` |  |
-| `g_split_part` | :31091 | `split_emit_module` |  |
-| `g_split_priv` | :31093 | `split_emit_module` |  |
-| `g_stmt_bare_lit` | :3619 | `gen_stmt` | g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just parsed was a bare numeric/string LITERAL in  |
-| `g_stmt_bare_value` | :3646 | `gen_stmt` | g_stmt_bare_value — the literal flag's general sibling (critic A2, the last silent prefix-arity cascade): set  |
-| `g_stmt_col` | :3561 | `gen_block_ret`, `gen_stmt` | g_stmt_col — column of the current statement's first token, captured alongside g_stmt_line. `die_stmt` anchors |
-| `g_stmt_line` | :3554 | `gen_block_ret`, `gen_stmt` | g_stmt_line — source line of the statement gen_stmt is currently parsing. Read by gen_ident's "unexpected toke |
+| `g_sanitize_address` | :31492 | `main` | Emission policy, set by main's --sanitize-address flag. |
+| `g_split_fh` | :31363 | `__sp_close`, `__sp_open` |  |
+| `g_split_fill` | :31361 | `split_emit_module` |  |
+| `g_split_max` | :31357 | `main` |  |
+| `g_split_min` | :31358 | `main` |  |
+| `g_split_n` | :31356 | `__sp_whole`, `dce_emit_module`, `split_emit_module` | Partitioned emission — see "Partitioned emission" below. |
+| `g_split_out` | :31359 | `main` |  |
+| `g_split_part` | :31360 | `split_emit_module` |  |
+| `g_split_priv` | :31362 | `split_emit_module` |  |
+| `g_stmt_bare_lit` | :3627 | `gen_stmt` | g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just parsed was a bare numeric/string LITERAL in  |
+| `g_stmt_bare_value` | :3654 | `gen_stmt` | g_stmt_bare_value — the literal flag's general sibling (critic A2, the last silent prefix-arity cascade): set  |
+| `g_stmt_col` | :3569 | `gen_block_ret`, `gen_stmt` | g_stmt_col — column of the current statement's first token, captured alongside g_stmt_line. `die_stmt` anchors |
+| `g_stmt_line` | :3562 | `gen_block_ret`, `gen_stmt` | g_stmt_line — source line of the statement gen_stmt is currently parsing. Read by gen_ident's "unexpected toke |
 | `g_str_idx` | :919 | `emit_deferred_cstr`, `emit_str_global`, `gen_str_lit` |  |
 | `g_str_syms` | :920 | `main` |  |
 | `g_strict_arity` | :1181 | `main` | strict-arity: the n-ary `&`/`\|` arity trap is an ERROR by default. The trap is the language's one documented f |

--- a/docs/dev/V1_HARDENING.md
+++ b/docs/dev/V1_HARDENING.md
@@ -8,21 +8,21 @@ in reviewable groups. No item below certifies the whole language or ecosystem.
 
 | Audit item | Evidence required before closure | Current disposition |
 |---|---|---|
-| A01: sanitizer coverage | Ordinary driver, bootstrap, split output and fuzz paths detect deliberate memory faults in generated code; clean controls, corpus and fuzz pass; UBSan/LLVM semantics documented | ASan emission implemented and calibrated; revealed HTTP/3 UAF and compiler leaks repaired; integer division/remainder, shifts and float casts now guard invalid domains, and the differential fuzzer now reaches those guards with computed operands; lexical stack-lifetime coverage remains open |
+| A01: sanitizer coverage | Ordinary driver, bootstrap, split output and fuzz paths detect deliberate memory faults in generated code; clean controls, corpus and fuzz pass; UBSan/LLVM semantics documented | ASan emission implemented and calibrated; revealed HTTP/3 UAF and compiler leaks repaired; integer division/remainder, shifts and float casts now guard invalid domains, and the differential fuzzer now reaches those guards with computed operands; lexical stack lifetimes are a recorded DECISION not to build (every alloca is entry-hoisted, so markers buy detection and stack reuse, not correctness, and owe an account of deferred cleanup) rather than pending work |
 | A02: trustworthy compiler runners | Missing-main rejection fixtures run; crash/hang/worker fault controls fail closed; complete corpus verdict accounting | Verified in local normal/sanitized corpus and POSIX/PowerShell controls; native Windows execution remains CI evidence |
 | A03: installed LSP | Separate installed project, unsaved edits, sibling/dependency imports, visible execution errors | Independently reproduced; repaired and verified with relocated binaries and 20 normal/ASan/LSan protocol/compiler controls on Linux; native Windows and actual distribution installation remain unverified |
 | A04: registry identity | Two local registries with equal package names; fetch, resolution, signing and lock identity preserved; errors never print success | Origin/key/index/archive/lock binding repaired; conflict-directed resolver checked against an exhaustive oracle; flat-layout coexistence and transactional/frozen installation remain open |
 | A05: signed install smoke | Signed fixtures install after relocation with transitive dependencies; missing/wrong/tampered signatures reject; CI runs it | Unsigned/stale smoke independently reproduced; signed five-program relocation smoke and CLI negative controls pass locally, wired into CI; remote run pending |
 | A06: JS dependencies | Fresh manager-native audits, reachability analysis, lockfile updates and builds/tests for all four trees; recurring checks | Fresh audits repaired; all four clean installs, builds/checks and zero-finding re-audits pass locally; weekly/PR checks added; all four remote audit/build jobs pass at `5b2a9b3a` |
 | A07: continuous package/service tests | Suite/prerequisite manifest, changed packages and reverse dependencies, scheduled coverage; registry/cloud and diagnostic gates in CI | Pending current workflow inventory |
-| A08: documentation consistency | Grammar, spec, platform claims, generated facts and executable docs agree with implementation | Runner prerequisites, macOS/musl claims and stale leak comments corrected from source; the binding path now accepts the block-expression initialiser its own grammar specifies; remaining claims pending |
+| A08: documentation consistency | Grammar, spec, platform claims, generated facts and executable docs agree with implementation | Runner prerequisites, macOS/musl claims and stale leak comments corrected from source; the binding path now accepts the block-expression initialiser its own grammar specifies; the grammar's "required methods are a compile error if an impl doesn't provide them" is now true; MEMORY.md §2.9's opt-in checks are counted correctly; remaining claims pending |
 | A09: package development | Clean checkout and unpacked consumer tests, shared environment setup, explicit public import surfaces | Pending reproduction |
 | A10: tree gates | Tracked formatting inventory, package-aware frontend coverage, recursive import checks with reported exclusions | The canonical-form gate now covers the tracked inventory (1,779 files) instead of five hand-listed directories, and the 18 files that had drifted are reformatted; package-aware frontend coverage and recursive import checks remain open |
 | A11: toolchain build integrity | Injected required-tool failures fail the build; stale binaries cannot substitute; logs and totals retained | Required tools now fail the build, use the canonical driver and remove stale outputs; isolated full-build controls pass locally and are wired into CI |
 | A12: LSP temporary files | Concurrent servers remain independent and no shared source files can be overwritten or leaked on errors | Source temporary files eliminated through compiler stdin snapshots; concurrent-server and missing-tool controls pass |
-| A13: safety contract | Default/strict/raw/FFI guarantees agree; witnesses and valid controls; opaque wrappers and container ownership audited | The pre-registered C-runtime surface is now checked at call sites exactly as an '&'-declared FFI symbol is — it had no argument or arity check at all. Container and opaque-handle ownership now has witnesses: every violation the default rules promise to catch is caught, the three that compile are the holes MEMORY.md declares, and two of those three are reported under --strict-borrowck. Open: a read of a maybe-moved binding has a witness but no check in either mode; MEMORY.md §2.9 undercounts strict mode's checks; the rest of the contract review is untouched |
+| A13: safety contract | Default/strict/raw/FFI guarantees agree; witnesses and valid controls; opaque wrappers and container ownership audited | The pre-registered C-runtime surface is now checked at call sites exactly as an '&'-declared FFI symbol is — it had no argument or arity check at all. An impl is now checked against the trait it names: a missing required method, a wrong arity, wrong non-receiver parameter types and a wrong return type were all accepted, and the last of those is a type confusion, because 'dyn' builds its thunk from the DECLARED signature. Container and opaque-handle ownership has witnesses: every violation the default rules promise to catch is caught, the three that compile are the holes MEMORY.md declares, and two of those three are reported under --strict-borrowck. MEMORY.md §2.9 is reconciled (three checks; the third one's description was too narrow). A read of a maybe-moved binding is a recorded decision not to build, with both measurements. Open: opaque wrappers beyond Channel, and whether the remaining guarantees agree |
 | A14: crypto/parser evidence | Instrumented fuzz controls and retained seeds; pinned ACVP/HTTP oracles; measured backend timing; explicit X.509 policy and independent crypto review | Pending; requires A01 and external validation for independent review |
-| A15: release integrity | Mandatory target artifact gates, pinned tool downloads, installer integrity and state-preserving failure controls | The artifact set is now gated before publication, with eleven controls in CI; installer checksum/signature verification reviewed and found fail-closed; pinned tool downloads and state-preserving unpack remain open |
+| A15: release integrity | Mandatory target artifact gates, pinned tool downloads, installer integrity and state-preserving failure controls | The artifact set is gated before publication, with eleven controls in CI; installer checksum/signature verification reviewed and found fail-closed; the installer now stages its unpack so a failed extraction leaves the existing install intact (six controls, two of which fail against the previous installer); every tool a workflow downloads is pinned by sha256, including the zig that ships inside the published archive, with tools/check_pinned_downloads.py keeping it that way in CI |
 | A16: compiler architecture | Ownership/state boundaries, current global writer map, interacting-feature differential tests, diagnostic-site dispositions | Trait ordering work is merged; remaining acceptance is unverified |
 | A17: ecosystem capabilities | All package public surfaces mapped to executable consumer/runtime/install evidence and prerequisites; device/platform results distinguished from CPU substitutes | Pending package inventory and execution matrix |
 
@@ -1937,7 +1937,10 @@ can be made with one.
 Note also that `docs/MEMORY.md` §2.9 is titled "three opt-in checks" and
 enumerates three, while the aggregate-literal maybe-move above is a fourth
 thing `--strict-borrowck` reports. The prose and the implementation should
-be reconciled.
+be reconciled. (Reconciled on 2026-09-12: there are three checks, and the
+third one's DESCRIPTION named only one of the seven routes into the
+maybe-moved state. See "A13 / MEMORY.md §2.9: the opt-in checks, counted
+correctly" below.)
 
 ### A01: the leak inventory, triaged as far as machines go (2026-09-11)
 
@@ -2110,3 +2113,278 @@ the leak gate passes on all seven sources in both emission modes. Corpus 992
 pass / 19 skip; sanitized corpus 906 pass / 86 leak / zero other sanitizer
 findings; RSS 38 MB; DCE 180 emitted / 12 reachable with identical
 behaviour; the tree's 303 diagnostics are unchanged.
+
+### The sweep past declarations: expression position, arms, terminators (2026-09-12)
+
+The declaration sweep that found thirteen defects was continued into the
+positions it had not reached: expression position, trait and impl bodies,
+match and select arms, foreach, and the `!` / `?` / `Z` / `#` / `@` / `.`
+operator forms. Method unchanged — take a construct the grammar allows,
+write it in a spelling nothing in the tree uses, and check the
+implementation against `spec/grammar.ebnf`. About 140 spellings; four
+defects, three of which the declaration invariant cannot see because they
+keep `main` and fail later.
+
+**`Z NoSuchType` was the one type position with no type check.** Binding,
+return, parameter, struct field, global, FFI parameter, FFI return and enum
+payload types all run `check_type_known`; `Z` did not. It fell through to
+the getelementptr-null path and emitted `getelementptr %NoSuchType,
+%NoSuchType* null, i64 1` for a type nothing declares. nurlc exited 0 and
+clang said "base element of getelementptr must be sized" — about generated
+IR, with no NURL source location. `gen_sizeof` now takes `syms` and runs
+the same check every other type position runs.
+
+**An or-pattern's alternatives were never checked against the enum.** The
+FIRST name of a match arm has been checked for years, with a comment
+explaining precisely this miscompile: an unknown name emits `load i64,
+i64* @<name>` for a global nothing defines. `A | B → body` checked `A` and
+not `B`. `?? c { Red | Nope → … }` compiled, exited 0, and clang reported
+`use of undefined value '@Nope'`. The same check now runs over every
+alternative, anchored on the arm's own pattern token.
+
+**`break` and `continue` inside a `;` defer body compiled to an infinite
+loop.** `^` inside a defer is already rejected, with the reason: the defer
+chain runs DURING return and cannot itself return. The other two block
+terminators had no such check, and the enclosing loop's labels were still
+in scope, so the jump branched into `loop_exit` — a block the chain had
+already come from — which fell straight back into the defer chain with its
+armed flag still set. `~ < k 3 { ; { break } = k + k 1 }` compiled, exited
+0, and printed its epilogue forever. The defer body now shadows the loop
+labels, so a `break` there is reported with its own message, while a loop
+written INSIDE the defer body still breaks normally.
+
+The fourth is A13's, below. `tools/tests/test_declaration_forms.py` grew
+from 44 forms to 95 across three tables (declarations, statements, match
+arms). Sixteen of the new rows are rejections the pre-change compiler
+accepted; running the extended table against a compiler built from the parent
+commit fails exactly those sixteen and passes the other 79, which is what
+makes them evidence rather than assertion.
+
+Two forms were checked, found to be the language rather than a defect, and
+are pinned as `compiles` with the reason: an impl of a trait that is not
+declared anywhere (`Drop`, `Ord` and `Show` are implemented with no
+declaration), and a receiver type in a non-generic trait's impl that
+differs from the declaration's (that slot is a placeholder each impl
+replaces — `% Show { @ show i n → s }` is implemented for `i` and for `b`).
+
+One hole was found and is NOT closed: a trait method header with no return
+arrow (`% Sh { @ area i o }`) is accepted at the declaration. Nothing
+consumes the recorded signature unless the trait is used dynamically, and
+the dyn re-parse is where it is reported today
+(`compiler/tests/diag_dynsig_context.nu` pins that message and its
+context). Rejecting it at the declaration is the right place, and it would
+retire that fixture's witness; the signature check below therefore skips a
+header with no arrow rather than shadowing the existing diagnostic with a
+worse-located one.
+
+Evidence: corpus 992 PASS / 19 SKIP / 0 FAIL / 0 MISSING / 0 ORPHAN;
+the sanitized corpus 992 PASS / 19 SKIP with zero sanitizer findings;
+`nurlfmt --check` canonical over 1,790 files; strict-arity, memgate and
+dcegate pass; seven arithmetic methods, 31 ownership methods, seven
+compiler-cleanup methods, two driver-path controls, the WASI IR control and
+eleven release-artifact controls all pass. The check that matters most for
+a change that ADDS diagnostics is the tree sweep: every tracked first-party
+`.nu` file (816 of them) compiled with the parent commit's compiler and
+with this one produces **byte-identical** output and exit codes.
+
+### A13: an impl was never checked against the trait it names (2026-09-12)
+
+`% Trait Type { … }` registered whatever methods it contained and checked
+none of them against the trait's declaration. Three things followed, and
+the third is a type confusion rather than a missing convenience:
+
+- A required method — one the trait declares with a signature and no body —
+  could simply be absent. The grammar says "Required methods are a compile
+  error if an impl doesn't provide them"; nothing enforced it.
+- The arity and the non-receiver parameter types could disagree.
+- The RETURN type could disagree, and `dyn` dispatch builds its thunk from
+  the DECLARED signature. A trait declaring `→ i` implemented with `→ s`
+  produced a vtable whose thunk returns i64, called a function returning
+  i8*, and handed the caller a pointer to read as an integer. The witness
+  prints a raw pointer value and exits 0 with no diagnostic anywhere.
+
+`check_impl_contract` now runs in `resolve_trait_impls`, which is already
+the point where the whole program's traits are known, so declaration order
+and imports are not a factor. For each method the trait declares: if the
+impl provides it, its signature is compared; if not, it must have a default
+body. The comparison substitutes the trait's type parameter with this
+impl's Self type and its associated types with this impl's bindings — the
+same two substitutions `register_missing_defaults` applies to a default
+body — and then lowers BOTH sides with `scan_method_signature`, the same
+scanner the impl's own registration went through. Comparing lowered types
+rather than source spelling is what makes `inout` receivers
+(`%Counter*`), associated-type returns (`type Elem i`) and type aliases
+(`i` / `i64`) compare correctly; all three are in the corpus and all three
+were what the first two attempts got wrong.
+
+Three boundaries the corpus taught, each now a comment at the check:
+
+- A trait that is not DECLARED is not an error. `Drop`, `Ord` and `Show`
+  are implemented with no declaration; that is how the built-in protocols
+  work. There is no contract to check for one, so the check returns.
+- A NON-generic trait's receiver slot is a placeholder. Only a generic
+  trait's receiver is contractual, because substitution makes it exact.
+- An impl body the parser could not read (`@ 5 Dog self → i`) is recorded
+  as malformed at scan time, so "missing required method" does not shadow
+  the parse error that explains it.
+
+### A15: a staged unpack, and tools pinned by content (2026-09-12)
+
+Both remaining A15 halves are closed.
+
+**The installer no longer destroys a working install to make room for one.**
+`tools/get-nurl.sh` removed the toolchain's paths and let `tar` write over
+the hole. Every failure from that point on — a truncated archive, a full
+disk, a killed terminal — left a prefix with no compiler in it, repairable
+only by a successful re-run. It now unpacks into `$PREFIX/.stage.$$`,
+checks the staged tree for `bin/nurl`, and only then swaps: directories
+replaced wholesale so a file dropped upstream cannot linger, `bin/` merged
+file by file because it also holds programs installed with `nurlpkg
+install`. The destructive window is a handful of renames on one filesystem
+instead of the length of an extraction, and the staging directory is on the
+existing `EXIT` trap. `webdocs/public/install.sh` was re-synced, which
+`tools/check_installer_sync.sh` confirms.
+
+`tools/tests/test_installer_unpack.py` serves a release over `file://` so
+the real download, checksum and unpack path runs with no network: a fresh
+install; an upgrade that replaces the toolchain and keeps `credentials`,
+`models/` and a `nurlpkg`-installed `bin/mytool`; a truncated archive; an
+archive with no `bin/nurl`; a checksum mismatch; and the pre-existing
+refusal to overwrite a prefix that is not a NURL install. Six controls, all
+passing, and two of them FAIL against the pre-change installer — which is
+what makes them a control rather than a description.
+
+**Downloaded tools are pinned by content, not only by URL.** A
+version-pinned URL says what was asked for, not what came back. Twelve
+sites were unpinned, including the zig the release job unpacks INTO the
+published archive — bytes that reach every user of the installer — and two
+benchmark jobs whose reference runtime was whatever `curl
+https://wasmtime.dev/install.sh | bash` installed that day, under numbers
+the repo publishes. Now: zig 0.16.0 by sha256 in `release.yml`, `fuzz.yml`
+and `wasm-bench.yml` (digests from ziglang.org's own index); wasmtime
+v48.0.2 as a pinned release archive with a checksum in place of both
+`curl | bash` sites; cloud-hypervisor v46.0 by sha256; and `rustup-init`
+1.29.1 from the archive URL with a checksum across all seven bench
+workflows, in place of `curl https://sh.rustup.rs | sh`. The Rust
+TOOLCHAIN stays `stable` deliberately — the point of that column is what
+current stable Rust does, and the resolved version is recorded in each
+run's toolchain-versions step.
+
+`tools/check_pinned_downloads.py` keeps it that way: per `run:` block, a
+download of an executable or archive must be followed by `sha256sum -c` in
+the same block, and nothing may pipe a downloaded script into a shell.
+Fetches that are not tool installs — an `api.github.com` query whose body
+the job parses, traffic to a server the job started — are excluded by host,
+not by naming files. It reports all twelve sites against the parent
+commit's workflows and passes on all sixteen workflow files now; it runs in
+CI beside `check_installer_sync.sh`.
+
+### A13 / MEMORY.md §2.9: the opt-in checks, counted correctly (2026-09-12)
+
+The ledger noted that `docs/MEMORY.md` §2.9 is titled "three opt-in checks"
+and enumerates three, while the aggregate-literal maybe-move is a fourth
+thing `--strict-borrowck` reports. Reading the implementation resolves it
+the other way: there are three checks, and the third one's DESCRIPTION was
+too narrow. Check 3 fires on a consume of a binding in the MAYBE-MOVED
+state, and §2.9 described only one of the routes into that state ("freed on
+one arm of a `?`"). The state is also reached by a value-producing `?` /
+`??` selecting the handle, by storing it in an aggregate literal, by
+pushing it into a container that frees its elements, by an alias assignment
+`= z a`, by a closure that captures and frees it, and by a call whose
+effect is not decidable at that point (the callee may `sink` the parameter
+or return the handle). §2.9 now lists all seven and says explicitly that a
+*read* of a maybe-moved binding is not covered, with a pointer here.
+
+Five of the seven were confirmed against the current compiler rather than
+taken from the code: a `Vec` handle selected by a `?`, stored into an
+aggregate literal, handed over by `= z a`, captured by a closure that frees
+it, and passed to a `sink` parameter. Each program compiles clean by
+default and each is reported under `--strict-borrowck`, naming the route it
+took ("its handle was stored into an aggregate literal at line 8", "a
+closure that captured it frees it at line 6"). That is the same one check
+firing on five spellings, which is the point.
+
+### Decisions recorded: the fourth strict check, and stack lifetimes (2026-09-12)
+
+Two items were carrying a witness and a measurement each, waiting on a
+decision rather than on work. Both are decided as **not now**, with the
+reasons, so the next reader inherits a position rather than a question.
+
+**A fourth `--strict-borrowck` check for a READ of a maybe-moved binding:
+not built.** The witness is real — a free on one arm of a `?` followed by
+an unconditional read after the join is a use-after-free on the taken path,
+reported in neither mode. The two measurements argue against building it
+now. Strict mode already reports 1,070 distinct sites across 553
+first-party files, so the acceptance bar the docs used for strict check #1
+("adds no new strict failures") cannot be applied, and a new check makes a
+mode nobody can run clean noisier still. And the borrow-check walk has no
+read events at all — its record kinds are `let`, `assign`, `move`,
+`maybemove`, `pendcall`, `cond`, `match`, `block` — so this is a new record
+stream out of `gen_ident`, which fires on every identifier in every
+program, plus a rule for which reads matter. The right order is: get strict
+mode to a state where its output can be read, then add checks to it.
+§2.9 now states the gap explicitly, which is the part that was missing.
+
+**A lexical stack-lifetime policy (`llvm.lifetime.start/end`): not built.**
+Every NURL alloca is hoisted to the entry block and lives for the whole
+function, so a use-after-scope inside one frame is not a memory error
+today — at worst a slot reused across loop iterations. The escape that IS
+a dangling pointer, a stack reference outliving its function, is rejected
+in every spelling tried: assignment, struct field store, conditional arm,
+closure of closure, nested blocks, loop body, interprocedural, and
+block-expression initialisers. Lifetime markers would therefore buy
+detection and stack reuse, not correctness, and they must still account for
+deferred cleanup reaching a slot after its lexical block — a defer runs
+during return, long after the block that allocated the slot has closed.
+That is a codegen change with a real correctness obligation for a benefit
+that is not correctness. It stays open in A01's row as a documented
+boundary rather than a pending repair.
+
+### A token deleted, again: two shapes no hand-written spelling reached (2026-09-12)
+
+The sweep from 2026-09-11 was re-run — seeds 1 and 3, fifty corpus programs,
+against a private copy of the compiler with the corpus copied out of the tree,
+as the harness enforces on itself. Three findings, two distinct defects, and
+both are the class this whole sweep exists for: a construct the language
+allows, reached by a path that skipped its own check, exiting 0 with no
+`main` and nothing on stderr.
+
+**An unterminated trait body swallowed the rest of the file.** Deleting one
+`}` from `% Speaker [T] { @ speak T self → i }` left the body open. The
+method-header scan advanced to "the first `{`", which is now the NEXT
+declaration's brace, so `: Dog { i pitch }` became the method's default body
+and the trait appeared to end at some inner `}`. The EMIT pass does not scan
+that way — it skips balanced braces — so it consumed to end of file. The two
+passes disagreed about where the trait ended, and `main` was inside the
+difference. Found twice independently (seed 3 on `diag_dyn_no_impl.nu`, seed
+1 on `showcase.nu`), which is what a real defect looks like from two seeds.
+
+Fixed in two places, because one alone is not the rule. The header scan now
+stops at the `→` and consumes exactly the return type — `skip_one_type`, a
+structural walk, because `parse_type` cannot stand in here: inside a trait
+declaration the type parameter lexes as the boolean literal (`% Maker [T] {
+@ make T self → T }`) and only the declaration's own context knows it names a
+type. And a trait or impl body now REJECTS any token that is neither a method
+nor an associated type, instead of skipping it. The skip is what made an
+unterminated body dangerous in the first place, and it was also silently
+accepting `% Sh { 42 }`, a nested declaration, and an impl body full of junk.
+
+**A generic template whose body brace was missing swallowed the next
+declaration.** `@ ship [T: Send] T v → i` with its `{` deleted: the template
+collector took tokens "until the next `{` anywhere", found `@ main → i {`'s
+brace, and called everything before it the signature and everything after it
+the body. Only the BOUNDED form reaches that path (`[T]` alone is rejected by
+the concrete path), which is why no hand-written spelling had found it. The
+collector now finds the end of the signature with the same structural walk,
+collects up to that point, and then requires the brace — which the concrete
+function path has always required.
+
+Both are pinned in `tools/tests/test_declaration_forms.py` (`trait_unterminated`,
+`generic_fn_bound_no_body`, plus the junk-in-body forms the same fix closed),
+and the `showcase.nu` mutant — found independently, before the fix existed —
+is rejected by the repaired compiler, which is the control that matters.
+
+Seeds 2 and 4 were still running on two very large corpus programs when this
+was written; the sweep is single-threaded per invocation and one 12 KB
+program is several thousand compiles. Run several `--seed`s in parallel
+rather than one long `--files`, and record which seeds have been run clean.

--- a/docs/dev/V1_HARDENING.md
+++ b/docs/dev/V1_HARDENING.md
@@ -2342,12 +2342,13 @@ boundary rather than a pending repair.
 
 ### A token deleted, again: two shapes no hand-written spelling reached (2026-09-12)
 
-The sweep from 2026-09-11 was re-run — seeds 1 and 3, fifty corpus programs,
-against a private copy of the compiler with the corpus copied out of the tree,
-as the harness enforces on itself. Three findings, two distinct defects, and
-both are the class this whole sweep exists for: a construct the language
-allows, reached by a path that skipped its own check, exiting 0 with no
-`main` and nothing on stderr.
+The sweep from 2026-09-11 was re-run to completion — **seeds 1, 2, 3 and 4,
+one hundred corpus programs**, against a private copy of the compiler with the
+corpus copied out of the tree, as the harness enforces on itself. **Four
+findings, two distinct defects**, and both are the class this whole sweep
+exists for: a construct the language allows, reached by a path that skipped
+its own check, exiting 0 with no `main` and nothing on stderr. Seed 2 found
+nothing over its 25 programs.
 
 **An unterminated trait body swallowed the rest of the file.** Deleting one
 `}` from `% Speaker [T] { @ speak T self → i }` left the body open. The
@@ -2374,17 +2375,22 @@ declaration.** `@ ship [T: Send] T v → i` with its `{` deleted: the template
 collector took tokens "until the next `{` anywhere", found `@ main → i {`'s
 brace, and called everything before it the signature and everything after it
 the body. Only the BOUNDED form reaches that path (`[T]` alone is rejected by
-the concrete path), which is why no hand-written spelling had found it. The
-collector now finds the end of the signature with the same structural walk,
-collects up to that point, and then requires the brace — which the concrete
-function path has always required.
+the concrete path), which is why no hand-written spelling had found it — and
+seed 4 found it again independently in `trait_order.nu`
+(`@ measure [A: Reading] A self → i`), which is what a real defect looks like
+from two seeds. The collector now finds the end of the signature with the same
+structural walk, collects up to that point, and then requires the brace —
+which the concrete function path has always required.
 
 Both are pinned in `tools/tests/test_declaration_forms.py` (`trait_unterminated`,
-`generic_fn_bound_no_body`, plus the junk-in-body forms the same fix closed),
-and the `showcase.nu` mutant — found independently, before the fix existed —
-is rejected by the repaired compiler, which is the control that matters.
+`generic_fn_bound_no_body`, plus the junk-in-body forms the same fix closed).
+The control that matters is the other direction: **all four mutants — found
+before either fix existed, three of them in programs no hand-written form
+resembles — are rejected by the repaired compiler**, each with a message and a
+position. The repairs answer witnesses they were not written against.
 
-Seeds 2 and 4 were still running on two very large corpus programs when this
-was written; the sweep is single-threaded per invocation and one 12 KB
-program is several thousand compiles. Run several `--seed`s in parallel
-rather than one long `--files`, and record which seeds have been run clean.
+Practical note for the next run: the sweep is single-threaded per invocation
+and one 12 KB corpus program is several thousand compiles, so seeds 2 and 4
+took roughly an hour each. Run several `--seed`s in parallel rather than one
+long `--files`. **Seeds 1-4 are now clean** against the repaired compiler;
+seed 5 onwards is where the next one is.

--- a/docs/dev/V1_HARDENING_HANDOFF.md
+++ b/docs/dev/V1_HARDENING_HANDOFF.md
@@ -222,15 +222,24 @@ compiler, so the repair answers a witness it was not written against.
    additionally requires external validation for the independent cryptographic
    review, which cannot be closed from inside this repo. A15 is closed.
 
-7. **Remote results.** Confirm the remote runs for these commits. Previous
-   remote state: every job passed at `070ff0a8` — the Linux compiler job,
-   FreeBSD, macOS ARM64, Windows, the sanitizer job, the runner
-   fault-injection controls, the unikernel job, the MinGW msvcrt cross-link
-   job, required-tool fault injection, webdocs and all four JavaScript
-   audit/build jobs. That validates those revisions and those workflow scopes,
-   not every distribution target. The workflow edits in this round change how
-   zig, wasmtime, cloud-hypervisor and rustup are fetched in the release,
-   fuzz, CI and seven bench workflows; those legs have not run remotely since.
+7. **Remote results, and the workflows CI cannot reach.** Every remote check
+   passed on this branch at `359ac597` — all seventeen: the Linux compiler job
+   with the bootstrap fixed point and corpus (13m28s), the same on arm64,
+   FreeBSD in a VM, Windows, the AddressSanitizer + UBSan job (20m22s), the
+   unikernel job, the MinGW msvcrt cross-link job, required-tool fault
+   injection, the runner fault-injection controls, webdocs and all four
+   JavaScript audit/build jobs. `check_pinned_downloads.py` ran there too, and
+   the unikernel job's `cloud-hypervisor` fetch printed `/tmp/cloud-hypervisor:
+   OK` — one of the new checksums verified on a real runner.
+
+   The honest gap: **only `ci.yml` runs on a pull request.** `release.yml` runs
+   on push/dispatch, `fuzz.yml` on a schedule, and all seven bench workflows on
+   dispatch only. So the zig, wasmtime and rustup pinning in those nine files
+   is verified by inspection and by the gate, not by having run — including
+   the release job's zig, which is the one whose bytes ship inside the
+   published archive. Dispatch `fuzz.yml` and one bench workflow before
+   trusting them, and watch the next release's "Fetch bundled zig backend"
+   step for its `OK` line.
 
 ## Reproduction
 

--- a/docs/dev/V1_HARDENING_HANDOFF.md
+++ b/docs/dev/V1_HARDENING_HANDOFF.md
@@ -1,10 +1,9 @@
 # v1 hardening continuation
 
-Work on branch `codex/v1-validation-hardening`. PR #1107 is a draft;
-do not merge it or declare v1 hardening complete from focused results.
-The complete scope and evidence requirements remain in
+The complete scope and evidence requirements are in
 [V1_HARDENING.md](V1_HARDENING.md). The external LLM-written audit supplies
-hypotheses, not authority.
+hypotheses, not authority. No item below certifies the whole language or
+ecosystem, and passing a narrow check does not establish a broad guarantee.
 
 ## Current implementation
 
@@ -30,35 +29,73 @@ dynamic invalid shifts and out-of-range/NaN/infinite float-to-integer casts
 before LLVM undefined behavior or poison. Scalar and aggregate-field casts
 share unsignedness, bounds and bool rejection. Fractional values that truncate
 into range remain valid; IEEE floating arithmetic is unchanged. The
-differential fuzzer now reaches those guards: half of its divisors and shift
+differential fuzzer reaches those guards: half of its divisors and shift
 amounts are computed sub-expressions clamped into the legal domain rather than
 literals, so the guard branch is live at -O0 and the oracle catches a guard
 that fires on a legal operand.
 
-Thirteen defects of one shape are closed: a construct the language allows,
-reached by a path that skipped its own check. Ten in the parser — a binding
-initialised by a block, a global constant with no value, a struct or generic
-function with no body, an unclosed type-parameter list, a `:` followed by
-junk, a function whose body is empty, two parameters sharing a name, a match
-with no arms, and a foreach over something that is not a slice. Each exited 0
-and lost the declaration after it, or emitted IR only clang rejected — or, in
-the foreach case, IR with empty types and nothing on stderr at all.
+**Nineteen defects of one shape are closed: a construct the language allows,
+reached by a path that skipped its own check.** Thirteen were found by
+sweeping declarations and simple statements; four more by continuing the same
+sweep into expression position, trait and impl bodies, match and select arms,
+and the block terminators; two more by the token-deletion sweep.
 
-Three more in the type checker. A field WRITE to a name the struct does not
-have stored into field 0 and printed `store  5, * %r` with no types; the read
-side had rejected the same typo for years, with a comment explaining exactly
-this miscompile. And the pre-registered C-runtime surface — `nurl_print` and
-the 117 others every program calls — was registered with a return type only,
-so its call sites had no arity or argument check at all: `( nurl_print 5 )`
+Ten in the parser — a binding initialised by a block, a global constant with
+no value, a struct or generic function with no body, an unclosed type-parameter
+list, a `:` followed by junk, a function whose body is empty, two parameters
+sharing a name, a match with no arms, and a foreach over something that is not
+a slice. Each exited 0 and lost the declaration after it, or emitted IR only
+clang rejected — or, in the foreach case, IR with empty types and nothing on
+stderr at all.
+
+Three in the type checker. A field WRITE to a name the struct does not have
+stored into field 0 and printed `store  5, * %r` with no types; the read side
+had rejected the same typo for years, with a comment explaining exactly this
+miscompile. And the pre-registered C-runtime surface — `nurl_print` and the
+117 others every program calls — was registered with a return type only, so
+its call sites had no arity or argument check at all: `( nurl_print 5 )`
 compiled and segfaulted dereferencing 5. Those symbols now get the FFI path's
 own side-tables, filled by parsing the `declare` lines the compiler already
 emits, so there is no second table to drift.
 
-`tools/tests/test_declaration_forms.py` pins the class with one invariant
-over 44 forms; the corpus pins each fix with its own rejection. Opening the
-block-initialiser path also exposed a borrow-checker hole: `bck_esc_let`
-recorded a referent depth without comparing it, so a closure over a
-block-local `: ~` struct could be bound outside that block.
+Four more from the continued sweep. `Z NoSuchType` was the one type position
+with no declared-type check, and emitted a getelementptr on a type nothing
+declares. An or-pattern's ALTERNATIVES were never checked against the enum,
+though the first name has been for years — `Red | Nope` emitted a load of a
+global nothing defines. `break` and `continue` inside a `;` defer body
+branched into a loop exit the defer chain had already left and re-entered the
+chain from there, so `; { break }` inside a loop compiled, exited 0 and ran
+forever; `^` was already rejected for that exact reason. And an impl was never
+checked against the trait it names: a missing required method, a wrong arity,
+wrong non-receiver parameter types and a wrong return type all compiled. The
+last is a type confusion, not a convenience — `dyn` builds its thunk from the
+DECLARED signature, so a trait promising `→ i` implemented with `→ s` hands
+the caller a pointer to read as an integer, with no diagnostic anywhere.
+
+Two more came from the token-deletion sweep, and both swallowed a whole
+declaration. Deleting one `}` left a trait body unterminated: the method-header
+scan advanced to "the first `{`", which is then the NEXT declaration's brace,
+so `: Dog { i pitch }` became the method's default body and the trait appeared
+to end at some inner `}` — while the emit pass skips BALANCED braces and
+therefore consumed to end of file. The two passes disagreed about where the
+trait ended and `main` was inside the difference: exit 0, no `main`, nothing
+on stderr. Deleting one `{` did the same to a generic template with a trait
+bound (`@ ship [T: Send] T v → i`): the collector took tokens "until the next
+`{` anywhere", found `@ main → i {`'s brace, and called everything after it
+the template's body. Only the BOUNDED form reaches that path, which is why no
+hand-written spelling had found it.
+
+Both header scans now stop at the `→` and consume exactly the return type,
+and a trait or impl body rejects any token that is neither a method nor an
+associated type instead of skipping it — that skip is what made an
+unterminated body dangerous, and it was also silently accepting `% Sh { 42 }`
+and an impl body full of junk.
+
+`tools/tests/test_declaration_forms.py` pins the class with one invariant over
+**95 forms** in three tables; the corpus pins each fix with its own rejection.
+Opening the block-initialiser path also exposed a borrow-checker hole:
+`bck_esc_let` recorded a referent depth without comparing it, so a closure over
+a block-local `: ~` struct could be bound outside that block.
 
 Two tree gates were checking less than they claimed. The canonical-form gate
 named five directories and left 464 first-party files ungated (18 had
@@ -73,159 +110,126 @@ only the Linux matrix as a hard gate — a failed Windows leg published a
 release with no `.zip`, and the PowerShell one-liner then 404s.
 `tools/check_release_artifacts.sh` runs before publication and requires the
 documented set, its checksums, and its signatures when signing ran; eleven
-controls cover it.
+controls cover it. The installer now stages its unpack, so a failed extraction
+leaves the existing install intact, and every tool a workflow downloads is
+pinned by sha256 — including the zig that ships inside the published archive.
 
 ## Latest compiler verification
 
-Both refreshed bootstraps pass. Normal build: 55-57 s; corpus 2 m 30 s. The
-corpus reports **985 PASS / 19 SKIP** over 1,004 inputs, with zero
-compiler/link/runtime/timeout failures. All seven arithmetic methods pass
-with both normal and instrumented compilers: 596 runtime cases across three
-modes, **1,788 executions plus two rejections**. All 31 ownership, seven
-compiler-cleanup and 20 LSP methods pass on the final shared instrumented
-toolchain. All six compiler leak-gate sources pass ordinary and split
-emission; sanitizer detection calibration also passes.
+Corpus **992 PASS / 19 SKIP** over 1,011 inputs, zero
+FAIL/MISSING/ORPHAN. Normal build 59 s; tests 2 m 56 s. The sanitized
+corpus reports **992 PASS / 19 SKIP with zero AddressSanitizer, UBSan or
+LSan findings**, zero timeouts and zero compile/link/run failures.
+All seven arithmetic methods, all 31 ownership methods, seven
+compiler-cleanup methods, two driver-path controls, the WASI IR control,
+eleven release-artifact controls and six installer-unpack controls pass.
+`nurlfmt --check` is canonical over 1,790 files; strict-arity, memgate,
+dcegate and leakgate pass, the last on both emission modes.
 
-After the parser changes, the 303 diagnostics the stdlib, packages and
-examples produce are byte-identical to those the pre-change compiler produced
-over the same 719 files. That is the check that matters most for a parser
-edit: the corpus cannot see code it does not contain.
+The check that matters most for a change that ADDS diagnostics is the tree
+sweep: every tracked first-party `.nu` file — **816 of them** — compiled with
+the parent commit's compiler and with this one produces **byte-identical**
+output and exit codes. The corpus cannot see code it does not contain; the
+tree can.
 
-Fuzz campaigns on the changed compiler: 600 integer seeds, 150 structural
-seeds with 37 sanitizer runs, and 200 inverse-oracle seeds — all clean.
+**Sixteen** of the new `test_declaration_forms.py` rows FAIL against a
+compiler built from the parent commit and pass against this one, and two of
+the six installer controls FAIL against the previous installer. That is what
+makes them controls rather than descriptions. The strongest single piece of
+evidence is a mutant the sweep found BEFORE the fix existed
+(`showcase.nu` with one `}` deleted): it is rejected by the repaired
+compiler, so the repair answers a witness it was not written against.
 
-Ownership traffic through the newly reachable block-expression path was
-checked separately under ASan+LSan with leak detection on: an owned tail
-value, one bound inside the block and handed out, a second owned local
-dropped at block exit, nested block initialisers, and allocation inside a
-loop. Correct values, zero findings.
+## Next work
 
-## Remote state and next work
+1. **Continue the same sweep.** Take a construct the grammar allows, write it
+   in a spelling nothing in the tree uses, and check the implementation
+   against `spec/grammar.ebnf`. Declarations, simple statements, expression
+   position, trait/impl bodies, match and select arms and the block
+   terminators are done. Not done: the `$`-import surface (aliased imports,
+   nested aliases, the duplicate-include guard), generic instantiation at
+   call sites, `dyn` construction and object safety, `inout` / `sink`
+   conventions, and the `pub` visibility boundary. Extend
+   `test_declaration_forms.py`'s tables rather than writing a second harness.
+   The two questions that found the most: what does this construct do in a
+   spelling nothing in the tree uses, and does the WRITE side of a check
+   exist as well as the read side.
 
-1. Every remote job passed on this branch at `070ff0a8`: the Linux compiler
-   job, FreeBSD, macOS ARM64, Windows, the sanitizer job, the runner
-   fault-injection controls, the unikernel job, the MinGW msvcrt cross-link
-   job, required-tool fault injection, webdocs and all four JavaScript
-   audit/build jobs. That validates those revisions and those workflow
-   scopes, not every distribution target. Keep PR #1107 a draft. The commits
-   after `070ff0a8` are pushed; confirm their remote results.
-2. Continue the sweep that found those thirteen defects. Take a construct
-   the grammar allows, write it in a spelling nothing in the tree uses, and
-   check the implementation against `spec/grammar.ebnf`. Declarations and
-   simple statements are done; expression position, trait/impl bodies,
-   select arms, foreach and the `!`/`?` operator forms are not. The
-   permanent control is `tools/tests/test_declaration_forms.py` — extend its
-   table rather than writing a second harness. The two questions that found
-   the most: what does this construct do in a spelling nothing in the tree
-   uses, and does the WRITE side of a check exist as well as the read side.
-3. A token-deletion sweep over corpus programs (delete one token; the
-   compiler must either reject the file or still emit `main`) is written but
-   has not completed a clean run — twice interrupted by rebuilding or
-   cleaning the tree underneath it. Run it against a PRIVATE copy of
-   `build/nurlc` and keep its mutants out of `compiler/tests/`; one was
-   committed by accident and had to be removed.
-4. A01's stack-lifetime item is narrower than the ledger recorded, and its
-   cited probe has been resolved. Written with a `: ~` struct the capture is
-   by pointer and the assignment is rejected at compile time; written with a
-   scalar — which is how a probe that PRINTS 42 must have been written — the
-   capture is by VALUE, so there is no dangling reference to detect and the
-   clean exit was the right answer. Running that probe under LeakSanitizer
-   instead found two real leaks in the closure-env machinery, both fixed and
-   pinned by `closure_env_assign.nu`.
+2. **One hole from the sweep is found and NOT closed.** A trait method header
+   with no return arrow (`% Sh { @ area i o }`) is accepted at the
+   declaration. Nothing consumes the recorded signature unless the trait is
+   used dynamically, and the dyn re-parse is where it is reported today —
+   `compiler/tests/diag_dynsig_context.nu` exists to pin that message and its
+   context. Rejecting it at the declaration is the right place and would
+   retire that fixture's witness, so it needs a decision about the fixture,
+   not just an edit. The impl-signature check skips a header with no arrow
+   for the same reason.
 
-   What remains: every NURL alloca is hoisted to the entry block and lives
-   for the whole function, so a use-after-scope inside one frame is not a
-   memory error today — at worst a slot reused across loop iterations. The
-   escape that IS a dangling pointer, a stack reference outliving its
-   function, is rejected in every spelling tried (assignment, struct field
-   store, conditional arm, closure of closure, nested blocks, loop body,
-   interprocedural, and block-expression initialisers). A lifetime-marker
-   policy therefore buys detection and stack reuse, not correctness, and
-   must still account for deferred cleanup reaching a slot after its lexical
-   block. Decide whether that trade is worth making before writing it.
+3. **Keep running the token-deletion sweep** (`tools/fuzz/mutate_delete.py`):
+   delete one token; the compiler must either reject the file or still emit
+   `main`. It found the eighteenth defect this round, in a construct no
+   hand-written spelling had reached. It is single-threaded per invocation
+   and a large corpus program is thousands of compiles, so run several
+   `--seed`s in parallel rather than one long `--files`. The ledger records
+   which seeds have been run clean; a seed nobody has run is where the next
+   one is.
 
-   The technique that paid here is worth repeating on its own: run existing
-   probes under LSan, not only ASan. The leak was invisible to every ASan
-   run and to the default sanitized corpus, which sets `detect_leaks=0`.
+4. **A01's remaining item is a recorded decision, not pending work.** Lexical
+   stack lifetimes: every NURL alloca is entry-hoisted and lives for the whole
+   function, so a use-after-scope inside one frame is not a memory error
+   today, and the escape that IS a dangling pointer is rejected in every
+   spelling tried. Lifetime markers buy detection and stack reuse, not
+   correctness, and owe an account of deferred cleanup reaching a slot after
+   its lexical block. Reopen it with that trade in hand, or leave it.
 
-   Turning it on for the whole corpus measured the boundary: 903 of 992
-   programs are leak-clean, 89 are not, with zero other sanitizer findings.
-   Grouping them by the function that allocated (`tools/fuzz/leak_triage.py`)
-   is what made them tractable — and what found that the COMPILER leaked a
-   whole rewritten copy of every aliased import, on a path `leakgate.sh`
-   could not reach because `nurlc.nu` has no aliased import. That is fixed
-   and the gate now covers it.
-   One cause is root-caused and now FIXED: a closure literal passed to a
-   GENERIC higher-order function leaked its env, because the call site asked
-   `g_fn_invoke_only` a question whose answer does not exist until the
-   instantiation is flushed. The argument-temporary path already solved that
-   shape — emit the free against a null-or-pointer value selected by a
-   private constant computed at module end — and the closure-env free now
-   uses it (`mem_env_owner` / `mem_emit_env_flags`). Three programs, 89
-   leakers to 86; it needed a bootstrap refresh, which is done.
+   What remains genuinely open in A01 is the leak inventory: 86 of 992 corpus
+   programs leak under `LSAN_DETECT_LEAKS=1`, and the ledger attributes them
+   to two root causes and one test-side habit rather than 86 defects.
+   - **The closure-env class.** A closure RETURNED by a function has no
+     owner: the binding path registers an env only for a closure LITERAL
+     initialiser. The env pointer is knowable at the binding; what is missing
+     is the fresh-vs-alias answer the string path gets from
+     `__last_call_ret_owned__`. Registering without it is a double free, so
+     this needs a summary bit, not a patch.
+   - **The escape-classification class.** A parameter stored into a container
+     that dies inside the same callee is classified as escaping, so the
+     caller's fresh temporary is never freed by anyone. The whole `fmt` family
+     does this, which makes it the idiomatic-printing leak. Fixing it needs
+     either a dataflow refinement (a store into a container that provably dies
+     before return is not an escape) or a parameter marker asserting
+     non-escape the way `sink` asserts consumption — the second is a language
+     decision.
+   The criterion that separates a compiler defect from a test that simply
+   never frees is "can the program free it?", not where the allocation was
+   made. Apply it with a control, by writing the same call with the free
+   present.
 
-   The rest of the closure-env class is a different sub-shape, characterised
-   in the ledger: a closure RETURNED by a function. `iter_zip_enum` binds an
-   iterator and ends it with `( ab 1 )`, which IS `iter_free` — the protocol
-   frees the chain but cannot free the closure's own env, because that is
-   what the call is executing on. The binding path registers an env only for
-   a closure LITERAL initialiser, so a call result has no owner. The env
-   pointer is knowable at the binding; what is missing is the fresh-vs-alias
-   answer the string path gets from `__last_call_ret_owned__`. Registering
-   without it is a double free, so this needs a summary bit, not a patch.
-   A second class is root-caused in the ledger too: a parameter stored into
-   a container that dies inside the same callee is classified as escaping,
-   so the caller's fresh temporary is never freed by anyone. The whole
-   `fmt` family does this, which makes it the idiomatic-printing leak.
-   Fixing it needs either a dataflow refinement (a store into a container
-   that provably dies before return is not an escape) or a parameter marker
-   that asserts non-escape the way `sink` asserts consumption — the second
-   is a language decision, not a repair.
-
-   The inventory is attributed at the group level. Tests that allocate and
-   never free anything are the largest group and need nothing from the
-   compiler. `bytes_from_hex`'s five callers could free and do not — the
-   same call written with the free present is leak-clean. The
-   `nurl_str_int` six are the escape-classification class, which no
-   spelling of the program can reclaim. Everything else is the closure-env
-   class, including `iter_zip_enum`, whose iterator is a closure returned
-   by a generic function rather than a literal in the test.
-
-   So: two root causes and one test-side habit, not ninety defects. The
-   criterion that separates them is "can the program free it?", not where
-   the allocation was made — apply it with a control, by writing the same
-   call with the free present.
-5. A13's container and opaque-handle half now has witnesses (see the
-   ledger): ten violations by construction, every one the default rules
-   promise to catch caught, the three that compile are holes
-   `docs/MEMORY.md` declares, and two of those three are reported under
-   `--strict-borrowck`. Two things came out of it that need an owner's
-   decision rather than an edit:
-   - A free on one arm of a `?` followed by an unconditional READ after the
-     join is a guaranteed use-after-free on the taken path and is reported
-     in neither mode. §2.1 says reads of a maybe-moved binding are never
-     flagged; strict mode is where false positives are acceptable, so a
-     fourth strict check has a witness and a home. Two numbers before
-     building it, both in the ledger: `--strict-borrowck` already reports
-     1,070 distinct sites across 553 first-party files, so the "adds no new
-     strict failures" bar the docs used for check #1 cannot be applied; and
-     the walk has no read events at all, so the check is a new record stream
-     out of `gen_ident`, not an `if`.
-   - `docs/MEMORY.md` §2.9 says "three opt-in checks" and lists three, while
-     strict mode also reports the aggregate-literal maybe-move.
-
-   Still open in A13: opaque wrappers beyond Channel, whether the default,
-   strict and raw guarantees agree on everything else, and A16's
+5. **A13's remaining scope.** The fourth strict check (a READ of a maybe-moved
+   binding) is a recorded decision not to build: strict mode already reports
+   1,070 sites across 553 first-party files, so its own acceptance bar cannot
+   be applied, and the walk has no read events at all — it is a new record
+   stream out of `gen_ident`, not an `if`. `docs/MEMORY.md` §2.9 now states
+   that gap explicitly. Still open: opaque wrappers beyond `Channel`, whether
+   the default, strict and raw guarantees agree on everything else, and A16's
    indirect/generic/embedded-origin cleanup counterexamples. Borrowed-initial
    mutable bindings are untouched.
-6. Retain every A01-A17 requirement. A07 (continuous package/service tests)
-   is still only an inventory question, and it sits against the standing
-   decision not to wire package tests into compiler CI — that needs a
-   direction before work, not after. A09, A14 and A17 are untouched. A15's
-   remaining halves are pinned tool downloads and a staged unpack: the
-   installer removes the old toolchain before extracting, so an extraction
-   interrupted after verification leaves a broken prefix that only a re-run
-   repairs.
+
+6. **Retain every A01-A17 requirement.** A07 (continuous package/service
+   tests) is still only an inventory question, and it sits against the
+   standing decision not to wire package tests into compiler CI — that needs
+   a direction before work, not after. A09, A14 and A17 are untouched; A14
+   additionally requires external validation for the independent cryptographic
+   review, which cannot be closed from inside this repo. A15 is closed.
+
+7. **Remote results.** Confirm the remote runs for these commits. Previous
+   remote state: every job passed at `070ff0a8` — the Linux compiler job,
+   FreeBSD, macOS ARM64, Windows, the sanitizer job, the runner
+   fault-injection controls, the unikernel job, the MinGW msvcrt cross-link
+   job, required-tool fault injection, webdocs and all four JavaScript
+   audit/build jobs. That validates those revisions and those workflow scopes,
+   not every distribution target. The workflow edits in this round change how
+   zig, wasmtime, cloud-hypervisor and rustup are fetched in the release,
+   fuzz, CI and seven bench workflows; those legs have not run remotely since.
 
 ## Reproduction
 
@@ -240,15 +244,27 @@ loop. Correct values, zero findings.
 - `python3 tools/tests/test_wasi_ir.py` — isolated shared-rewriter LLVM/leak control.
 - `./packages/wasmbuilder/tests/build_test.sh` — require actual Wasmtime execution.
 - `python3 tools/tests/test_driver_paths.py` — two real split/path controls.
-- `python3 tools/tests/test_declaration_forms.py` — 44 declaration and
-  statement forms against one invariant; needs only `build/nurlc`, under 0.2 s.
+- `python3 tools/tests/test_declaration_forms.py` — 95 declaration, statement
+  and match-arm forms against one invariant; needs only `build/nurlc`, under 0.3 s.
 - `python3 tools/tests/test_release_artifacts.py` — eleven controls over the
   release artifact-set gate; needs no toolchain at all.
+- `python3 tools/tests/test_installer_unpack.py` — six controls over the
+  staged unpack; serves a release over `file://`, no network, no toolchain.
+- `python3 tools/check_pinned_downloads.py` and `./tools/check_installer_sync.sh`
+  — the workflow and served-installer gates; both need no toolchain.
+- `./compiler/tests/nurlfmt_check.sh` and `./tools/check_strict_arity.sh`.
 - `python3 tools/fuzz/mutate_delete.py --files 40` — the token-deletion sweep.
   Tens of thousands of compiles; a hunting tool, not a gate.
 - `LSAN_DETECT_LEAKS=1 ./compiler/tests/run_san_tests.sh` — the whole corpus
   with leak detection on, which the default run leaves off.
 - `NURL_TEST_PWSH=/absolute/path/to/pwsh python3 tools/tests/test_compiler_runners.py`
+- **The tree sweep, for any change that adds a diagnostic.** Compile every
+  tracked first-party `.nu` file with the parent commit's compiler and with
+  the new one, and diff the two transcripts. A corpus fixture cannot see code
+  it does not contain; 816 real files can, and byte-identical output is the
+  only evidence that a new rejection rejects nothing that was valid. Build the
+  baseline by compiling `git show HEAD:compiler/nurlc.nu` with
+  `build/nurlc_lastgood.bin` and linking against `stdlib/runtime.o`.
 - Never rebuild shared compiler/runtime outputs while tests consume them; never
   overlap corpus runners using the same verdict directory. Both rules were
   broken in one session: a sweep died when `./build.sh` replaced `build/nurlc`

--- a/docs/dev/V1_HARDENING_HANDOFF.md
+++ b/docs/dev/V1_HARDENING_HANDOFF.md
@@ -170,9 +170,10 @@ compiler, so the repair answers a witness it was not written against.
    `main`. It found the eighteenth defect this round, in a construct no
    hand-written spelling had reached. It is single-threaded per invocation
    and a large corpus program is thousands of compiles, so run several
-   `--seed`s in parallel rather than one long `--files`. The ledger records
-   which seeds have been run clean; a seed nobody has run is where the next
-   one is.
+   `--seed`s in parallel rather than one long `--files` — one 12 KB corpus
+   program is several thousand compiles, and two of the four seeds took about
+   an hour each. **Seeds 1-4 are clean** against the repaired compiler; seed 5
+   onwards is where the next one is.
 
 4. **A01's remaining item is a recorded decision, not pending work.** Lexical
    stack lifetimes: every NURL alloca is entry-hoisted and lives for the whole

--- a/tools/check_pinned_downloads.py
+++ b/tools/check_pinned_downloads.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Every tool a workflow downloads must be pinned by CONTENT, not just by URL.
+
+A version-pinned URL says which release was asked for. It does not say what
+came back. The release workflow unpacks a downloaded zig into the published
+archive, so those bytes ship to users; a benchmark whose reference runtime is
+whatever `curl … | bash` installs that day cannot be compared across runs.
+
+The rule this enforces, per `run:` block:
+
+  * a download of an executable or an archive from the network must be
+    followed, in the same block, by `sha256sum -c` (or `shasum -a 256 -c`);
+  * nothing may pipe a downloaded script into a shell.
+
+Downloads that are not tool installs — an API query whose output is parsed,
+a request aimed at a server the job itself started — are not tool pinning and
+are skipped by the host/scheme rules below rather than by naming files.
+
+    python3 tools/check_pinned_downloads.py
+
+Exit 0 when every block is pinned; 1 with the offending block otherwise.
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# A fetch aimed at one of these is not a tool install: it is a query whose
+# body the job parses, or traffic to a server the job is testing.
+NOT_A_TOOL = re.compile(
+    r"""https?://(
+          localhost | 127\.0\.0\.1 | \[::1\] | 0\.0\.0\.0
+        | api\.github\.com
+        | (\w+\.)*nurl-lang\.org
+        )""", re.X)
+
+# The verification that counts.
+VERIFIED = re.compile(r"sha256sum\s+-c|shasum\s+-a\s*256\s+-c|minisign\s+-V")
+
+# `curl … | bash`, `wget -O- … | sh`, and the same with the pipe on the next
+# line after a continuation.
+PIPED_TO_SHELL = re.compile(r"(curl|wget)[^\n|]*\|\s*(sudo\s+)?(ba)?sh\b")
+
+DOWNLOAD = re.compile(r"\b(curl|wget)\b")
+URL = re.compile(r"https?://[^\s\"'`)]+")
+# Downloading one of these is downloading a program.
+ARTIFACT = re.compile(
+    r"\.(tar\.(gz|xz|bz2)|tgz|txz|zip|exe|msi|deb|rpm|pkg|dmg|whl|jar)(\?|$)"
+    r"|/releases/download/|-static$|/install\.sh$|/rustup\.sh$|sh\.rustup\.rs")
+
+
+def run_blocks(text):
+    """Yield (first_line_number, block_text) for every `run: |` block."""
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^(\s*)(- name:.*|.*\brun:\s*[|>][-+]?\s*)$", lines[i])
+        if m and "run:" in lines[i]:
+            indent = len(m.group(1))
+            body, j = [], i + 1
+            while j < len(lines):
+                line = lines[j]
+                if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+                    break
+                body.append(line)
+                j += 1
+            yield i + 1, "\n".join(body)
+            i = j
+            continue
+        i += 1
+
+
+def strip_comments(block):
+    """Shell comments are prose. A block explaining WHY it no longer pipes a
+    script into a shell must not be read as one that does."""
+    return "\n".join(line for line in block.splitlines()
+                     if not line.lstrip().startswith("#"))
+
+
+def check(path):
+    with open(path) as fh:
+        text = fh.read()
+    problems = []
+    for lineno, raw in run_blocks(text):
+        block = strip_comments(raw)
+        piped = PIPED_TO_SHELL.search(block)
+        if piped and not NOT_A_TOOL.search(block[piped.start():piped.end() + 200]):
+            problems.append((lineno, "pipes a downloaded script straight into a shell",
+                             piped.group(0)))
+            continue
+        if not DOWNLOAD.search(block):
+            continue
+        tools = [u for u in URL.findall(block)
+                 if ARTIFACT.search(u) and not NOT_A_TOOL.match(u)]
+        # A URL assembled from shell variables never matches ARTIFACT on its
+        # own; catch those by the extension of the file curl writes to.
+        if not tools and re.search(r"-[oO]\s*\"?[^\s\"]*\.(tar\.(gz|xz)|tgz|zip)", block):
+            tools = ["(URL built from shell variables)"]
+        if tools and not VERIFIED.search(block):
+            problems.append((lineno, "downloads a tool with no checksum check",
+                             tools[0]))
+    return problems
+
+
+def main():
+    rc = 0
+    files = sorted(f for f in os.listdir(WORKFLOWS) if f.endswith((".yml", ".yaml")))
+    for name in files:
+        for lineno, why, what in check(os.path.join(WORKFLOWS, name)):
+            print("ERROR: .github/workflows/%s:%d %s: %s"
+                  % (name, lineno, why, what), file=sys.stderr)
+            rc = 1
+    if rc == 0:
+        print("ok: %d workflow file(s); every downloaded tool is checksum-verified"
+              % len(files))
+    else:
+        print("\nPin it: download to a temp path, then\n"
+              "  echo \"<sha256>  /tmp/<file>\" | sha256sum -c -\n"
+              "before unpacking or installing. Take the digest from the\n"
+              "publisher's own index, and change it when you change the version.",
+              file=sys.stderr)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -168,28 +168,74 @@ esac
 #   share/               assets of tools installed via nurlpkg
 #   bin/<other tools>    programs installed via nurlpkg install
 # Wiping the whole prefix (as this did) silently logged the user out and
-# removed every installed tool. Remove only the toolchain's OWN paths —
-# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims —
-# and let tar overwrite the rest. Those directories are removed wholesale
-# so a file deleted upstream cannot linger.
-#
-# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
-# alive for the running process), which is what makes `nurl upgrade` —
-# nurlpkg upgrading the very tree it is executing from — safe here. The
-# Windows installer has to work around the same case differently.
+# removed every installed tool. Only the toolchain's OWN paths are replaced —
+# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims.
+# Those directories are replaced wholesale so a file deleted upstream cannot
+# linger; everything else in the prefix is left alone.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/docs" "$PREFIX/zig" "$PREFIX/libexec"
-        rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
-               "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
-               "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"
+        :
     else
         err "'$PREFIX' exists, is not empty, and is not a NURL install (no bin/nurl) — refusing to overwrite it. Remove it yourself or set NURL_HOME to a fresh path."
     fi
 fi
 info "installing to $PREFIX…"
 mkdir -p "$PREFIX"
-tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
+
+# Unpack into a staging directory INSIDE the prefix, check the result, and only
+# then touch the installed tree. The order used to be the other way round: the
+# old toolchain was deleted first and tar wrote over the hole, so an extraction
+# that stopped part-way — a full disk, a killed terminal — left a prefix with
+# no compiler in it, and only a successful re-run repaired that. Staging first
+# means every failure up to the last moment leaves the existing install intact,
+# and the destructive window is a handful of renames on one filesystem rather
+# than the length of an extraction.
+stage="$PREFIX/.stage.$$"
+rm -rf "$stage"
+mkdir -p "$stage" || err "cannot create staging directory $stage"
+# The staging directory is inside the prefix, so it must be cleaned up on every
+# exit path, not just this one — extend the trap that already owns $tmp.
+trap 'rm -rf "$tmp" "$stage"' EXIT
+tar xzf "$tmp/$archive" -C "$stage" --strip-components=1 \
+    || err "unpacking $archive failed — the existing install in $PREFIX was not touched."
+
+# Completeness is checked on the STAGED tree, before anything is removed.
+[ -x "$stage/bin/nurl" ] || err "the downloaded archive looks incomplete (no bin/nurl) — the existing install in $PREFIX was not touched."
+
+# Now the swap. Directories are replaced wholesale so a file deleted upstream
+# cannot linger; bin/ is merged file by file, because it also holds programs
+# the user installed with `nurlpkg install`.
+#
+# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
+# alive for the running process), which is what makes `nurl upgrade` —
+# nurlpkg upgrading the very tree it is executing from — safe here. The
+# Windows installer has to work around the same case differently.
+for d in build stdlib docs zig libexec; do
+    if [ -e "$stage/$d" ]; then
+        rm -rf "$PREFIX/$d"
+        mv "$stage/$d" "$PREFIX/$d"
+    fi
+done
+mkdir -p "$PREFIX/bin"
+# bin/ is merged file by file: it also holds programs installed with
+# `nurlpkg install`, which an upgrade must not remove.
+if [ -d "$stage/bin" ]; then
+    for f in "$stage/bin/"*; do
+        [ -e "$f" ] || continue
+        rm -f "$PREFIX/bin/$(basename "$f")"
+        mv "$f" "$PREFIX/bin/$(basename "$f")"
+    done
+    rmdir "$stage/bin" 2>/dev/null || true
+fi
+# Everything else the archive ships at the top level — nurl.sh, nurl.bat, env,
+# and whatever a future release adds — without deleting what is already there.
+for f in "$stage"/* "$stage"/.[!.]*; do
+    [ -e "$f" ] || continue
+    rm -rf "$PREFIX/$(basename "$f")"
+    mv "$f" "$PREFIX/$(basename "$f")"
+done
+rm -rf "$stage"
+trap 'rm -rf "$tmp"' EXIT
 
 [ -x "$PREFIX/bin/nurl" ] || err "install looks incomplete: $PREFIX/bin/nurl missing."
 

--- a/tools/tests/test_declaration_forms.py
+++ b/tools/tests/test_declaration_forms.py
@@ -20,6 +20,19 @@ here even in a spelling nobody thought to write a fixture for.
 
 A form listed as `compiles` must produce main; a form listed as `rejects`
 must exit 1. Nothing may exit 0 without main.
+
+The 2026-09-12 sweep extended the table past declarations and simple
+statements, into expression position, trait and impl bodies, match and
+select arms, and the block terminators. It found four more of the same
+shape, three of which the invariant above cannot see because they keep
+main and fail later: `Z NoSuchType` emitted a getelementptr on a type
+nothing declares; an or-pattern alternative that named no variant emitted
+a load of a global nothing defines; a `break`/`continue` inside a `;`
+defer block branched into the loop exit the defer chain had already left,
+so the program ran forever; and an impl was never checked against the
+trait it names — a missing required method, a wrong arity, wrong parameter
+types or a wrong return type all compiled, and `dyn` dispatch then called
+through a vtable built from the DECLARED signature.
 """
 import os
 import subprocess
@@ -61,12 +74,55 @@ DECLARATIONS = [
     ("generic_fn",            "@ g [T] T x → T { ^ x }",        "compiles"),
     ("generic_fn_no_body",    "@ g [T] → T",                    "rejects"),
     ("generic_fn_unclosed",   "@ g [T x → T { ^ x }",           "rejects"),
+    # A template's signature ends at its return type, not at "the next '{'
+    # anywhere in the file". With the old rule, a generic whose body brace was
+    # missing collected the NEXT declaration's '{' as its own body opener and
+    # swallowed that declaration whole — exit 0, no main, nothing on stderr.
+    # Only the bounded form (`[T: Trait]`) reached that path, which is why no
+    # hand-written spelling had found it; deleting one token did.
+    ("generic_fn_bound",      "@ g [T : Send] T x → i { ^ 0 }", "compiles"),
+    ("generic_fn_bound_no_body", "@ g [T : Send] T x → i   ^ 0 }", "rejects"),
     # ── '&' / '%' / '$' ──────────────────────────────────────────────
     ("ffi_complete",          "& `libm` @ cbrt f x → f",        "compiles"),
     ("trait_empty",           "% Show { }",                     "compiles"),
     ("trait_no_body",         "% Show",                         "rejects"),
     ("impl_no_body",          "% Show i",                       "rejects"),
     ("import_missing",        "$ `no_such_module.nu`",          "rejects"),
+    # An impl must satisfy the trait it names: the trait has to exist, every
+    # method it declares without a body has to be provided, and a provided
+    # method has to have the signature the trait declares. `dyn` builds its
+    # thunk from the DECLARATION, so a disagreement is a type confusion at
+    # the call, not a local matter.
+    ("impl_complete",         "% Sh { @ area i o → i }\n% Sh i { @ area i o → i { ^ * o 2 } }", "compiles"),
+    ("impl_uses_default",     "% Sh { @ area i o → i { ^ o } }\n% Sh i { }", "compiles"),
+    ("impl_overrides_default", "% Sh { @ area i o → i { ^ o } }\n% Sh i { @ area i o → i { ^ * o 2 } }", "compiles"),
+    ("impl_missing_required", "% Sh { @ area i o → i }\n% Sh i { }", "rejects"),
+    # An impl of a trait that is not DECLARED anywhere is the idiom, not an
+    # error: `Drop`, `Ord` and `Show` are implemented with no declaration.
+    # There is simply no contract to check for one.
+    ("impl_undeclared_trait", "% NoSuchTrait i { @ f i o → i { ^ 1 } }", "compiles"),
+    ("impl_ret_mismatch",     "% Sh { @ area i o → i }\n% Sh i { @ area i o → s { ^ `x` } }", "rejects"),
+    ("impl_arity_mismatch",   "% Sh { @ area i o i k → i }\n% Sh i { @ area i o → i { ^ o } }", "rejects"),
+    ("impl_param_mismatch",   "% Sh { @ area i o i k → i }\n% Sh i { @ area i o f k → i { ^ o } }", "rejects"),
+    # A NON-generic trait's receiver slot is a placeholder each impl replaces
+    # — `% Show { @ show i n → s }` is implemented for `i` and for `b` — so a
+    # differing receiver there is the idiom, not a violation. In a GENERIC
+    # trait the receiver is the type parameter, and substitution makes it
+    # exact; `impl_generic_mismatch` covers that side.
+    ("impl_receiver_placeholder", "% Sh { @ area i o → i }\n% Sh b { @ area b o → i { ^ ? o 1 0 } }", "compiles"),
+    ("impl_generic_ok",       ": Dog { i n }\n% Sp [T] { @ speak T d → i }\n% Sp Dog { @ speak Dog d → i { ^ . d n } }", "compiles"),
+    ("impl_generic_mismatch", ": Dog { i n }\n% Sp [T] { @ speak T d → i }\n% Sp Dog { @ speak Dog d → s { ^ `x` } }", "rejects"),
+    # A trait body holds methods and associated types. Any other token used
+    # to be skipped, and the skip is what made an UNTERMINATED body
+    # dangerous: the scan stopped at the next declaration's closing brace
+    # while the emit pass skipped balanced braces to end of file, so the two
+    # disagreed about where the trait ended and `main` vanished with no
+    # diagnostic at all. Found by deleting one '}' from a corpus program.
+    ("trait_unterminated",    "% Sp [T] { @ speak T self → i\n: Dog { i pitch }\n% Sp Dog { @ speak Dog d → i { ^ . d pitch } }", "rejects"),
+    ("trait_junk_in_body",    "% Sh { 42 }", "rejects"),
+    ("trait_method_no_name",  "% Sh { @ → i }", "rejects"),
+    ("trait_nested_decl",     "% Sh { : Pt { i x } }", "rejects"),
+    ("impl_junk_in_body",     "% Sh { @ area i o → i }\n% Sh i { 42 }", "rejects"),
 ]
 
 # Statement forms, placed inside main's body ahead of the print.
@@ -94,7 +150,64 @@ STATEMENTS = [
     # A field write gets the same check the read side has.
     ("field_store_ok",   ": ~ Pt q @ Pt { 1 2 }\n    = . q x 5",   "compiles"),
     ("field_store_bad",  ": ~ Pt q @ Pt { 1 2 }\n    = . q nope 5", "rejects"),
+    # ── expression position ──────────────────────────────────────────
+    # Every other type position runs the declared-type check; `Z` did not,
+    # and emitted a getelementptr on an undeclared type.
+    ("sizeof_base",      ": i q Z i",                              "compiles"),
+    ("sizeof_struct",    ": i q Z Pt",                             "compiles"),
+    ("sizeof_ptr",       ": i q Z *Pt",                            "compiles"),
+    ("sizeof_unknown",   ": i q Z NoSuchType",                     "rejects"),
+    ("sizeof_ptr_unknown", ": i q Z *NoSuchType",                  "rejects"),
+    ("bin_one_operand",  ": i q + 1",                              "rejects"),
+    ("not_no_operand",   ": i q !",                                "rejects"),
+    ("cond_two_operands", ": i q ? > k 0 1",                       "rejects"),
+    ("agg_over_fields",  ": Pt p @ Pt { 1 2 3 }",                  "rejects"),
+    ("agg_unclosed",     ": Pt p @ Pt { 1 2",                      "rejects"),
+    ("slice_no_bar",     ": [i ys [i 1 2 3]",                      "rejects"),
+    ("slice_unclosed",   ": [i ys [i | 1 2 3",                     "rejects"),
+    ("call_unclosed",    "( nurl_print `x`",                       "rejects"),
+    ("closure_zero_param", ": (@ v) f \\ → v { }",               "compiles"),
+    ("closure_empty_body", ": (@ i i) f \\ i x → i { }",         "rejects"),
+    ("closure_dup_param",  ": (@ i i i) f \\ i a i a → i { ^ a }", "rejects"),
+    # ── block terminators inside a ';' defer body ────────────────────
+    # The defer chain runs DURING return, after the loop has exited. `^`
+    # was rejected here; `break` and `continue` were not, and branched
+    # back into the exit block the chain had just come from — an infinite
+    # loop that compiled, exited 0 and printed forever.
+    ("defer_return",     "; { ^ 1 }",                              "rejects"),
+    ("defer_break",      "~ < k 3 { ; { break } = k + k 1 }",      "rejects"),
+    ("defer_continue",   "~ < k 3 { ; { continue } = k + k 1 }",   "rejects"),
+    ("defer_own_loop",   "; { ~ < k 3 { = k + k 1 } }",            "compiles"),
+    # ── select arms ──────────────────────────────────────────────────
+    ("select_arm_no_block", "?? { [i] k → o }",                    "rejects"),
+    ("select_default_only", "?? { _ → { } }",                      "rejects"),
+    ("select_two_defaults", "?? { _ → { } _ → { } }",              "rejects"),
 ]
+
+# Match arms need an enum to match on; kept in their own template so the
+# statement rows above stay in the context their expectations were set in.
+MATCHES = [
+    ("match_variant",      "?? c { Red → { } _ → { } }",           "compiles"),
+    ("match_no_arms",      "?? c { }",                             "rejects"),
+    ("match_unknown",      "?? c { Nope → { } _ → { } }",          "rejects"),
+    ("match_nonexhaustive", "?? c { Red → { } }",                  "rejects"),
+    ("match_dup_variant",  "?? c { Red → { } Red → { } _ → { } }", "rejects"),
+    # The first name is checked against the enum's variants; an or-pattern
+    # ALTERNATIVE was not, and emitted a load of a global nothing defines.
+    ("match_or_known",     "?? c { Red | Green → { } _ → { } }",   "compiles"),
+    ("match_or_unknown",   "?? c { Red | Nope → { } _ → { } }",    "rejects"),
+    ("match_or_repeat",    "?? c { Red | Red → { } _ → { } }",     "rejects"),
+]
+
+MATCH_TEMPLATE = """: | Color { Red Green Blue }
+
+@ main → i {
+    : Color c @ Color { Green }
+    %s
+    ( nurl_print `MAIN RAN\\n` )
+    ^ 0
+}
+"""
 
 STMT_TEMPLATE = """: Pt { i x i y }
 
@@ -151,6 +264,11 @@ class DeclarationForms(unittest.TestCase):
         for name, stmt, expectation in STATEMENTS:
             with self.subTest(form=name):
                 self.check(name, STMT_TEMPLATE % stmt, expectation)
+
+    def test_match_forms(self):
+        for name, stmt, expectation in MATCHES:
+            with self.subTest(form=name):
+                self.check(name, MATCH_TEMPLATE % stmt, expectation)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_installer_unpack.py
+++ b/tools/tests/test_installer_unpack.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""The installer must not destroy a working install to make room for one.
+
+`tools/get-nurl.sh` used to delete the toolchain's paths and then extract
+the archive over the hole. Every failure from that point on — a truncated
+archive, a full disk, a killed terminal — left a prefix with no compiler
+in it, repairable only by a successful re-run. Now it unpacks into a
+staging directory inside the prefix, checks the result, and only then
+swaps: the destructive window is a handful of renames on one filesystem.
+
+These controls serve a release over `file://` so the real download,
+checksum and unpack path runs; nothing here reaches the network.
+
+  python3 tools/tests/test_installer_unpack.py
+"""
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+INSTALLER = os.path.join(ROOT, "tools", "get-nurl.sh")
+VERSION = "v9.9.9"
+
+
+def target_triple():
+    """The same triple get-nurl.sh computes for this host."""
+    machine = os.uname().machine
+    cpu = {"x86_64": "x86_64", "amd64": "x86_64",
+           "aarch64": "arm64", "arm64": "arm64"}.get(machine)
+    system = os.uname().sysname
+    if system == "Linux" and cpu:
+        return "linux-%s-glibc" % cpu
+    if system == "FreeBSD" and cpu == "x86_64":
+        return "freebsd-x86_64"
+    return None
+
+
+class InstallerUnpack(unittest.TestCase):
+    def setUp(self):
+        self.triple = target_triple()
+        if self.triple is None:
+            self.skipTest("get-nurl.sh publishes no archive for this host")
+        if shutil.which("curl") is None and shutil.which("wget") is None:
+            self.skipTest("no curl or wget to fetch even a file:// URL")
+        self.tmp = tempfile.mkdtemp(prefix="installer-unpack-")
+        self.serve = os.path.join(self.tmp, "serve")
+        self.prefix = os.path.join(self.tmp, "prefix")
+        os.makedirs(self.serve)
+        self.archive = "nurl-%s-%s.tar.gz" % (VERSION, self.triple)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ── fixtures ───────────────────────────────────────────────────────
+    def publish(self, entries, truncate=False):
+        """Write a release archive (and its checksum) into the served dir.
+
+        `entries` maps archive-relative paths to contents; the archive's
+        top-level `nurl/` directory is what --strip-components=1 removes.
+        """
+        staging = os.path.join(self.tmp, "stage-src", "nurl")
+        shutil.rmtree(os.path.join(self.tmp, "stage-src"), ignore_errors=True)
+        for rel, content in entries.items():
+            path = os.path.join(staging, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as fh:
+                fh.write(content)
+            if rel.startswith("bin/"):
+                os.chmod(path, 0o755)
+        path = os.path.join(self.serve, self.archive)
+        with tarfile.open(path, "w:gz") as tar:
+            tar.add(staging, arcname="nurl")
+        if truncate:
+            # A download that verified and then stopped part-way through
+            # being unpacked: the bytes on disk are a valid prefix of a
+            # gzip stream, so tar starts and then fails.
+            with open(path, "rb") as fh:
+                data = fh.read()
+            with open(path, "wb") as fh:
+                fh.write(data[: max(64, len(data) // 2)])
+        with open(path, "rb") as fh:
+            digest = hashlib.sha256(fh.read()).hexdigest()
+        with open(path + ".sha256", "w") as fh:
+            fh.write("%s  %s\n" % (digest, self.archive))
+
+    def good_release(self):
+        return {
+            "bin/nurl": "#!/bin/sh\necho new-nurl\n",
+            "bin/nurlc": "#!/bin/sh\necho new-nurlc\n",
+            "build/nurlc": "new compiler\n",
+            "stdlib/core/string.nu": "new stdlib\n",
+            "nurl.sh": "new driver\n",
+        }
+
+    def prior_install(self):
+        """A prefix holding a previous toolchain plus user state."""
+        for rel, content in {
+            "bin/nurl": "#!/bin/sh\necho old-nurl\n",
+            "bin/nurlc": "#!/bin/sh\necho old-nurlc\n",
+            "bin/mytool": "#!/bin/sh\necho installed-by-nurlpkg\n",
+            "build/nurlc": "old compiler\n",
+            "build/gone-upstream": "removed in the new release\n",
+            "stdlib/core/string.nu": "old stdlib\n",
+            "nurl.sh": "old driver\n",
+            "credentials": "publish-token\n",
+            "models/big.gguf": "tens of gigabytes, pretend\n",
+        }.items():
+            path = os.path.join(self.prefix, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as fh:
+                fh.write(content)
+            if rel.startswith("bin/"):
+                os.chmod(path, 0o755)
+
+    def install(self):
+        env = dict(os.environ)
+        env["NURL_INSTALL_BASE"] = "file://" + self.serve
+        env["NURL_HOME"] = self.prefix
+        # No signature is published for a locally served archive; without
+        # this the minisign leg fails closed, which is its own control.
+        env["NURL_INSTALL_INSECURE"] = "1"
+        return subprocess.run(
+            ["bash", INSTALLER, "--version", VERSION, "--prefix", self.prefix],
+            capture_output=True, env=env, timeout=180)
+
+    def read(self, rel):
+        with open(os.path.join(self.prefix, rel)) as fh:
+            return fh.read()
+
+    def assertNoStagingLeft(self):
+        leftovers = [n for n in os.listdir(self.prefix) if n.startswith(".stage.")]
+        self.assertEqual(leftovers, [], "a staging directory was left behind")
+
+    # ── controls ───────────────────────────────────────────────────────
+    def test_fresh_install(self):
+        self.publish(self.good_release())
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stderr.decode("utf-8", "replace")[-2000:])
+        self.assertEqual(self.read("build/nurlc"), "new compiler\n")
+        self.assertTrue(os.access(os.path.join(self.prefix, "bin/nurl"), os.X_OK))
+        self.assertNoStagingLeft()
+
+    def test_upgrade_replaces_toolchain_and_keeps_user_state(self):
+        self.prior_install()
+        self.publish(self.good_release())
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stderr.decode("utf-8", "replace")[-2000:])
+        self.assertEqual(self.read("build/nurlc"), "new compiler\n")
+        self.assertEqual(self.read("stdlib/core/string.nu"), "new stdlib\n")
+        # A file the new release dropped must not linger: build/ is
+        # replaced wholesale, not merged.
+        self.assertFalse(os.path.exists(os.path.join(self.prefix, "build/gone-upstream")))
+        # …but user state in the same prefix survives.
+        self.assertEqual(self.read("credentials"), "publish-token\n")
+        self.assertEqual(self.read("models/big.gguf"), "tens of gigabytes, pretend\n")
+        self.assertEqual(self.read("bin/mytool"), "#!/bin/sh\necho installed-by-nurlpkg\n")
+        self.assertNoStagingLeft()
+
+    def test_failed_unpack_leaves_prior_install_intact(self):
+        """The case the staging directory exists for."""
+        self.prior_install()
+        self.publish(self.good_release(), truncate=True)
+        r = self.install()
+        self.assertNotEqual(r.returncode, 0, "a truncated archive must not install")
+        self.assertEqual(self.read("build/nurlc"), "old compiler\n")
+        self.assertEqual(self.read("stdlib/core/string.nu"), "old stdlib\n")
+        self.assertEqual(self.read("nurl.sh"), "old driver\n")
+        self.assertTrue(os.access(os.path.join(self.prefix, "bin/nurlc"), os.X_OK))
+        self.assertEqual(self.read("credentials"), "publish-token\n")
+        self.assertNoStagingLeft()
+
+    def test_incomplete_archive_leaves_prior_install_intact(self):
+        """An archive that unpacks but ships no `bin/nurl`."""
+        self.prior_install()
+        release = self.good_release()
+        del release["bin/nurl"]
+        self.publish(release)
+        r = self.install()
+        self.assertNotEqual(r.returncode, 0, "an archive with no bin/nurl must not install")
+        self.assertEqual(self.read("build/nurlc"), "old compiler\n")
+        self.assertEqual(self.read("bin/nurl"), "#!/bin/sh\necho old-nurl\n")
+        self.assertNoStagingLeft()
+
+    def test_checksum_mismatch_never_reaches_the_prefix(self):
+        """Fail-closed before unpacking — the existing check, pinned here
+        against the staged path so a future edit cannot reorder them."""
+        self.prior_install()
+        self.publish(self.good_release())
+        with open(os.path.join(self.serve, self.archive + ".sha256"), "w") as fh:
+            fh.write("%s  %s\n" % ("0" * 64, self.archive))
+        r = self.install()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn(b"checksum mismatch", r.stderr)
+        self.assertEqual(self.read("build/nurlc"), "old compiler\n")
+        self.assertNoStagingLeft()
+
+    def test_refuses_a_prefix_that_is_not_an_install(self):
+        """The pre-existing guard: a non-empty directory that is not ours."""
+        os.makedirs(os.path.join(self.prefix, "someone-elses"))
+        with open(os.path.join(self.prefix, "someone-elses", "data"), "w") as fh:
+            fh.write("not a NURL install\n")
+        self.publish(self.good_release())
+        r = self.install()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn(b"refusing to overwrite", r.stderr)
+        self.assertEqual(self.read("someone-elses/data"), "not a NURL install\n")
+        self.assertNoStagingLeft()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/webdocs/public/install.sh
+++ b/webdocs/public/install.sh
@@ -168,28 +168,74 @@ esac
 #   share/               assets of tools installed via nurlpkg
 #   bin/<other tools>    programs installed via nurlpkg install
 # Wiping the whole prefix (as this did) silently logged the user out and
-# removed every installed tool. Remove only the toolchain's OWN paths —
-# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims —
-# and let tar overwrite the rest. Those directories are removed wholesale
-# so a file deleted upstream cannot linger.
-#
-# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
-# alive for the running process), which is what makes `nurl upgrade` —
-# nurlpkg upgrading the very tree it is executing from — safe here. The
-# Windows installer has to work around the same case differently.
+# removed every installed tool. Only the toolchain's OWN paths are replaced —
+# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims.
+# Those directories are replaced wholesale so a file deleted upstream cannot
+# linger; everything else in the prefix is left alone.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/docs" "$PREFIX/zig" "$PREFIX/libexec"
-        rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
-               "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
-               "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"
+        :
     else
         err "'$PREFIX' exists, is not empty, and is not a NURL install (no bin/nurl) — refusing to overwrite it. Remove it yourself or set NURL_HOME to a fresh path."
     fi
 fi
 info "installing to $PREFIX…"
 mkdir -p "$PREFIX"
-tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
+
+# Unpack into a staging directory INSIDE the prefix, check the result, and only
+# then touch the installed tree. The order used to be the other way round: the
+# old toolchain was deleted first and tar wrote over the hole, so an extraction
+# that stopped part-way — a full disk, a killed terminal — left a prefix with
+# no compiler in it, and only a successful re-run repaired that. Staging first
+# means every failure up to the last moment leaves the existing install intact,
+# and the destructive window is a handful of renames on one filesystem rather
+# than the length of an extraction.
+stage="$PREFIX/.stage.$$"
+rm -rf "$stage"
+mkdir -p "$stage" || err "cannot create staging directory $stage"
+# The staging directory is inside the prefix, so it must be cleaned up on every
+# exit path, not just this one — extend the trap that already owns $tmp.
+trap 'rm -rf "$tmp" "$stage"' EXIT
+tar xzf "$tmp/$archive" -C "$stage" --strip-components=1 \
+    || err "unpacking $archive failed — the existing install in $PREFIX was not touched."
+
+# Completeness is checked on the STAGED tree, before anything is removed.
+[ -x "$stage/bin/nurl" ] || err "the downloaded archive looks incomplete (no bin/nurl) — the existing install in $PREFIX was not touched."
+
+# Now the swap. Directories are replaced wholesale so a file deleted upstream
+# cannot linger; bin/ is merged file by file, because it also holds programs
+# the user installed with `nurlpkg install`.
+#
+# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
+# alive for the running process), which is what makes `nurl upgrade` —
+# nurlpkg upgrading the very tree it is executing from — safe here. The
+# Windows installer has to work around the same case differently.
+for d in build stdlib docs zig libexec; do
+    if [ -e "$stage/$d" ]; then
+        rm -rf "$PREFIX/$d"
+        mv "$stage/$d" "$PREFIX/$d"
+    fi
+done
+mkdir -p "$PREFIX/bin"
+# bin/ is merged file by file: it also holds programs installed with
+# `nurlpkg install`, which an upgrade must not remove.
+if [ -d "$stage/bin" ]; then
+    for f in "$stage/bin/"*; do
+        [ -e "$f" ] || continue
+        rm -f "$PREFIX/bin/$(basename "$f")"
+        mv "$f" "$PREFIX/bin/$(basename "$f")"
+    done
+    rmdir "$stage/bin" 2>/dev/null || true
+fi
+# Everything else the archive ships at the top level — nurl.sh, nurl.bat, env,
+# and whatever a future release adds — without deleting what is already there.
+for f in "$stage"/* "$stage"/.[!.]*; do
+    [ -e "$f" ] || continue
+    rm -rf "$PREFIX/$(basename "$f")"
+    mv "$f" "$PREFIX/$(basename "$f")"
+done
+rm -rf "$stage"
+trap 'rm -rf "$tmp"' EXIT
 
 [ -x "$PREFIX/bin/nurl" ] || err "install looks incomplete: $PREFIX/bin/nurl missing."
 


### PR DESCRIPTION
Continues the v1-hardening sweep past declarations — into expression position, trait and impl bodies, match and select arms, the block terminators — and re-runs the token-deletion sweep. Six defects, all one shape: **a construct the language allows, reached by a path that skipped its own check.**

## The six

| Construct | What it did |
|---|---|
| `Z NoSuchType` | The one type position with no `check_type_known`. Emitted a getelementptr on a type nothing declares; exit 0, clang reported the generated IR. |
| `?? c { Red \| Nope → … }` | An or-pattern's ALTERNATIVES were never checked against the enum — the first name has been for years, with a comment explaining exactly this miscompile. Emitted `load i64, i64* @Nope`. |
| `~ < k 3 { ; { break } … }` | The defer chain runs DURING return, after the loop has exited, so the jump branched into `loop_exit` — which fell back into the chain, armed flag still set. Compiled, exited 0, **printed its epilogue forever**. `^` was already rejected for this reason. |
| `% Sh i { @ area i o → s … }` | An impl was never checked against the trait it names. Missing required method, wrong arity, wrong parameter types, wrong return type — all compiled. `dyn` builds its thunk from the DECLARED signature, so `→ i` implemented as `→ s` hands the caller a pointer to read as an integer. |
| `% Sp [T] { @ speak T self → i` (no `}`) | The header scan advanced to "the first `{`", which is the NEXT declaration's brace; the emit pass skips BALANCED braces and ate the rest of the file. The passes disagreed about where the trait ended and `main` was inside the difference — exit 0, no main, **nothing on stderr**. |
| `@ f [T: Send] T x → i` (no `{`) | Same, for a generic template. Only the bounded form reaches that path, which is why no hand-written spelling had found it. |

The last two came from `tools/fuzz/mutate_delete.py` — delete one token, demand an answer.

## Three boundaries the corpus taught

Each is a comment at the check, because each cost a build to learn:

- **An undeclared trait is not an error.** `Drop`, `Ord` and `Show` are implemented with no declaration; that is how the built-in protocols work.
- **A non-generic trait's receiver slot is a placeholder.** `% Show { @ show i n → s }` is implemented for `i` AND for `b`. Only a generic trait's receiver is contractual, because substitution makes it exact.
- **Compare lowered types, not spelling.** `inout` receivers (`%Counter*`), associated-type returns (`type Elem i`) and aliases (`i`/`i64`) only compare correctly if both sides go through the scanner the impl's own registration used.

## A15 closes

**The installer stages its unpack.** It used to delete the toolchain and let `tar` write over the hole, so any failure after that point left a prefix with no compiler, repairable only by a successful re-run. It now unpacks into `$PREFIX/.stage.$$`, checks the staged tree, and swaps — directories wholesale, `bin/` merged file by file because it also holds `nurlpkg install`ed tools.

**Twelve unpinned tool downloads are pinned by sha256** — including the zig the release job unpacks INTO the published archive (bytes that reach every user of the installer) and two benchmark runtimes taken from `curl … | bash`, under numbers this repo publishes. `tools/check_pinned_downloads.py` keeps it that way in CI.

## Decisions recorded, not deferred

`docs/MEMORY.md` §2.9 said "three opt-in checks" while strict mode appeared to report a fourth. Reading the implementation resolves it the other way: there are three, and the third one's description named one of the **seven** routes into the maybe-moved state. Five of the seven are confirmed against the current compiler.

Two questions that had a witness and a measurement each are now decided with their reasons: **no fourth strict check** (strict mode is already 1,070 sites from clean, and the walk has no read events at all — it is a new record stream, not an `if`), and **no lexical stack-lifetime policy** (every alloca is entry-hoisted, so markers buy detection and stack reuse, not correctness, and owe an account of deferred cleanup).

## Evidence

- Corpus **992 PASS / 19 SKIP / 0 FAIL / 0 MISSING / 0 ORPHAN**.
- Sanitized corpus **992 PASS / 19 SKIP, zero ASan/UBSan/LSan findings**, zero timeouts.
- **Every tracked first-party `.nu` file — 816 of them — produces byte-identical diagnostics** under the parent commit's compiler and this one. A corpus fixture cannot see code it does not contain; the tree can, and that is the check that matters for a change which adds rejections.
- `test_declaration_forms.py`: 44 forms → **95**. **Sixteen** of the new rows FAIL against a compiler built from the parent commit.
- `test_installer_unpack.py`: six controls, **two of which fail against the previous installer**.
- `check_pinned_downloads.py` reports all twelve sites against the parent commit's workflows.
- A mutant the sweep found *before the fix existed* (`showcase.nu`, one `}` deleted) is rejected by the repaired compiler — the repair answers a witness it was not written against.
- Seven arithmetic methods, 31 ownership methods, seven compiler-cleanup methods, two driver-path controls, the WASI IR control, eleven release-artifact controls, memgate, dcegate, leakgate (both emission modes), `nurlfmt --check` over 1,790 files, strict-arity and installer-sync all pass.

## Still open

`docs/dev/V1_HARDENING_HANDOFF.md` is rewritten. One hole is found and deliberately NOT closed: a trait method header with no return arrow is accepted at the declaration, and `compiler/tests/diag_dynsig_context.nu` exists to pin the message the dyn re-parse gives it — closing it at the declaration retires that fixture's witness, so it needs a decision about the fixture, not just an edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g5UXhMGuUv7dyRnaD8D7r